### PR TITLE
Make CountryCode required param for Address

### DIFF
--- a/Core/src/main/java/com/paypal/android/core/Address.kt
+++ b/Core/src/main/java/com/paypal/android/core/Address.kt
@@ -1,6 +1,10 @@
 package com.paypal.android.core
 
 data class Address(
+    /**
+     * The [two-character ISO 3166-1 code], that identifies the country or region.
+     */
+    val countryCode: String,
 
     /**
      * Optional. Line 1 of the Address (eg. number, street, etc)
@@ -27,10 +31,5 @@ data class Address(
      * Optional. Zip code or equivalent is usually required for countries that have them.
      * For a list of countries that do not have postal codes please refer to http://en.wikipedia.org/wiki/Postal_code
      */
-    val postalCode: String? = null,
-
-    /**
-     * Optional. 2 letter country code
-     */
-    val countryCode: String? = null,
+    val postalCode: String? = null
 )

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
@@ -188,14 +188,14 @@ class CardFragment : Fragment() {
 
             val (monthString, yearString) = expirationDate.split("/")
 
-            val billing = Address(
+            val billingAddress = Address(
                 countryCode = "US",
                 streetAddress = "3272 Gateway Road",
                 locality = "Aloha",
                 postalCode = "97007"
             )
 
-            val card = Card(cardNumber, monthString, yearString, securityCode, billingAddress = billing)
+            val card = Card(cardNumber, monthString, yearString, securityCode, billingAddress = billingAddress)
             CardRequest(order.id!!, card)
         }
 

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
@@ -21,6 +21,7 @@ import com.paypal.android.card.CardRequest
 import com.paypal.android.card.model.CardResult
 import com.paypal.android.card.threedsecure.SCA
 import com.paypal.android.card.threedsecure.ThreeDSecureRequest
+import com.paypal.android.core.Address
 import com.paypal.android.core.CoreConfig
 import com.paypal.android.core.PayPalSDKError
 import com.paypal.android.databinding.FragmentCardBinding
@@ -187,7 +188,14 @@ class CardFragment : Fragment() {
 
             val (monthString, yearString) = expirationDate.split("/")
 
-            val card = Card(cardNumber, monthString, yearString, securityCode)
+            val billing = Address(
+                countryCode = "US",
+                streetAddress = "3272 Gateway Road",
+                locality = "Aloha",
+                postalCode = "97007"
+            )
+
+            val card = Card(cardNumber, monthString, yearString, securityCode, billingAddress = billing)
             CardRequest(order.id!!, card)
         }
 


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 -  Makez countryCode a required parameter for address

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 
