### PR TITLE
Use Java Style Callback for CardClient

### DIFF
--- a/Card/src/main/java/com/paypal/android/card/CardClient.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardClient.kt
@@ -10,10 +10,7 @@ import kotlinx.coroutines.launch
 /**
  * Use this client to approve an order with a [Card].
  */
-class CardClient internal constructor(
-    private val cardAPI: CardAPI,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Main
-) {
+class CardClient internal constructor(private val cardAPI: CardAPI) {
 
     constructor(configuration: CoreConfig) :
             this(CardAPI(API(configuration)))
@@ -25,14 +22,6 @@ class CardClient internal constructor(
      * @param card The card to use for approval
      * @param completion A completion handler for receiving a [CardResult]
      */
-    fun approveOrder(
-        orderID: String,
-        card: Card,
-        completion: (CardResult) -> Unit
-    ) {
-        CoroutineScope(dispatcher).launch {
-            val cardResult = cardAPI.confirmPaymentSource(orderID, card)
-            completion(cardResult)
-        }
-    }
+    suspend fun approveOrder(orderID: String, card: Card) =
+        cardAPI.confirmPaymentSource(orderID, card)
 }

--- a/Card/src/main/java/com/paypal/android/card/CardClient.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardClient.kt
@@ -2,10 +2,6 @@ package com.paypal.android.card
 
 import com.paypal.android.core.API
 import com.paypal.android.core.CoreConfig
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 /**
  * Use this client to approve an order with a [Card].
@@ -20,7 +16,7 @@ class CardClient internal constructor(private val cardAPI: CardAPI) {
      *
      * @param orderID The id of the order
      * @param card The card to use for approval
-     * @param completion A completion handler for receiving a [CardResult]
+     * @return [CardResult]
      */
     suspend fun approveOrder(orderID: String, card: Card) =
         cardAPI.confirmPaymentSource(orderID, card)

--- a/Card/src/main/java/com/paypal/android/card/CardClient.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardClient.kt
@@ -2,11 +2,18 @@ package com.paypal.android.card
 
 import com.paypal.android.core.API
 import com.paypal.android.core.CoreConfig
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 /**
  * Use this client to approve an order with a [Card].
  */
-class CardClient internal constructor(private val cardAPI: CardAPI) {
+class CardClient internal constructor(
+    private val cardAPI: CardAPI,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Main
+) {
 
     constructor(configuration: CoreConfig) :
             this(CardAPI(API(configuration)))
@@ -16,8 +23,16 @@ class CardClient internal constructor(private val cardAPI: CardAPI) {
      *
      * @param orderID The id of the order
      * @param card The card to use for approval
-     * @return [CardResult]
+     * @param completion A completion handler for receiving a [CardResult]
      */
-    suspend fun approveOrder(orderID: String, card: Card) =
-        cardAPI.confirmPaymentSource(orderID, card)
+    fun approveOrder(
+        orderID: String,
+        card: Card,
+        callback: CardResultCallback
+    ) {
+        CoroutineScope(dispatcher).launch {
+            val cardResult = cardAPI.confirmPaymentSource(orderID, card)
+            callback.onCardResult(cardResult)
+        }
+    }
 }

--- a/Card/src/main/java/com/paypal/android/card/CardResultCallback.java
+++ b/Card/src/main/java/com/paypal/android/card/CardResultCallback.java
@@ -1,0 +1,7 @@
+package com.paypal.android.card;
+
+import androidx.annotation.NonNull;
+
+public interface CardResultCallback {
+    void onCardResult(@NonNull CardResult result);
+}

--- a/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
@@ -29,7 +29,7 @@ class CardClientUnitTest {
 
     @Before
     fun beforeEach() {
-        sut = CardClient(cardAPI, testCoroutineDispatcher)
+        sut = CardClient(cardAPI)
         coEvery { cardAPI.confirmPaymentSource(orderID, card) } returns cardResult
 
         Dispatchers.setMain(testCoroutineDispatcher)
@@ -43,10 +43,7 @@ class CardClientUnitTest {
 
     @Test
     fun `approve order confirms payment source using card api`() = runBlockingTest {
-        lateinit var capturedResult: CardResult
-        sut.approveOrder(orderID, card) { result ->
-            capturedResult = result
-        }
-        assertSame(cardResult, capturedResult)
+        val result = sut.approveOrder(orderID, card)
+        assertSame(cardResult, result)
     }
 }

--- a/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
@@ -29,7 +29,7 @@ class CardClientUnitTest {
 
     @Before
     fun beforeEach() {
-        sut = CardClient(cardAPI)
+        sut = CardClient(cardAPI, testCoroutineDispatcher)
         coEvery { cardAPI.confirmPaymentSource(orderID, card) } returns cardResult
 
         Dispatchers.setMain(testCoroutineDispatcher)
@@ -43,7 +43,10 @@ class CardClientUnitTest {
 
     @Test
     fun `approve order confirms payment source using card api`() = runBlockingTest {
-        val result = sut.approveOrder(orderID, card)
-        assertSame(cardResult, result)
+        lateinit var capturedResult: CardResult
+        sut.approveOrder(orderID, card) { result ->
+            capturedResult = result
+        }
+        assertSame(cardResult, capturedResult)
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
@@ -78,14 +78,16 @@ class CardViewModel @Inject constructor(
 
         viewModelScope.launch {
             val order = fetchOrder()
-            when (val result = cardClient.approveOrder(order.id!!, card)) {
-                is CardResult.Success -> {
-                    Log.d(TAG, "SUCCESS")
-                    Log.d(TAG, "${result.status}")
-                }
-                is CardResult.Error -> {
-                    Log.e(TAG, "ERROR")
-                    Log.e(TAG, result.payPalSDKError.errorDescription.orEmpty())
+            cardClient.approveOrder(order.id!!, card) { result ->
+                when (result) {
+                    is CardResult.Success -> {
+                        Log.d(TAG, "SUCCESS")
+                        Log.d(TAG, "${result.status}")
+                    }
+                    is CardResult.Error -> {
+                        Log.e(TAG, "ERROR")
+                        Log.e(TAG, result.payPalSDKError.errorDescription.orEmpty())
+                    }
                 }
             }
         }

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
@@ -44,7 +44,8 @@ class CardViewModel @Inject constructor(
     var environment: String? = null
     val autoFillCards = PrefillCardData.cards
 
-    private val configuration = CoreConfig(BuildConfig.CLIENT_ID, clientSecret = BuildConfig.CLIENT_SECRET)
+    private val configuration =
+        CoreConfig(BuildConfig.CLIENT_ID, clientSecret = BuildConfig.CLIENT_SECRET)
     private val cardClient = CardClient(configuration)
 
     fun onCardNumberChange(newCardNumber: String) {
@@ -77,16 +78,14 @@ class CardViewModel @Inject constructor(
 
         viewModelScope.launch {
             val order = fetchOrder()
-            cardClient.approveOrder(order.id!!, card) { result ->
-                when (result) {
-                    is CardResult.Success -> {
-                        Log.d(TAG, "SUCCESS")
-                        Log.d(TAG, "${result.status}")
-                    }
-                    is CardResult.Error -> {
-                        Log.e(TAG, "ERROR")
-                        Log.e(TAG, result.payPalSDKError.errorDescription.orEmpty())
-                    }
+            when (val result = cardClient.approveOrder(order.id!!, card)) {
+                is CardResult.Success -> {
+                    Log.d(TAG, "SUCCESS")
+                    Log.d(TAG, "${result.status}")
+                }
+                is CardResult.Error -> {
+                    Log.e(TAG, "ERROR")
+                    Log.e(TAG, result.payPalSDKError.errorDescription.orEmpty())
                 }
             }
         }

--- a/PayPalCheckout/src/main/java/com/paypal/android/checkout/PayPalCheckoutResultCallback.java
+++ b/PayPalCheckout/src/main/java/com/paypal/android/checkout/PayPalCheckoutResultCallback.java
@@ -1,0 +1,7 @@
+package com.paypal.android.checkout;
+
+import androidx.annotation.NonNull;
+
+public interface PayPalCheckoutResultCallback {
+    void onPayPalCheckoutResult(@NonNull PayPalCheckoutResult result);
+}

--- a/PayPalCheckout/src/main/java/com/paypal/android/checkout/PayPalClient.kt
+++ b/PayPalCheckout/src/main/java/com/paypal/android/checkout/PayPalClient.kt
@@ -25,18 +25,20 @@ class PayPalClient(application: Application, coreConfig: CoreConfig, returnUrl: 
         PayPalCheckout.setConfig(config)
     }
 
-    fun checkout(orderId: String, complete: (PayPalCheckoutResult) -> Unit) {
+    fun checkout(orderId: String, callback: PayPalCheckoutResultCallback) {
         PayPalCheckout.start(CreateOrder { createOrderActions ->
             createOrderActions.set(orderId)
         },
             onApprove = OnApprove { approval ->
-                complete(PayPalCheckoutResult.Success(approval.data.orderId, approval.data.payerId))
+                val result =
+                    PayPalCheckoutResult.Success(approval.data.orderId, approval.data.payerId)
+                callback.onPayPalCheckoutResult(result)
             },
             onCancel = OnCancel {
-                complete(PayPalCheckoutResult.Cancellation)
+                callback.onPayPalCheckoutResult(PayPalCheckoutResult.Cancellation)
             },
             onError = OnError { errorInfo ->
-                complete(PayPalCheckoutResult.Failure(ErrorInfo(errorInfo)))
+                callback.onPayPalCheckoutResult(PayPalCheckoutResult.Failure(ErrorInfo(errorInfo)))
             })
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Use Java Style Callback in CardClient
 - This will eliminate the need for merchants to return `null` when implementing a callback in Java

 ### Checklist

 ~- [ ] Added a changelog entry~