### PR TITLE
Align Card API with iOS

### DIFF
--- a/Card/src/main/java/com/paypal/android/card/CardAPI.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardAPI.kt
@@ -1,6 +1,5 @@
 package com.paypal.android.card
 
-import android.webkit.URLUtil
 import com.paypal.android.core.API
 import com.paypal.android.core.APIClientError
 import com.paypal.android.core.HttpResponse.Companion.SERVER_ERROR
@@ -21,51 +20,64 @@ internal class CardAPI(
         val apiRequest = requestFactory.createConfirmPaymentSourceRequest(orderID, card)
         val httpResponse = api.send(apiRequest)
         val correlationID = httpResponse.headers["Paypal-Debug-Id"]
+
         val bodyResponse = httpResponse.body
         if (bodyResponse.isNullOrBlank()) {
             throw APIClientError.noResponseData(correlationID)
         }
-        return when (httpResponse.status) {
-            HTTP_OK -> {
-                runCatching {
-                    val json = PaymentsJSON(bodyResponse)
-                    val status = json.getString("status")
-                    val id = json.getString("id")
 
-                    CardResult(id, OrderStatus.valueOf(status))
-                }.recover {
-                    throw APIClientError.dataParsingError(correlationID)
-                }.getOrNull()!!
-            }
-            STATUS_UNKNOWN_HOST -> {
-                throw APIClientError.unknownHost(correlationID)
-            }
-            STATUS_UNDETERMINED -> {
-                throw APIClientError.unknownError(correlationID)
-            }
-            SERVER_ERROR -> {
-                throw APIClientError.serverResponseError(correlationID)
-            }
-            else -> {
-                val json = PaymentsJSON(bodyResponse)
-                val message = json.getString("message")
+        val status = httpResponse.status
+        if (status == HTTP_OK) {
+            return parseCardResult(bodyResponse, correlationID)
+        } else {
+            throw parseCardError(status, bodyResponse, correlationID)
+        }
+    }
 
-                val errorDetails = mutableListOf<OrderErrorDetail>()
-                val errorDetailsJson = json.getJSONArray("details")
-                for (i in 0 until errorDetailsJson.length()) {
-                    val errorJson = errorDetailsJson.getJSONObject(i)
-                    val issue = errorJson.getString("issue")
-                    val description = errorJson.getString("description")
-                    errorDetails += OrderErrorDetail(issue, description)
-                }
+    private fun parseCardResult(bodyResponse: String, correlationID: String?): CardResult =
+        runCatching {
+            val json = PaymentsJSON(bodyResponse)
+            val status = json.getString("status")
+            val id = json.getString("id")
 
-                val description = "$message -> $errorDetails"
-                throw APIClientError.httpURLConnectionError(
-                    httpResponse.status,
-                    description,
-                    correlationID
-                )
+            CardResult(id, OrderStatus.valueOf(status))
+        }.recover {
+            throw APIClientError.dataParsingError(correlationID)
+        }.getOrNull()!!
+
+    private fun parseCardError(
+        status: Int,
+        bodyResponse: String,
+        correlationID: String?
+    ) = when (status) {
+        STATUS_UNKNOWN_HOST -> {
+            APIClientError.unknownHost(correlationID)
+        }
+        STATUS_UNDETERMINED -> {
+            APIClientError.unknownError(correlationID)
+        }
+        SERVER_ERROR -> {
+            APIClientError.serverResponseError(correlationID)
+        }
+        else -> {
+            val json = PaymentsJSON(bodyResponse)
+            val message = json.getString("message")
+
+            val errorDetails = mutableListOf<OrderErrorDetail>()
+            val errorDetailsJson = json.getJSONArray("details")
+            for (i in 0 until errorDetailsJson.length()) {
+                val errorJson = errorDetailsJson.getJSONObject(i)
+                val issue = errorJson.getString("issue")
+                val description = errorJson.getString("description")
+                errorDetails += OrderErrorDetail(issue, description)
             }
+
+            val description = "$message -> $errorDetails"
+            APIClientError.httpURLConnectionError(
+                status,
+                description,
+                correlationID
+            )
         }
     }
 }

--- a/Card/src/main/java/com/paypal/android/card/CardAPI.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardAPI.kt
@@ -37,7 +37,7 @@ internal class CardAPI(
                     val status = json.getString("status")
                     val id = json.getString("id")
 
-                    CardResult.Success(id, OrderStatus.valueOf(status))
+                    CardResult(id, OrderStatus.valueOf(status))
                 }.recover {
                     // TODO: include correlationId
                     throw APIClientError.dataParsingError

--- a/Card/src/main/java/com/paypal/android/card/CardClient.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardClient.kt
@@ -2,10 +2,6 @@ package com.paypal.android.card
 
 import com.paypal.android.core.API
 import com.paypal.android.core.CoreConfig
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 /**
  * Use this client to approve an order with a [Card].

--- a/Card/src/main/java/com/paypal/android/card/CardClient.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardClient.kt
@@ -10,10 +10,7 @@ import kotlinx.coroutines.launch
 /**
  * Use this client to approve an order with a [Card].
  */
-class CardClient internal constructor(
-    private val cardAPI: CardAPI,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Main
-) {
+class CardClient internal constructor(private val cardAPI: CardAPI) {
 
     constructor(configuration: CoreConfig) :
             this(CardAPI(API(configuration)))
@@ -22,15 +19,7 @@ class CardClient internal constructor(
      * Confirm [Card] payment source for an order.
      *
      * @param request [CardRequest] for requesting an order approval
-     * @param callback [CardResultCallback] for receiving a [CardResult]
      */
-    fun approveOrder(
-        request: CardRequest,
-        callback: CardResultCallback
-    ) {
-        CoroutineScope(dispatcher).launch {
-            val cardResult = cardAPI.confirmPaymentSource(request.orderID, request.card)
-            callback.onCardResult(cardResult)
-        }
-    }
+    suspend fun approveOrder(request: CardRequest): CardResult =
+        cardAPI.confirmPaymentSource(request.orderID, request.card)
 }

--- a/Card/src/main/java/com/paypal/android/card/CardResult.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardResult.kt
@@ -1,17 +1,5 @@
 package com.paypal.android.card
 
 import com.paypal.android.core.OrderStatus
-import com.paypal.android.core.PayPalSDKError
 
-sealed class CardResult {
-
-    class Success(
-        val orderID: String,
-        val status: OrderStatus
-    ) : CardResult()
-
-    class Error(
-        val payPalSDKError: PayPalSDKError,
-        val correlationID: String?
-    ) : CardResult()
-}
+data class CardResult(val orderID: String, val status: OrderStatus)

--- a/Card/src/main/java/com/paypal/android/card/CardResult.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardResult.kt
@@ -2,4 +2,7 @@ package com.paypal.android.card
 
 import com.paypal.android.core.OrderStatus
 
+/**
+ * A result returned by [CardClient] when an order was successfully approved with a [Card].
+ */
 data class CardResult(val orderID: String, val status: OrderStatus)

--- a/Card/src/main/java/com/paypal/android/card/CardResultCallback.java
+++ b/Card/src/main/java/com/paypal/android/card/CardResultCallback.java
@@ -1,7 +1,0 @@
-package com.paypal.android.card;
-
-import androidx.annotation.NonNull;
-
-public interface CardResultCallback {
-    void onCardResult(@NonNull CardResult result);
-}

--- a/Card/src/test/java/com/paypal/android/card/CardAPIUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardAPIUnitTest.kt
@@ -1,7 +1,6 @@
 package com.paypal.android.card
 
 import com.paypal.android.core.API
-import com.paypal.android.core.APIClientError
 import com.paypal.android.core.APIRequest
 import com.paypal.android.core.HttpMethod
 import com.paypal.android.core.HttpResponse

--- a/Card/src/test/java/com/paypal/android/card/CardAPIUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardAPIUnitTest.kt
@@ -30,6 +30,21 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class CardAPIUnitTest {
 
+    // language=JSON
+    private val successBody = """
+            {
+                "id": "testOrderID",
+                "status": "APPROVED",
+                "payment_source": {
+                    "card": {
+                        "last_digits": "7321",
+                        "brand": "VISA",
+                        "type": "CREDIT"
+                    }
+                }
+            }
+        """
+
     private val api = mockk<API>(relaxed = true)
     private val requestBuilder = mockk<CardAPIRequestFactory>()
     private val paymentsJSON = mockk<PaymentsJSON>()
@@ -85,7 +100,7 @@ class CardAPIUnitTest {
 
     @Test
     fun `it sends a confirm payment source api request`() = runBlockingTest {
-        val httpResponse = HttpResponse(200)
+        val httpResponse = HttpResponse(200, emptyMap(), successBody)
         coEvery { api.send(apiRequest) } returns httpResponse
 
         sut.confirmPaymentSource(orderID, card)
@@ -94,21 +109,7 @@ class CardAPIUnitTest {
 
     @Test
     fun `it returns a confirm payment source result`() = runBlockingTest {
-        // language=JSON
-        val body = """
-            {
-                "id": "testOrderID",
-                "status": "APPROVED",
-                "payment_source": {
-                    "card": {
-                        "last_digits": "7321",
-                        "brand": "VISA",
-                        "type": "CREDIT"
-                    }
-                }
-            }
-        """
-        val httpResponse = HttpResponse(200, headers, body)
+        val httpResponse = HttpResponse(200, headers, successBody)
         coEvery { api.send(apiRequest) } returns httpResponse
 
         val result = sut.confirmPaymentSource(orderID, card)
@@ -151,7 +152,7 @@ class CardAPIUnitTest {
             }
 
             assertEquals(
-                APIClientError.unknownError.errorDescription,
+                "An unknown error occurred. Contact developer.paypal.com/support.",
                 capturedError.errorDescription
             )
         }
@@ -171,7 +172,7 @@ class CardAPIUnitTest {
             }
 
             assertEquals(
-                APIClientError.noResponseData.errorDescription,
+                "An error occurred due to missing HTTP response data. Contact developer.paypal.com/support.",
                 capturedError.errorDescription
             )
         }
@@ -193,7 +194,7 @@ class CardAPIUnitTest {
             }
 
             assertEquals(
-                APIClientError.dataParsingError.errorDescription,
+                "An error occurred parsing HTTP response data. Contact developer.paypal.com/support.",
                 capturedError.errorDescription
             )
         }
@@ -212,7 +213,7 @@ class CardAPIUnitTest {
         }
 
         assertEquals(
-            APIClientError.unknownHost.errorDescription,
+            "An error occurred due to an invalid HTTP response. Contact developer.paypal.com/support.",
             capturedError.errorDescription
         )
     }
@@ -231,7 +232,7 @@ class CardAPIUnitTest {
         }
 
         assertEquals(
-            APIClientError.serverResponseError.errorDescription,
+            "A server occurred. Contact developer.paypal.com/support.",
             capturedError.errorDescription
         )
     }

--- a/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
@@ -21,7 +21,7 @@ class CardClientUnitTest {
     private val orderID = "sample-order-id"
 
     private val cardAPI = mockk<CardAPI>(relaxed = true)
-    private val cardResult = CardResult.Success("orderId", OrderStatus.APPROVED)
+    private val cardResult = CardResult("orderId", OrderStatus.APPROVED)
 
     private val testCoroutineDispatcher = TestCoroutineDispatcher()
 

--- a/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
@@ -29,7 +29,7 @@ class CardClientUnitTest {
 
     @Before
     fun beforeEach() {
-        sut = CardClient(cardAPI, testCoroutineDispatcher)
+        sut = CardClient(cardAPI)
         coEvery { cardAPI.confirmPaymentSource(orderID, card) } returns cardResult
 
         Dispatchers.setMain(testCoroutineDispatcher)
@@ -45,10 +45,7 @@ class CardClientUnitTest {
     fun `approve order confirms payment source using card api`() = runBlockingTest {
         val request = CardRequest(orderID, card)
 
-        lateinit var capturedResult: CardResult
-        sut.approveOrder(request) { result ->
-            capturedResult = result
-        }
-        assertSame(cardResult, capturedResult)
+        val actualResult = sut.approveOrder(request)
+        assertSame(actualResult, cardResult)
     }
 }

--- a/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
@@ -3,13 +3,8 @@ package com.paypal.android.card
 import com.paypal.android.core.OrderStatus
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test

--- a/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
@@ -23,22 +23,12 @@ class CardClientUnitTest {
     private val cardAPI = mockk<CardAPI>(relaxed = true)
     private val cardResult = CardResult("orderId", OrderStatus.APPROVED)
 
-    private val testCoroutineDispatcher = TestCoroutineDispatcher()
-
     private lateinit var sut: CardClient
 
     @Before
     fun beforeEach() {
         sut = CardClient(cardAPI)
         coEvery { cardAPI.confirmPaymentSource(orderID, card) } returns cardResult
-
-        Dispatchers.setMain(testCoroutineDispatcher)
-    }
-
-    @After
-    fun afterEach() {
-        Dispatchers.resetMain()
-        testCoroutineDispatcher.cleanupTestCoroutines()
     }
 
     @Test

--- a/Core/src/main/java/com/paypal/android/core/APIClientError.kt
+++ b/Core/src/main/java/com/paypal/android/core/APIClientError.kt
@@ -3,27 +3,31 @@ package com.paypal.android.core
 object APIClientError {
 
     // 0. An unknown error occurred.
-    val unknownError = PayPalSDKError(
+    fun unknownError(correlationID: String?) = PayPalSDKError(
         code = Code.UNKNOWN.ordinal,
-        errorDescription = "An unknown error occurred. Contact developer.paypal.com/support."
+        errorDescription = "An unknown error occurred. Contact developer.paypal.com/support.",
+        correlationID = correlationID
     )
 
     // 1. Error parsing HTTP response data.
-    val dataParsingError = PayPalSDKError(
+    fun dataParsingError(correlationID: String?) = PayPalSDKError(
         code = Code.DATA_PARSING_ERROR.ordinal,
-        errorDescription = "An error occurred parsing HTTP response data. Contact developer.paypal.com/support."
+        errorDescription = "An error occurred parsing HTTP response data. Contact developer.paypal.com/support.",
+        correlationID = correlationID
     )
 
     // 2. Unknown Host from network.
-    val unknownHost = PayPalSDKError(
+    fun unknownHost(correlationID: String?) = PayPalSDKError(
         code = Code.UNKNOWN_HOST.ordinal,
-        errorDescription = "An error occurred due to an invalid HTTP response. Contact developer.paypal.com/support."
+        errorDescription = "An error occurred due to an invalid HTTP response. Contact developer.paypal.com/support.",
+        correlationID = correlationID
     )
 
     // 3. Missing HTTP response data.
-    val noResponseData = PayPalSDKError(
+    fun noResponseData(correlationID: String?) = PayPalSDKError(
         code = Code.NO_RESPONSE_DATA.ordinal,
-        errorDescription = "An error occurred due to missing HTTP response data. Contact developer.paypal.com/support."
+        errorDescription = "An error occurred due to missing HTTP response data. Contact developer.paypal.com/support.",
+        correlationID = correlationID
     )
 
     // 4. There was an error constructing the URLRequest.
@@ -33,18 +37,19 @@ object APIClientError {
     )
 
     // 5. The server's response body returned an error message.
-    val serverResponseError = PayPalSDKError(
+    fun serverResponseError(correlationID: String?) = PayPalSDKError(
         code = Code.SERVER_RESPONSE_ERROR.ordinal,
-        errorDescription = "A server occurred. Contact developer.paypal.com/support."
+        errorDescription = "A server occurred. Contact developer.paypal.com/support.",
+        correlationID = correlationID
     )
 
     // Error returned from HttpURLConnection while making request.
-    val httpURLConnectionError: (code: Int, description: String) -> PayPalSDKError = { code, description ->
+    fun httpURLConnectionError(code: Int, description: String, correlationID: String?) =
         PayPalSDKError(
             code = code,
-            errorDescription = description
+            errorDescription = description,
+            correlationID = correlationID
         )
-    }
 }
 
 internal enum class Code {

--- a/Core/src/main/java/com/paypal/android/core/PayPalSDKError.kt
+++ b/Core/src/main/java/com/paypal/android/core/PayPalSDKError.kt
@@ -1,5 +1,8 @@
 package com.paypal.android.core
 
+/**
+ * Class used to describe PayPal errors when they occur.
+ */
 data class PayPalSDKError(
     val code: Int,
     val errorDescription: String,

--- a/Core/src/main/java/com/paypal/android/core/PayPalSDKError.kt
+++ b/Core/src/main/java/com/paypal/android/core/PayPalSDKError.kt
@@ -2,5 +2,6 @@ package com.paypal.android.core
 
 data class PayPalSDKError(
     val code: Int?,
-    val errorDescription: String?
+    val errorDescription: String?,
+    val correlationID: String? = null
 ) : Exception("Error: $code - Description: $errorDescription")

--- a/Core/src/main/java/com/paypal/android/core/PayPalSDKError.kt
+++ b/Core/src/main/java/com/paypal/android/core/PayPalSDKError.kt
@@ -1,7 +1,7 @@
 package com.paypal.android.core
 
 data class PayPalSDKError(
-    val code: Int?,
-    val errorDescription: String?,
+    val code: Int,
+    val errorDescription: String,
     val correlationID: String? = null
 ) : Exception("Error: $code - Description: $errorDescription")

--- a/Demo/src/main/java/com/paypal/android/ui/PaymentMethodsFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/PaymentMethodsFragment.kt
@@ -22,7 +22,7 @@ import androidx.navigation.fragment.findNavController
 import com.paypal.android.R
 import com.paypal.android.ui.theme.DemoTheme
 
-class PaymentMethodsFragment : Fragment() {
+class PaymentMethodsFragment : Fragment(), View.OnClickListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -84,5 +84,9 @@ class PaymentMethodsFragment : Fragment() {
 
     private fun navigate(action: NavDirections) {
         findNavController().navigate(action)
+    }
+
+    override fun onClick(p0: View?) {
+        TODO("Not yet implemented")
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/PaymentMethodsFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/PaymentMethodsFragment.kt
@@ -22,7 +22,7 @@ import androidx.navigation.fragment.findNavController
 import com.paypal.android.R
 import com.paypal.android.ui.theme.DemoTheme
 
-class PaymentMethodsFragment : Fragment(), View.OnClickListener {
+class PaymentMethodsFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -84,9 +84,5 @@ class PaymentMethodsFragment : Fragment(), View.OnClickListener {
 
     private fun navigate(action: NavDirections) {
         findNavController().navigate(action)
-    }
-
-    override fun onClick(p0: View?) {
-        TODO("Not yet implemented")
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
@@ -80,16 +80,14 @@ class CardViewModel @Inject constructor(
         viewModelScope.launch {
             val order = fetchOrder()
             val request = CardRequest(order.id!!, card)
-            cardClient.approveOrder(request) { result ->
-                when (result) {
-                    is CardResult.Success -> {
-                        Log.d(TAG, "SUCCESS")
-                        Log.d(TAG, "${result.status}")
-                    }
-                    is CardResult.Error -> {
-                        Log.e(TAG, "ERROR")
-                        Log.e(TAG, result.payPalSDKError.errorDescription.orEmpty())
-                    }
+            when (val result = cardClient.approveOrder(request)) {
+                is CardResult.Success -> {
+                    Log.d(TAG, "SUCCESS")
+                    Log.d(TAG, "${result.status}")
+                }
+                is CardResult.Error -> {
+                    Log.e(TAG, "ERROR")
+                    Log.e(TAG, result.payPalSDKError.errorDescription.orEmpty())
                 }
             }
         }

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
@@ -15,7 +15,6 @@ import com.paypal.android.api.services.PayPalDemoApi
 import com.paypal.android.card.Card
 import com.paypal.android.card.CardClient
 import com.paypal.android.card.CardRequest
-import com.paypal.android.card.CardResult
 import com.paypal.android.core.CoreConfig
 import com.paypal.android.core.PayPalSDKError
 import com.paypal.android.data.card.PrefillCardData

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
@@ -17,6 +17,7 @@ import com.paypal.android.card.CardClient
 import com.paypal.android.card.CardRequest
 import com.paypal.android.card.CardResult
 import com.paypal.android.core.CoreConfig
+import com.paypal.android.core.PayPalSDKError
 import com.paypal.android.data.card.PrefillCardData
 import com.paypal.android.ui.card.validation.CardFormatter
 import com.paypal.android.ui.card.validation.DateFormatter
@@ -80,15 +81,14 @@ class CardViewModel @Inject constructor(
         viewModelScope.launch {
             val order = fetchOrder()
             val request = CardRequest(order.id!!, card)
-            when (val result = cardClient.approveOrder(request)) {
-                is CardResult.Success -> {
-                    Log.d(TAG, "SUCCESS")
-                    Log.d(TAG, "${result.status}")
-                }
-                is CardResult.Error -> {
-                    Log.e(TAG, "ERROR")
-                    Log.e(TAG, result.payPalSDKError.errorDescription.orEmpty())
-                }
+
+            try {
+                val result = cardClient.approveOrder(request)
+                Log.d(TAG, "SUCCESS")
+                Log.d(TAG, "${result.status}")
+            } catch (error: PayPalSDKError) {
+                Log.e(TAG, "ERROR")
+                Log.e(TAG, error.errorDescription.orEmpty())
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# PayPal Android SDK
 Welcome to the PayPal Android SDK. This library will help you accept Card, PayPal, and Venmo payments in your Android app.
 
 ## FAQ
@@ -44,15 +43,16 @@ card.number = "4111111111111111"
 card.cvv = "123"
 
 // STEP 4: Call checkout method
-cardClient.checkoutWithCard(ORDER_ID, card) { result, error _>
-    error?.let {
-        // handle checkout error
-        return
-    }
-    result?.let {
-        val orderID = it.orderID 
-        // Send orderID to your server to process the payment
-    }
+lifecycleScope.launch {
+  try {
+    let result = cardClient.checkoutWithCard(ORDER_ID, card)
+  
+    // send orderID to your server to process the payment
+    val orderID = result.orderID 
+  
+  } catch (e: PayPalSDKError) {
+    // handle checkout error
+  }
 }
 
 // STEP 5: Send orderID to your server to capture/authorize

--- a/docs/Card/integration.md
+++ b/docs/Card/integration.md
@@ -107,15 +107,13 @@ Approve the order using your `CardClient`.
 Call `CardClient#approveOrder` to approve the order, and then handle results:
 
 ```kotlin
-cardClient.approveOrder(cardRequest) { result ->
-    when (result) {
-        is CardResult.Success -> {
-            // order was successfully approved and is ready to be captured/authorized (see step 6)
-        } 
-        is CardResult.Error -> {
-            // inspect `result.error` for more information
-        } 
-    }
+viewLifecycleOwner.lifecycleScope.launch {
+  try {
+    val result = cardClient.approveOrder(cardRequest)
+    // order was successfully approved and is ready to be captured/authorized (see step 6)
+  } catch (error: PayPalSDKError) {
+    // inspect `error` for more information
+  }
 }
 ```
 


### PR DESCRIPTION
### Summary of changes

 - Replace `CardClient#approveOrder` callback pattern with a coroutine style suspend function. 

 ### Checklist

 ~- [ ] Added a changelog entry~
