### PR TITLE
[DTPPSDK-235] Add Diffuse AAR Analysis to GitHub Actions

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -27,7 +27,7 @@ jobs:
           distribution: 'zulu'
       - name: Lint
         run: ./gradlew lint
-  build_main:
+  build_main_and_current:
     name: Build Main Branch
     runs-on: ubuntu-latest
     steps:
@@ -45,7 +45,24 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: Card AAR
+          name: Main Card AAR
+          path: Card/build/outputs/aar/Card-release.aar
+    name: Build Current Branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Current Branch
+        uses: actions/checkout@v2
+      - name: Set up Java 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+      - name: Assemble Release AAR
+        run: ./gradlew clean assembleRelease
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Current Card AAR
           path: Card/build/outputs/aar/Card-release.aar
   diffuse:
     name: Diffuse AAR Analysis

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -76,6 +76,6 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - name: Run Diffuse Analysis - Card
-        run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar --stdout --text output.txt
+        run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar --text output.txt
       - name: Run Diffuse Analysis - Core
-        run: diffuse diff --aar main-core-aar/Core-release.aar current-core-aar/Core-release.aar --stdout --html output.html
+        run: diffuse diff --aar main-core-aar/Core-release.aar current-core-aar/Core-release.aar --html output.html

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,5 +1,5 @@
 name: Static Analysis
-on: [pull_request, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   detekt:
     name: Detekt
@@ -27,3 +27,8 @@ jobs:
           distribution: 'zulu'
       - name: Lint
         run: ./gradlew lint
+  diffuse:
+    name: Diffuse AAR Analysis
+    runs-on: macOS-11
+    steps:
+      - run: brew install JakeWharton/repo/diffuse

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: Main Card AAR
+          name: main-card-aar 
           path: Card/build/outputs/aar/Card-release.aar
       - name: Checkout Current Branch
         uses: actions/checkout@v2
@@ -59,7 +59,11 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: Current Card AAR
+          name: current-card-aar
           path: Card/build/outputs/aar/Card-release.aar
       - name: Install Diffuse
         run: brew install JakeWharton/repo/diffuse
+      - name: Download Workflow Artifacts 
+        uses: actions/download-artifact@v2
+      - name: Run Diffuse Analysis
+        run: diffuse diff --aar main-card-aar current-card-aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -42,20 +42,30 @@ jobs:
           ref: main
       - name: Assemble Release AAR
         run: ./gradlew clean assembleRelease
-      - name: Upload Artifacts
+      - name: Upload Main Card Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: main-card-aar 
           path: Card/build/outputs/aar/Card-release.aar
+      - name: Upload Main Core Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: main-core-aar
+          path: Core/build/outputs/aar/Core-release.aar
       - name: Checkout Current Branch
         uses: actions/checkout@v2
       - name: Assemble Release AAR
         run: ./gradlew clean assembleRelease
-      - name: Upload Artifacts
+      - name: Upload Current Card Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: current-card-aar
           path: Card/build/outputs/aar/Card-release.aar
+      - name: Upload Current Core Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: current-core-aar
+          path: Core/build/outputs/aar/Core-release.aar
       - name: Install Diffuse
         run: brew install JakeWharton/repo/diffuse
       - name: Download Workflow Artifacts 
@@ -65,5 +75,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
-      - name: Run Diffuse Analysis
+      - name: Run Diffuse Analysis - Card
         run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar
+      - name: Run Diffuse Analysis - Core
+        run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar
+      - name: Diffuse Help
+        run: diffuse diff --help

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -76,8 +76,6 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - name: Run Diffuse Analysis - Card
-        run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar
+        run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar --stdout html
       - name: Run Diffuse Analysis - Core
-        run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar
-      - name: Diffuse Help
-        run: diffuse diff --help
+        run: diffuse diff --aar main-core-aar/Core-release.aar current-core-aar/Core-release.aar --stdout html

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -71,6 +71,6 @@ jobs:
           java-version: '11'
       - name: Run Diffuse Analysis - Card
 #        run: diffuse diff --aar main-aar/Card-release.aar current-aar/Card-release.aar
-        run: ls current-aar
-#      - name: Run Diffuse Analysis - Core
-#        run: diffuse diff --aar main-aar/Core-release.aar current-aar/Core-release.aar
+        run: ls current-aar/Card
+      - name: Run Diffuse Analysis - Core
+        run: diffuse diff --aar main-aar/Core/Core-release.aar current-aar/Core/Core-release.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,46 +1,51 @@
 name: Static Analysis
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 jobs:
-#  detekt:
-#    name: Detekt
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v2
-#      - name: Set up Java 8
-#        uses: actions/setup-java@v2
-#        with:
-#          java-version: '8'
-#          distribution: 'zulu'
-#      - name: Run Detekt
-#        run: ./gradlew detekt
-#  android_lint:
-#    name: Android Lint
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v2
-#      - name: Set up Java 8
-#        uses: actions/setup-java@v2
-#        with:
-#          java-version: '8'
-#          distribution: 'zulu'
-#      - name: Lint
-#        run: ./gradlew lint
-  diffuse:
-    name: Diffuse AAR Analysis 
-    runs-on: macOS-11
+  detekt:
+    name: Detekt
+    runs-on: ubuntu-latest
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
           java-version: '8'
           distribution: 'zulu'
+      - name: Run Detekt
+        run: ./gradlew detekt
+
+  android_lint:
+    name: Android Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Set up Java 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+      - name: Lint
+        run: ./gradlew lint
+
+  diffuse:
+    name: Diffuse AAR Analysis
+    runs-on: macOS-11
+    steps:
+      # Set up environment to assemble SDK
+      - name: Set up Java 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+
+      # Assemble artifacts from main branch
       - name: Checkout Main Branch
         uses: actions/checkout@v2
         with:
           ref: main
-      - name: Assemble Release AAR
+      - name: Assemble Release AAR on Main Branch
         run: ./gradlew clean assembleRelease
       - name: Upload Main Branch Artifacts
         uses: actions/upload-artifact@v2
@@ -49,9 +54,11 @@ jobs:
           path: |
             Core/build/outputs/aar/Core-release.aar
             Card/build/outputs/aar/Card-release.aar
+
+      # Assemble artifacts from current branch
       - name: Checkout Current Branch
         uses: actions/checkout@v2
-      - name: Assemble Release AAR
+      - name: Assemble Release AAR on Current Branch
         run: ./gradlew clean assembleRelease
       - name: Upload Current Branch Artifacts
         uses: actions/upload-artifact@v2
@@ -60,6 +67,8 @@ jobs:
           path: |
             Core/build/outputs/aar/Core-release.aar
             Card/build/outputs/aar/Card-release.aar
+
+      # Set up Diffuse
       - name: Install Diffuse
         run: brew install JakeWharton/repo/diffuse
       - name: Download Workflow Artifacts 
@@ -69,6 +78,8 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
+
+      # Run Diffuse analysis
       - name: Run Diffuse Analysis - Card
         run: diffuse diff --aar main-aar/Card/build/outputs/aar/Card-release.aar current-aar/Card/build/outputs/aar/Card-release.aar
       - name: Run Diffuse Analysis - Core

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -27,9 +27,9 @@ jobs:
           distribution: 'zulu'
       - name: Lint
         run: ./gradlew lint
-  build_main_and_current:
-    name: Build Main Branch
-    runs-on: ubuntu-latest
+  diffuse:
+    name: Diffuse AAR Analysis 
+    runs-on: macOS-11
     steps:
       - name: Checkout Main Branch
         uses: actions/checkout@v2
@@ -47,9 +47,6 @@ jobs:
         with:
           name: Main Card AAR
           path: Card/build/outputs/aar/Card-release.aar
-    name: Build Current Branch
-    runs-on: ubuntu-latest
-    steps:
       - name: Checkout Current Branch
         uses: actions/checkout@v2
       - name: Set up Java 8
@@ -64,8 +61,5 @@ jobs:
         with:
           name: Current Card AAR
           path: Card/build/outputs/aar/Card-release.aar
-  diffuse:
-    name: Diffuse AAR Analysis
-    runs-on: macOS-11
-    steps:
-      - run: brew install JakeWharton/repo/diffuse
+      - name: Install Diffuse
+        run: brew install JakeWharton/repo/diffuse

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -70,6 +70,7 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - name: Run Diffuse Analysis - Card
-        run: diffuse diff --aar main-aar/Card-release.aar current-aar/Card-release.aar
-      - name: Run Diffuse Analysis - Core
-        run: diffuse diff --aar main-aar/Core-release.aar current-aar/Core-release.aar
+#        run: diffuse diff --aar main-aar/Card-release.aar current-aar/Card-release.aar
+        run: ls current-aar
+#      - name: Run Diffuse Analysis - Core
+#        run: diffuse diff --aar main-aar/Core-release.aar current-aar/Core-release.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -76,6 +76,6 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - name: Run Diffuse Analysis - Card
-        run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar --stdout html
+        run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar --stdout --text output.txt
       - name: Run Diffuse Analysis - Core
-        run: diffuse diff --aar main-core-aar/Core-release.aar current-core-aar/Core-release.aar --stdout html
+        run: diffuse diff --aar main-core-aar/Core-release.aar current-core-aar/Core-release.aar --stdout --html output.html

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -47,8 +47,8 @@ jobs:
         with:
           name: main-aar
           path: |
-          Core/build/outputs/aar/Core-release.aar
-          Card/build/outputs/aar/Card-release.aar
+            Core/build/outputs/aar/Core-release.aar
+            Card/build/outputs/aar/Card-release.aar
       - name: Checkout Current Branch
         uses: actions/checkout@v2
       - name: Assemble Release AAR
@@ -57,8 +57,8 @@ jobs:
         uses: actions/upload-artifact@v2
           name: current-aar
           path: |
-          Core/build/outputs/aar/Core-release.aar
-          Card/build/outputs/aar/Card-release.aar
+            Core/build/outputs/aar/Core-release.aar
+            Card/build/outputs/aar/Card-release.aar
       - name: Install Diffuse
         run: brew install JakeWharton/repo/diffuse
       - name: Download Workflow Artifacts 

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -27,6 +27,25 @@ jobs:
           distribution: 'zulu'
       - name: Lint
         run: ./gradlew lint
+  build_main:
+    name: Build Main Branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Main Branch
+        uses: actions/checkout@v2
+        with:
+          ref: main
+      - name: Set up Java 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+      - name: Assemble Release AAR
+        run: ./gradlew clean assembleRelease
+        uses: actions/upload-artifact@v2
+        with:
+          name: Card AAR
+          path: Card/build/outputs/aar/Card-release.aar
   diffuse:
     name: Diffuse AAR Analysis
     runs-on: macOS-11

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -41,8 +41,8 @@ jobs:
           java-version: '8'
           distribution: 'zulu'
       - name: Assemble Release AAR
-        run: ./gradlew clean assembleRelease
-        uses: actions/upload-artifact@v2
+      - run: ./gradlew clean assembleRelease
+      - uses: actions/upload-artifact@v2
         with:
           name: Card AAR
           path: Card/build/outputs/aar/Card-release.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,32 +1,32 @@
 name: Static Analysis
 on: [push, pull_request, workflow_dispatch]
 jobs:
-#  detekt:
-#    name: Detekt
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v2
-#      - name: Set up Java 8
-#        uses: actions/setup-java@v2
-#        with:
-#          java-version: '8'
-#          distribution: 'zulu'
-#      - name: Run Detekt
-#        run: ./gradlew detekt
-#  android_lint:
-#    name: Android Lint
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v2
-#      - name: Set up Java 8
-#        uses: actions/setup-java@v2
-#        with:
-#          java-version: '8'
-#          distribution: 'zulu'
-#      - name: Lint
-#        run: ./gradlew lint
+  detekt:
+    name: Detekt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Set up Java 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+      - name: Run Detekt
+        run: ./gradlew detekt
+  android_lint:
+    name: Android Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Set up Java 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+      - name: Lint
+        run: ./gradlew lint
   diffuse:
     name: Diffuse AAR Analysis 
     runs-on: macOS-11
@@ -76,6 +76,6 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - name: Run Diffuse Analysis - Card
-        run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar --text output.txt
+        run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar
       - name: Run Diffuse Analysis - Core
-        run: diffuse diff --aar main-core-aar/Core-release.aar current-core-aar/Core-release.aar --html output.html
+        run: diffuse diff --aar main-core-aar/Core-release.aar current-core-aar/Core-release.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -31,15 +31,15 @@ jobs:
     name: Diffuse AAR Analysis 
     runs-on: macOS-11
     steps:
-      - name: Checkout Main Branch
-        uses: actions/checkout@v2
-        with:
-          ref: main
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
           java-version: '8'
           distribution: 'zulu'
+      - name: Checkout Main Branch
+        uses: actions/checkout@v2
+        with:
+          ref: main
       - name: Assemble Release AAR
         run: ./gradlew clean assembleRelease
       - name: Upload Artifacts
@@ -49,11 +49,6 @@ jobs:
           path: Card/build/outputs/aar/Card-release.aar
       - name: Checkout Current Branch
         uses: actions/checkout@v2
-      - name: Set up Java 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8'
-          distribution: 'zulu'
       - name: Assemble Release AAR
         run: ./gradlew clean assembleRelease
       - name: Upload Artifacts
@@ -66,4 +61,8 @@ jobs:
       - name: Download Workflow Artifacts 
         uses: actions/download-artifact@v2
       - name: Run Diffuse Analysis
+        uses: actions/setup-java@v2
+          with:
+            distribution: 'zulu'
+            java-version: '11'
         run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -41,8 +41,9 @@ jobs:
           java-version: '8'
           distribution: 'zulu'
       - name: Assemble Release AAR
-      - run: ./gradlew clean assembleRelease
-      - uses: actions/upload-artifact@v2
+        run: ./gradlew clean assembleRelease
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
         with:
           name: Card AAR
           path: Card/build/outputs/aar/Card-release.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,32 +1,32 @@
 name: Static Analysis
 on: [push, pull_request, workflow_dispatch]
 jobs:
-  detekt:
-    name: Detekt
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8'
-          distribution: 'zulu'
-      - name: Run Detekt
-        run: ./gradlew detekt
-  android_lint:
-    name: Android Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8'
-          distribution: 'zulu'
-      - name: Lint
-        run: ./gradlew lint
+#  detekt:
+#    name: Detekt
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Repository
+#        uses: actions/checkout@v2
+#      - name: Set up Java 8
+#        uses: actions/setup-java@v2
+#        with:
+#          java-version: '8'
+#          distribution: 'zulu'
+#      - name: Run Detekt
+#        run: ./gradlew detekt
+#  android_lint:
+#    name: Android Lint
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Repository
+#        uses: actions/checkout@v2
+#      - name: Set up Java 8
+#        uses: actions/setup-java@v2
+#        with:
+#          java-version: '8'
+#          distribution: 'zulu'
+#      - name: Lint
+#        run: ./gradlew lint
   diffuse:
     name: Diffuse AAR Analysis 
     runs-on: macOS-11
@@ -66,4 +66,4 @@ jobs:
       - name: Download Workflow Artifacts 
         uses: actions/download-artifact@v2
       - name: Run Diffuse Analysis
-        run: diffuse diff --aar main-card-aar current-card-aar
+        run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -70,7 +70,6 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - name: Run Diffuse Analysis - Card
-#        run: diffuse diff --aar main-aar/Card-release.aar current-aar/Card-release.aar
-        run: ls current-aar/Card
+        run: diffuse diff --aar main-aar/Card/build/outputs/aar/Card-release.aar current-aar/Card/build/outputs/aar/Card-release.aar
       - name: Run Diffuse Analysis - Core
-        run: diffuse diff --aar main-aar/Core/Core-release.aar current-aar/Core/Core-release.aar
+        run: diffuse diff --aar main-aar/Core/build/outputs/aar/Core-release.aar current-aar/Core/build/outputs/aar/Core-release.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -55,6 +55,7 @@ jobs:
         run: ./gradlew clean assembleRelease
       - name: Upload Current Branch Artifacts
         uses: actions/upload-artifact@v2
+        with:
           name: current-aar
           path: |
             Core/build/outputs/aar/Core-release.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -60,9 +60,10 @@ jobs:
         run: brew install JakeWharton/repo/diffuse
       - name: Download Workflow Artifacts 
         uses: actions/download-artifact@v2
-      - name: Run Diffuse Analysis
+      - name: Set up Java 11
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
           java-version: '11'
+      - name: Run Diffuse Analysis
         run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,32 +1,32 @@
 name: Static Analysis
 on: [push, pull_request, workflow_dispatch]
 jobs:
-  detekt:
-    name: Detekt
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8'
-          distribution: 'zulu'
-      - name: Run Detekt
-        run: ./gradlew detekt
-  android_lint:
-    name: Android Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8'
-          distribution: 'zulu'
-      - name: Lint
-        run: ./gradlew lint
+#  detekt:
+#    name: Detekt
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Repository
+#        uses: actions/checkout@v2
+#      - name: Set up Java 8
+#        uses: actions/setup-java@v2
+#        with:
+#          java-version: '8'
+#          distribution: 'zulu'
+#      - name: Run Detekt
+#        run: ./gradlew detekt
+#  android_lint:
+#    name: Android Lint
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Repository
+#        uses: actions/checkout@v2
+#      - name: Set up Java 8
+#        uses: actions/setup-java@v2
+#        with:
+#          java-version: '8'
+#          distribution: 'zulu'
+#      - name: Lint
+#        run: ./gradlew lint
   diffuse:
     name: Diffuse AAR Analysis 
     runs-on: macOS-11
@@ -42,30 +42,23 @@ jobs:
           ref: main
       - name: Assemble Release AAR
         run: ./gradlew clean assembleRelease
-      - name: Upload Main Card Artifacts
+      - name: Upload Main Branch Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: main-card-aar 
-          path: Card/build/outputs/aar/Card-release.aar
-      - name: Upload Main Core Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: main-core-aar
-          path: Core/build/outputs/aar/Core-release.aar
+          name: main-aar
+          path: |
+          Core/build/outputs/aar/Core-release.aar
+          Card/build/outputs/aar/Card-release.aar
       - name: Checkout Current Branch
         uses: actions/checkout@v2
       - name: Assemble Release AAR
         run: ./gradlew clean assembleRelease
-      - name: Upload Current Card Artifacts
+      - name: Upload Current Branch Artifacts
         uses: actions/upload-artifact@v2
-        with:
-          name: current-card-aar
-          path: Card/build/outputs/aar/Card-release.aar
-      - name: Upload Current Core Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: current-core-aar
-          path: Core/build/outputs/aar/Core-release.aar
+          name: current-aar
+          path: |
+          Core/build/outputs/aar/Core-release.aar
+          Card/build/outputs/aar/Card-release.aar
       - name: Install Diffuse
         run: brew install JakeWharton/repo/diffuse
       - name: Download Workflow Artifacts 
@@ -76,6 +69,6 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - name: Run Diffuse Analysis - Card
-        run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar
+        run: diffuse diff --aar main-aar/Card-release.aar current-aar/Card-release.aar
       - name: Run Diffuse Analysis - Core
-        run: diffuse diff --aar main-core-aar/Core-release.aar current-core-aar/Core-release.aar
+        run: diffuse diff --aar main-aar/Core-release.aar current-aar/Core-release.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/download-artifact@v2
       - name: Run Diffuse Analysis
         uses: actions/setup-java@v2
-          with:
-            distribution: 'zulu'
-            java-version: '11'
+        with:
+          distribution: 'zulu'
+          java-version: '11'
         run: diffuse diff --aar main-card-aar/Card-release.aar current-card-aar/Card-release.aar


### PR DESCRIPTION
### Summary of changes

 - Set up [Diffuse](https://github.com/JakeWharton/diffuse) aar size analysis in GitHub actions
 - Running locally requires Diffuse to be installed via homebrew - this doesn't seem necessary (CI should be fine for now), so did not include steps to run locally in the README. 

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
