### PR TITLE
Adds PayPalCredit and PayLater funding options

### DIFF
--- a/Demo/src/main/java/com/paypal/android/ui/paypal/PayPalFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypal/PayPalFragment.kt
@@ -17,6 +17,7 @@ import com.paypal.android.checkoutweb.PayPalWebCheckoutListener
 import com.paypal.android.checkoutweb.PayPalWebCheckoutResult
 import com.paypal.android.checkoutweb.PayPalWebCheckoutRequest
 import com.paypal.android.checkoutweb.PayPalWebCheckoutClient
+import com.paypal.android.checkoutweb.PayPalWebCheckoutFunding
 import com.paypal.android.core.APIClientError
 import com.paypal.android.core.CoreConfig
 import com.paypal.android.core.Environment
@@ -53,7 +54,9 @@ class PayPalFragment : Fragment(), PayPalWebCheckoutListener {
         paypalClient = PayPalWebCheckoutClient(requireActivity(), coreConfig, "com.paypal.android.demo")
         paypalClient.listener = this
 
-        binding.submitButton.setOnClickListener { launchNativeCheckout() }
+        binding.submitButton.setOnClickListener { launchWebCheckout() }
+        binding.payPalButton.setOnClickListener { launchWebCheckout(PayPalWebCheckoutFunding.PAY_LATER) }
+        binding.payPalCreditButton.setOnClickListener { launchWebCheckout(PayPalWebCheckoutFunding.CREDIT) }
 
         return binding.root
     }
@@ -94,7 +97,7 @@ class PayPalFragment : Fragment(), PayPalWebCheckoutListener {
         hideLoader()
     }
 
-    private fun launchNativeCheckout() {
+    private fun launchWebCheckout(funding: PayPalWebCheckoutFunding = PayPalWebCheckoutFunding.DEFAULT) {
         showLoader()
 
         lifecycleScope.launch {
@@ -104,7 +107,7 @@ class PayPalFragment : Fragment(), PayPalWebCheckoutListener {
                 val orderJson = parser.parse(OrderUtils.orderWithShipping) as JsonObject
                 val order = payPalDemoApi.fetchOrderId(countryCode = "US", orderJson)
                 order.id?.let { orderId ->
-                    paypalClient.approveOrder(PayPalWebCheckoutRequest(orderId))
+                    paypalClient.approveOrder(PayPalWebCheckoutRequest(orderId, funding))
                 }
             } catch (e: UnknownHostException) {
                 Log.e(TAG, e.message!!)

--- a/Demo/src/main/java/com/paypal/android/ui/paypal/PayPalFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypal/PayPalFragment.kt
@@ -17,7 +17,7 @@ import com.paypal.android.checkoutweb.PayPalWebCheckoutListener
 import com.paypal.android.checkoutweb.PayPalWebCheckoutResult
 import com.paypal.android.checkoutweb.PayPalWebCheckoutRequest
 import com.paypal.android.checkoutweb.PayPalWebCheckoutClient
-import com.paypal.android.checkoutweb.PayPalWebCheckoutFunding
+import com.paypal.android.checkoutweb.PayPalWebCheckoutFundingSource
 import com.paypal.android.core.APIClientError
 import com.paypal.android.core.CoreConfig
 import com.paypal.android.core.Environment
@@ -55,8 +55,8 @@ class PayPalFragment : Fragment(), PayPalWebCheckoutListener {
         paypalClient.listener = this
 
         binding.submitButton.setOnClickListener { launchWebCheckout() }
-        binding.payPalButton.setOnClickListener { launchWebCheckout(PayPalWebCheckoutFunding.PAY_LATER) }
-        binding.payPalCreditButton.setOnClickListener { launchWebCheckout(PayPalWebCheckoutFunding.CREDIT) }
+        binding.payPalButton.setOnClickListener { launchWebCheckout(PayPalWebCheckoutFundingSource.PAY_LATER) }
+        binding.payPalCreditButton.setOnClickListener { launchWebCheckout(PayPalWebCheckoutFundingSource.CREDIT) }
 
         return binding.root
     }
@@ -97,7 +97,7 @@ class PayPalFragment : Fragment(), PayPalWebCheckoutListener {
         hideLoader()
     }
 
-    private fun launchWebCheckout(funding: PayPalWebCheckoutFunding = PayPalWebCheckoutFunding.DEFAULT) {
+    private fun launchWebCheckout(funding: PayPalWebCheckoutFundingSource = PayPalWebCheckoutFundingSource.PAYPAL) {
         showLoader()
 
         lifecycleScope.launch {

--- a/Demo/src/main/java/com/paypal/android/ui/paypal/PayPalFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypal/PayPalFragment.kt
@@ -56,7 +56,9 @@ class PayPalFragment : Fragment(), PayPalWebCheckoutListener {
 
         binding.submitButton.setOnClickListener { launchWebCheckout() }
         binding.payPalButton.setOnClickListener { launchWebCheckout(PayPalWebCheckoutFundingSource.PAY_LATER) }
-        binding.payPalCreditButton.setOnClickListener { launchWebCheckout(PayPalWebCheckoutFundingSource.PAYPAL_CREDIT) }
+        binding.payPalCreditButton.setOnClickListener {
+            launchWebCheckout(PayPalWebCheckoutFundingSource.PAYPAL_CREDIT)
+        }
 
         return binding.root
     }

--- a/Demo/src/main/java/com/paypal/android/ui/paypal/PayPalFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypal/PayPalFragment.kt
@@ -56,7 +56,7 @@ class PayPalFragment : Fragment(), PayPalWebCheckoutListener {
 
         binding.submitButton.setOnClickListener { launchWebCheckout() }
         binding.payPalButton.setOnClickListener { launchWebCheckout(PayPalWebCheckoutFundingSource.PAY_LATER) }
-        binding.payPalCreditButton.setOnClickListener { launchWebCheckout(PayPalWebCheckoutFundingSource.CREDIT) }
+        binding.payPalCreditButton.setOnClickListener { launchWebCheckout(PayPalWebCheckoutFundingSource.PAYPAL_CREDIT) }
 
         return binding.root
     }

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/BrowserSwitchHelper.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/BrowserSwitchHelper.kt
@@ -11,7 +11,7 @@ internal class BrowserSwitchHelper(private val urlScheme: String) {
 
     private val redirectUriPayPalCheckout = "$urlScheme://x-callback-url/paypal-sdk/paypal-checkout"
 
-    private fun buildPayPalCheckoutUri(@NonNull orderId: String?, @NonNull config: CoreConfig): Uri {
+    private fun buildPayPalCheckoutUri(@NonNull orderId: String?, @NonNull config: CoreConfig, @NonNull funding: PayPalWebCheckoutFunding): Uri {
         val baseURL = when (config.environment) {
             Environment.LIVE -> "https://www.paypal.com"
             Environment.SANDBOX -> "https://www.sandbox.paypal.com"
@@ -23,16 +23,18 @@ internal class BrowserSwitchHelper(private val urlScheme: String) {
             .appendQueryParameter("token", orderId)
             .appendQueryParameter("redirect_uri", redirectUriPayPalCheckout)
             .appendQueryParameter("native_xo", "1")
+            .appendQueryParameter("fundingSource", funding.value)
             .build()
     }
 
     fun configurePayPalBrowserSwitchOptions(
         @NonNull orderId: String?,
-        @NonNull config: CoreConfig
+        @NonNull config: CoreConfig,
+        @NonNull funding: PayPalWebCheckoutFunding
     ): BrowserSwitchOptions {
         val metadata = JSONObject().put("order_id", orderId)
         return BrowserSwitchOptions()
-            .url(buildPayPalCheckoutUri(orderId, config))
+            .url(buildPayPalCheckoutUri(orderId, config, funding))
             .returnUrlScheme(urlScheme)
             .metadata(metadata)
     }

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/BrowserSwitchHelper.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/BrowserSwitchHelper.kt
@@ -11,7 +11,7 @@ internal class BrowserSwitchHelper(private val urlScheme: String) {
 
     private val redirectUriPayPalCheckout = "$urlScheme://x-callback-url/paypal-sdk/paypal-checkout"
 
-    private fun buildPayPalCheckoutUri(@NonNull orderId: String?, @NonNull config: CoreConfig, @NonNull funding: PayPalWebCheckoutFunding): Uri {
+    private fun buildPayPalCheckoutUri(@NonNull orderId: String?, @NonNull config: CoreConfig, @NonNull funding: PayPalWebCheckoutFundingSource): Uri {
         val baseURL = when (config.environment) {
             Environment.LIVE -> "https://www.paypal.com"
             Environment.SANDBOX -> "https://www.sandbox.paypal.com"
@@ -30,7 +30,7 @@ internal class BrowserSwitchHelper(private val urlScheme: String) {
     fun configurePayPalBrowserSwitchOptions(
         @NonNull orderId: String?,
         @NonNull config: CoreConfig,
-        @NonNull funding: PayPalWebCheckoutFunding
+        @NonNull funding: PayPalWebCheckoutFundingSource
     ): BrowserSwitchOptions {
         val metadata = JSONObject().put("order_id", orderId)
         return BrowserSwitchOptions()

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutClient.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutClient.kt
@@ -58,7 +58,8 @@ class PayPalWebCheckoutClient internal constructor(
     fun approveOrder(request: PayPalWebCheckoutRequest) {
         val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(
             request.orderID,
-            coreConfig
+            coreConfig,
+            request.funding
         )
         browserSwitchClient.start(activity, browserSwitchOptions)
     }

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutClient.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutClient.kt
@@ -59,7 +59,7 @@ class PayPalWebCheckoutClient internal constructor(
         val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(
             request.orderID,
             coreConfig,
-            request.funding
+            request.fundingSource
         )
         browserSwitchClient.start(activity, browserSwitchOptions)
     }

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFunding.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFunding.kt
@@ -1,0 +1,5 @@
+package com.paypal.android.checkoutweb
+
+enum class PayPalWebCheckoutFunding(val value: String) {
+    CREDIT("credit"), PAY_LATER("paylater"), DEFAULT("")
+}

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFunding.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFunding.kt
@@ -1,8 +1,0 @@
-package com.paypal.android.checkoutweb
-
-/**
- * Enum class to specify the type of funding for an order
- */
-enum class PayPalWebCheckoutFunding(val value: String) {
-    CREDIT("credit"), PAY_LATER("paylater"), DEFAULT("")
-}

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFunding.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFunding.kt
@@ -1,5 +1,8 @@
 package com.paypal.android.checkoutweb
 
+/**
+ * Enum class to specify the type of funding for an order
+ */
 enum class PayPalWebCheckoutFunding(val value: String) {
     CREDIT("credit"), PAY_LATER("paylater"), DEFAULT("")
 }

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFundingSource.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFundingSource.kt
@@ -2,15 +2,18 @@ package com.paypal.android.checkoutweb
 
 /**
  * Enum class to specify the type of funding for an order.
+ * For more information go to: https://developer.paypal.com/docs/checkout/pay-later/us/
  */
 enum class PayPalWebCheckoutFundingSource(val value: String) {
     /**
      * PAYPAL_CREDIT will launch the web checkout flow and display PayPal Credit funding to eligible customers
+     * Eligible costumers receive a revolving line of credit that they can use to pay over time.
      */
     PAYPAL_CREDIT("credit"),
 
     /**
-     * PAY_LATER will launch the web checkout flow and display Pay Later offers to eligible customers.
+     * PAY_LATER will launch the web checkout flow and display Pay Later offers to eligible customers,
+     * which include short-term, interest-free payments and other special financing options.
      */
     PAY_LATER("paylater"),
 

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFundingSource.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFundingSource.kt
@@ -1,0 +1,8 @@
+package com.paypal.android.checkoutweb
+
+/**
+ * Enum class to specify the type of funding for an order
+ */
+enum class PayPalWebCheckoutFundingSource(val value: String) {
+    CREDIT("credit"), PAY_LATER("paylater"), PAYPAL("paypal")
+}

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFundingSource.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFundingSource.kt
@@ -4,5 +4,18 @@ package com.paypal.android.checkoutweb
  * Enum class to specify the type of funding for an order
  */
 enum class PayPalWebCheckoutFundingSource(val value: String) {
-    CREDIT("credit"), PAY_LATER("paylater"), PAYPAL("paypal")
+    /**
+     * CREDIT will launch the web checkout flow with credit funding selected
+     */
+    CREDIT("credit"),
+
+    /**
+     * PAY_LATER will launch the web checkout flow with pay later selected
+     */
+    PAY_LATER("paylater"),
+
+    /**
+     * PAYPAL will launch the web checkout default flow
+     */
+    PAYPAL("paypal")
 }

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFundingSource.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutFundingSource.kt
@@ -1,21 +1,21 @@
 package com.paypal.android.checkoutweb
 
 /**
- * Enum class to specify the type of funding for an order
+ * Enum class to specify the type of funding for an order.
  */
 enum class PayPalWebCheckoutFundingSource(val value: String) {
     /**
-     * CREDIT will launch the web checkout flow with credit funding selected
+     * PAYPAL_CREDIT will launch the web checkout flow and display PayPal Credit funding to eligible customers
      */
-    CREDIT("credit"),
+    PAYPAL_CREDIT("credit"),
 
     /**
-     * PAY_LATER will launch the web checkout flow with pay later selected
+     * PAY_LATER will launch the web checkout flow and display Pay Later offers to eligible customers.
      */
     PAY_LATER("paylater"),
 
     /**
-     * PAYPAL will launch the web checkout default flow
+     * PAYPAL will launch the web checkout for a one-time PayPal Checkout flow
      */
     PAYPAL("paypal")
 }

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutRequest.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutRequest.kt
@@ -4,5 +4,6 @@ package com.paypal.android.checkoutweb
  * Creates an instance of a PayPalRequest.
  *
  * @param orderID The ID of the order to be approved.
+ * @param funding specify funding (credit, paylater or default)
  */
 data class PayPalWebCheckoutRequest @JvmOverloads constructor (val orderID: String, val funding: PayPalWebCheckoutFunding = PayPalWebCheckoutFunding.DEFAULT)

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutRequest.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutRequest.kt
@@ -6,4 +6,4 @@ package com.paypal.android.checkoutweb
  * @param orderID The ID of the order to be approved.
  * @param funding specify funding (credit, paylater or default)
  */
-data class PayPalWebCheckoutRequest @JvmOverloads constructor (val orderID: String, val funding: PayPalWebCheckoutFunding = PayPalWebCheckoutFunding.DEFAULT)
+data class PayPalWebCheckoutRequest @JvmOverloads constructor (val orderID: String, val funding: PayPalWebCheckoutFundingSource = PayPalWebCheckoutFundingSource.PAYPAL)

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutRequest.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutRequest.kt
@@ -5,4 +5,4 @@ package com.paypal.android.checkoutweb
  *
  * @param orderID The ID of the order to be approved.
  */
-data class PayPalWebCheckoutRequest(val orderID: String)
+data class PayPalWebCheckoutRequest @JvmOverloads constructor (val orderID: String, val funding: PayPalWebCheckoutFunding = PayPalWebCheckoutFunding.DEFAULT)

--- a/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutRequest.kt
+++ b/PayPalWebCheckout/src/main/java/com/paypal/android/checkoutweb/PayPalWebCheckoutRequest.kt
@@ -4,6 +4,6 @@ package com.paypal.android.checkoutweb
  * Creates an instance of a PayPalRequest.
  *
  * @param orderID The ID of the order to be approved.
- * @param funding specify funding (credit, paylater or default)
+ * @param fundingSource specify funding (credit, paylater or default)
  */
-data class PayPalWebCheckoutRequest @JvmOverloads constructor (val orderID: String, val funding: PayPalWebCheckoutFundingSource = PayPalWebCheckoutFundingSource.PAYPAL)
+data class PayPalWebCheckoutRequest @JvmOverloads constructor (val orderID: String, val fundingSource: PayPalWebCheckoutFundingSource = PayPalWebCheckoutFundingSource.PAYPAL)

--- a/PayPalWebCheckout/src/test/java/com/paypal/android/checkoutweb/BrowserSwitchHelperUnitTest.kt
+++ b/PayPalWebCheckout/src/test/java/com/paypal/android/checkoutweb/BrowserSwitchHelperUnitTest.kt
@@ -23,13 +23,14 @@ class BrowserSwitchHelperUnitTest {
         val finalUrl = "https://www.sandbox.paypal.com/checkoutnow?" +
                 "token=$mockOrderId" +
                 "&redirect_uri=$urlScheme" +
-                "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1"
+                "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1" +
+                "&fundingSource="
         val uri = Uri.parse(finalUrl)
 
         every { mockCoreConfig.environment } returns Environment.SANDBOX
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFunding.DEFAULT)
 
         expectThat(browserSwitchOptions) {
             get { metadata?.get("order_id") }.isEqualTo(mockOrderId)
@@ -47,13 +48,14 @@ class BrowserSwitchHelperUnitTest {
         val finalUrl = "https://www.msmaster.qa.paypal.com/checkoutnow?" +
                 "token=$mockOrderId" +
                 "&redirect_uri=$urlScheme" +
-                "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1"
+                "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1" +
+                "&fundingSource="
         val uri = Uri.parse(finalUrl)
 
         every { mockCoreConfig.environment } returns Environment.STAGING
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFunding.DEFAULT)
 
         expectThat(browserSwitchOptions) {
             get { url?.host }.isEqualTo(uri.host)
@@ -69,16 +71,63 @@ class BrowserSwitchHelperUnitTest {
         val finalUrl = "https://www.paypal.com/checkoutnow?" +
                 "token=$mockOrderId" +
                 "&redirect_uri=$urlScheme" +
-                "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1"
+                "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1" +
+                "&fundingSource="
         val uri = Uri.parse(finalUrl)
 
         every { mockCoreConfig.environment } returns Environment.LIVE
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFunding.DEFAULT)
 
         expectThat(browserSwitchOptions) {
             get { url?.host }.isEqualTo(uri.host)
+        }
+    }
+
+    @Test
+    fun `when configurePayPalBrowserSwitchOptions is CREDIT funding, the correct url is returned`() {
+        val mockOrderId = "fake_order_id"
+        val mockCoreConfig = mockk<CoreConfig>(relaxed = true)
+
+        val urlScheme = "com.android.test.scheme"
+        val finalUrl = "https://www.paypal.com/checkoutnow?" +
+                "token=$mockOrderId" +
+                "&redirect_uri=$urlScheme" +
+                "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1" +
+                "&fundingSource=credit"
+        val uri = Uri.parse(finalUrl)
+
+        every { mockCoreConfig.environment } returns Environment.LIVE
+
+        val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFunding.CREDIT)
+
+        expectThat(browserSwitchOptions) {
+            get { url }.isEqualTo(uri)
+        }
+    }
+
+    @Test
+    fun `when configurePayPalBrowserSwitchOptions is PAY_LATER funding, the correct url is returned`() {
+        val mockOrderId = "fake_order_id"
+        val mockCoreConfig = mockk<CoreConfig>(relaxed = true)
+
+        val urlScheme = "com.android.test.scheme"
+        val finalUrl = "https://www.paypal.com/checkoutnow?" +
+                "token=$mockOrderId" +
+                "&redirect_uri=$urlScheme" +
+                "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1" +
+                "&fundingSource=paylater"
+        val uri = Uri.parse(finalUrl)
+
+        every { mockCoreConfig.environment } returns Environment.LIVE
+
+        val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFunding.PAY_LATER)
+
+        expectThat(browserSwitchOptions) {
+            get { url }.isEqualTo(uri)
         }
     }
 }

--- a/PayPalWebCheckout/src/test/java/com/paypal/android/checkoutweb/BrowserSwitchHelperUnitTest.kt
+++ b/PayPalWebCheckout/src/test/java/com/paypal/android/checkoutweb/BrowserSwitchHelperUnitTest.kt
@@ -30,7 +30,7 @@ class BrowserSwitchHelperUnitTest {
         every { mockCoreConfig.environment } returns Environment.SANDBOX
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFunding.DEFAULT)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFundingSource.PAYPAL)
 
         expectThat(browserSwitchOptions) {
             get { metadata?.get("order_id") }.isEqualTo(mockOrderId)
@@ -55,7 +55,7 @@ class BrowserSwitchHelperUnitTest {
         every { mockCoreConfig.environment } returns Environment.STAGING
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFunding.DEFAULT)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFundingSource.PAYPAL)
 
         expectThat(browserSwitchOptions) {
             get { url?.host }.isEqualTo(uri.host)
@@ -78,7 +78,7 @@ class BrowserSwitchHelperUnitTest {
         every { mockCoreConfig.environment } returns Environment.LIVE
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFunding.DEFAULT)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFundingSource.PAYPAL)
 
         expectThat(browserSwitchOptions) {
             get { url?.host }.isEqualTo(uri.host)
@@ -101,7 +101,7 @@ class BrowserSwitchHelperUnitTest {
         every { mockCoreConfig.environment } returns Environment.LIVE
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFunding.CREDIT)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFundingSource.CREDIT)
 
         expectThat(browserSwitchOptions) {
             get { url }.isEqualTo(uri)
@@ -124,7 +124,7 @@ class BrowserSwitchHelperUnitTest {
         every { mockCoreConfig.environment } returns Environment.LIVE
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFunding.PAY_LATER)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFundingSource.PAY_LATER)
 
         expectThat(browserSwitchOptions) {
             get { url }.isEqualTo(uri)

--- a/PayPalWebCheckout/src/test/java/com/paypal/android/checkoutweb/BrowserSwitchHelperUnitTest.kt
+++ b/PayPalWebCheckout/src/test/java/com/paypal/android/checkoutweb/BrowserSwitchHelperUnitTest.kt
@@ -18,19 +18,20 @@ class BrowserSwitchHelperUnitTest {
     fun `when configurePayPalBrowserSwitchOptions is executed, the correct BrowserSwitchOptions is returned`() {
         val mockOrderId = "fake_order_id"
         val mockCoreConfig = mockk<CoreConfig>(relaxed = true)
+        val mockFundingSource = PayPalWebCheckoutFundingSource.PAYPAL
 
         val urlScheme = "com.android.test.scheme"
         val finalUrl = "https://www.sandbox.paypal.com/checkoutnow?" +
                 "token=$mockOrderId" +
                 "&redirect_uri=$urlScheme" +
                 "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1" +
-                "&fundingSource="
+                "&fundingSource=${mockFundingSource.value}"
         val uri = Uri.parse(finalUrl)
 
         every { mockCoreConfig.environment } returns Environment.SANDBOX
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFundingSource.PAYPAL)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, mockFundingSource)
 
         expectThat(browserSwitchOptions) {
             get { metadata?.get("order_id") }.isEqualTo(mockOrderId)
@@ -43,19 +44,20 @@ class BrowserSwitchHelperUnitTest {
     fun `when configurePayPalBrowserSwitchOptions is executed with STAGING, the correct url is returned`() {
         val mockOrderId = "fake_order_id"
         val mockCoreConfig = mockk<CoreConfig>(relaxed = true)
+        val mockFundingSource = PayPalWebCheckoutFundingSource.PAYPAL
 
         val urlScheme = "com.android.test.scheme"
         val finalUrl = "https://www.msmaster.qa.paypal.com/checkoutnow?" +
                 "token=$mockOrderId" +
                 "&redirect_uri=$urlScheme" +
                 "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1" +
-                "&fundingSource="
+                "&fundingSource=${mockFundingSource.value}"
         val uri = Uri.parse(finalUrl)
 
         every { mockCoreConfig.environment } returns Environment.STAGING
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFundingSource.PAYPAL)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, mockFundingSource)
 
         expectThat(browserSwitchOptions) {
             get { url?.host }.isEqualTo(uri.host)
@@ -66,19 +68,20 @@ class BrowserSwitchHelperUnitTest {
     fun `when configurePayPalBrowserSwitchOptions is executed with LIVE, the correct url is returned`() {
         val mockOrderId = "fake_order_id"
         val mockCoreConfig = mockk<CoreConfig>(relaxed = true)
+        val mockFundingSource = PayPalWebCheckoutFundingSource.PAYPAL
 
         val urlScheme = "com.android.test.scheme"
         val finalUrl = "https://www.paypal.com/checkoutnow?" +
                 "token=$mockOrderId" +
                 "&redirect_uri=$urlScheme" +
                 "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1" +
-                "&fundingSource="
+                "&fundingSource=${mockFundingSource.value}"
         val uri = Uri.parse(finalUrl)
 
         every { mockCoreConfig.environment } returns Environment.LIVE
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFundingSource.PAYPAL)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, mockFundingSource)
 
         expectThat(browserSwitchOptions) {
             get { url?.host }.isEqualTo(uri.host)
@@ -89,19 +92,20 @@ class BrowserSwitchHelperUnitTest {
     fun `when configurePayPalBrowserSwitchOptions is CREDIT funding, the correct url is returned`() {
         val mockOrderId = "fake_order_id"
         val mockCoreConfig = mockk<CoreConfig>(relaxed = true)
+        val mockFundingSource = PayPalWebCheckoutFundingSource.CREDIT
 
         val urlScheme = "com.android.test.scheme"
         val finalUrl = "https://www.paypal.com/checkoutnow?" +
                 "token=$mockOrderId" +
                 "&redirect_uri=$urlScheme" +
                 "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1" +
-                "&fundingSource=credit"
+                "&fundingSource=${mockFundingSource.value}"
         val uri = Uri.parse(finalUrl)
 
         every { mockCoreConfig.environment } returns Environment.LIVE
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFundingSource.CREDIT)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, mockFundingSource)
 
         expectThat(browserSwitchOptions) {
             get { url }.isEqualTo(uri)
@@ -112,19 +116,20 @@ class BrowserSwitchHelperUnitTest {
     fun `when configurePayPalBrowserSwitchOptions is PAY_LATER funding, the correct url is returned`() {
         val mockOrderId = "fake_order_id"
         val mockCoreConfig = mockk<CoreConfig>(relaxed = true)
+        val mockFundingSource = PayPalWebCheckoutFundingSource.PAY_LATER
 
         val urlScheme = "com.android.test.scheme"
         val finalUrl = "https://www.paypal.com/checkoutnow?" +
                 "token=$mockOrderId" +
                 "&redirect_uri=$urlScheme" +
                 "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1" +
-                "&fundingSource=paylater"
+                "&fundingSource=${mockFundingSource.value}"
         val uri = Uri.parse(finalUrl)
 
         every { mockCoreConfig.environment } returns Environment.LIVE
 
         val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, PayPalWebCheckoutFundingSource.PAY_LATER)
+        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(mockOrderId, mockCoreConfig, mockFundingSource)
 
         expectThat(browserSwitchOptions) {
             get { url }.isEqualTo(uri)

--- a/PayPalWebCheckout/src/test/java/com/paypal/android/checkoutweb/BrowserSwitchHelperUnitTest.kt
+++ b/PayPalWebCheckout/src/test/java/com/paypal/android/checkoutweb/BrowserSwitchHelperUnitTest.kt
@@ -92,7 +92,7 @@ class BrowserSwitchHelperUnitTest {
     fun `when configurePayPalBrowserSwitchOptions is CREDIT funding, the correct url is returned`() {
         val mockOrderId = "fake_order_id"
         val mockCoreConfig = mockk<CoreConfig>(relaxed = true)
-        val mockFundingSource = PayPalWebCheckoutFundingSource.CREDIT
+        val mockFundingSource = PayPalWebCheckoutFundingSource.PAYPAL_CREDIT
 
         val urlScheme = "com.android.test.scheme"
         val finalUrl = "https://www.paypal.com/checkoutnow?" +

--- a/PayPalWebCheckout/src/test/java/com/paypal/android/checkoutweb/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebCheckout/src/test/java/com/paypal/android/checkoutweb/PayPalWebCheckoutClientUnitTest.kt
@@ -41,7 +41,7 @@ class PayPalWebCheckoutClientUnitTest {
             browserSwitchHelper.configurePayPalBrowserSwitchOptions(
                 any(),
                 coreConfig,
-                payPalRequest.funding
+                payPalRequest.fundingSource
             )
         } returns browserSwitchOptions
 

--- a/PayPalWebCheckout/src/test/java/com/paypal/android/checkoutweb/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebCheckout/src/test/java/com/paypal/android/checkoutweb/PayPalWebCheckoutClientUnitTest.kt
@@ -40,7 +40,8 @@ class PayPalWebCheckoutClientUnitTest {
         every {
             browserSwitchHelper.configurePayPalBrowserSwitchOptions(
                 any(),
-                coreConfig
+                coreConfig,
+                payPalRequest.funding
             )
         } returns browserSwitchOptions
 

--- a/docs/PayPal/integration.md
+++ b/docs/PayPal/integration.md
@@ -134,6 +134,9 @@ Configure your `PayPalWebCheckoutRequest` and include the order ID generated [st
 val payPalWebCheckoutRequest = PayPalWebCheckoutRequest("<ORDER_ID>")
 ```
 
+You can also specify the funding source for your order which are `PayPal` (default), `PayLater` and `PayPalCredit`.
+For more information go to: https://developer.paypal.com/docs/checkout/pay-later/us/
+
 ### 7. Approve the order through the Payments SDK
 
 When a user initiates the PayPal payment flow through your UI, approve the order using your `PayPalWebCheckoutClient`

--- a/docs/PayPal/integration.md
+++ b/docs/PayPal/integration.md
@@ -26,11 +26,11 @@ For initial setup, the `curl` commands below can be used as a reference for maki
 
 ### 1. Add the Payments SDK  to your app
 
-In your `build.gradle` file, add the following dependency:
+In your `build.gradle` file, add the following dependency [see step 8](#8-Capture-authorize-the-order):
 
 ```groovy
 dependencies {
-   implementation "com.paypal.android:paypal-web-checkout:1.0.0"[see step 8](#8-Capture-authorize-the-order)
+   implementation "com.paypal.android:paypal-web-checkout:1.0.0"
 }
 ```
 


### PR DESCRIPTION

### Summary of changes

 -  This PR adds the `PayPalWebCheckoutFunding` to the web checkout flow. That value can be either `CREDIT` or `PAY_LATER`

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 
