### PR TITLE
Access Token Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ dependencies {
 
 ## Access Token
 
+> NOTE: We use curl to demonstrate the overall composition of the Access Token HTTP request. This example can be adapted to any server-side language/framework of your choice.
+
 The PayPal SDK uses access tokens for authentication. You can create an access token in two steps:
 
 1. Follw the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a `CLIENT_ID` and `CLIENT_SECRET` from the PayPal Developer site.
 1. Use the credentials obtained in step 1 to make the following HTTP request using Basic Authentication:
-
-> NOTE: We use curl to demonstrate the overall composition of the Access Token HTTP request. This example can be adapted to any server-side language/framework of your choice.
 
 ```bash
 # for LIVE environment

--- a/README.md
+++ b/README.md
@@ -54,10 +54,8 @@ The PayPal SDK uses access tokens for authentication.
 
 To create an access token:
 
-1. Follw the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a `CLIENT_ID` and `CLIENT_SECRET` from the PayPal Developer site.
-1. Make an HTTP request using the credentials obtained in step 1 to fetch an access token:
-
-:warning:&nbsp;Make sure the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set.
+1. Follw the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client ID and secret from the PayPal Developer site.
+1. Make an HTTP request with [Basic Authentication](https://www.twilio.com/docs/glossary/what-is-basic-authentication) using the credentials obtained in step 1 to fetch an access token:
 
 **Request**
 ```bash
@@ -73,6 +71,8 @@ curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
 -H 'Content-Type: application/x-www-form-urlencoded' \
 -d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'
 ```
+
+:warning:&nbsp;Make sure the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set.
 
 **Response**
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To create an access token, follow the steps in [Get Started](https://developer.p
 
 ```bash
 curl --location --request POST 'https://api.paypal.com/v1/oauth2/token' \
--H "Authorization: Basic $(echo $CLIENT_ID:$CLIENT_SECRET | base64)" \
+-u $CLIENT_ID:$CLIENT_SECRET
 -H 'Content-Type: application/x-www-form-urlencoded' \
 -d '"grant_type=client_credentials&response_type=token&return_authn_schemes=true"'
 ```

--- a/README.md
+++ b/README.md
@@ -46,19 +46,25 @@ dependencies {
 }
 ```
 
-## Usage
-The SDK uses AccessToken integration, meaning that an access token is needed to use every module of the SDK. To create an access token, a client ID and secret are needed.
-Follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to create a `CLIENT_ID` and `SECRET`. In order to create an access token, run the following request with
-`CLIENT_ID:SECRET` encoded in base64, on the `Authorization` header:
+## Access Token
 
-**Request**
+The PayPal SDK uses access tokens for authentication.
+
+To create an access token, you will first need to follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client id and client secret.
+
+Then, make the following http request from your server using Basic authentication:
+
 ```bash
-curl --location --request POST 'https://api.sandbox.paypal.com/v1/oauth2/token' \
---header 'Content-Type: application/json' \
---header 'Authorization: Basic <CLIENT_ID:SECRET>'
+curl --location --request POST 'https://api.paypal.com/v1/oauth2/token' \
+-H "Authorization: Basic $(echo $CLIENT_ID:$CLIENT_SECRET | base64)" \
+-H 'Content-Type: application/x-www-form-urlencoded' \
+-d '"grant_type=client_credentials&response_type=token&return_authn_schemes=true"'
 ```
 
-**Response**
+We use curl to demonstrate the composition of the HTTP request. Make sure to set environment variables for `CLIENT_ID` and `CLIENT_SECRET` when fetching an access token from the command line.
+
+This example can be adapted to any server-side language to receive the following JSON result:
+
 ```json
 {
   "scope": "...",
@@ -69,9 +75,13 @@ curl --location --request POST 'https://api.sandbox.paypal.com/v1/oauth2/token' 
   "nonce": "..."
 }
 ```
-Insert `ACCESS_TOKEN` in the `CoreConfig` object to use in any of the modules.
 
-To know how to use each dependency of the SDK, go to any of the following:
+Use the `ACCESS_TOKEN` to create a `CoreConfig` object to use in any of the SDK modules.
+
+## Modules
+
+Each feature module has its own onboarding guide:
+
 - [Card](docs/Card)
 - [PayPalUI](docs/PayPalUI)
 - [PayPal Web Checkout](docs/PayPalWebCheckout)

--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ dependencies {
 
 ## Access Token
 
-> NOTE: We use curl to demonstrate the overall composition of the Access Token HTTP request. This example can be adapted to any server-side language/framework of your choice.
-
 The PayPal SDK uses access tokens for authentication. You can create an access token in two steps:
 
 1. Follw the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a `CLIENT_ID` and `CLIENT_SECRET` from the PayPal Developer site.
@@ -70,6 +68,8 @@ curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
 ```
 
 :warning:&nbsp;Make sure the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set.
+
+> We use command-line curl to demonstrate the overall composition of the Access Token HTTP request. This example can be adapted to any server-side language/framework of your choice.
 
 On success, we receive the following JSON result:
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ curl --location --request POST 'https://api.paypal.com/v1/oauth2/token' \
 -d '"grant_type=client_credentials&response_type=token&return_authn_schemes=true"'
 ```
 
-Make sure to set environment variables for `CLIENT_ID` and `CLIENT_SECRET` when fetching an access token from the command line. We use curl to demonstrate the composition of the HTTP request.
+Make sure to set environment variables for `CLIENT_ID` and `CLIENT_SECRET` when fetching an access token from the command line.
 
-This example can be adapted to any server-side language to receive the following JSON result:
+We use curl to demonstrate the composition of the HTTP request. This example can be adapted to any server-side language to receive the following JSON result:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
 -d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'
 ```
 
-:warning:&nbsp;Make sure that the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set.
+:warning:&nbsp;Make sure the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set.
 
 > NOTE: We use curl to demonstrate the overall composition of the Access Token HTTP request. This example can be adapted to any server-side language/framework of your choice.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The PayPal SDK uses access tokens for authentication. You can create an access t
 1. Follw the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a `CLIENT_ID` and `CLIENT_SECRET` from the PayPal Developer site.
 1. Use the credentials obtained in step 1 to make the following HTTP request using Basic Authentication:
 
+> NOTE: We use curl to demonstrate the overall composition of the Access Token HTTP request. This example can be adapted to any server-side language/framework of your choice.
+
 ```bash
 # for LIVE environment
 curl -X POST https://api.paypal.com/v1/oauth2/token \
@@ -68,8 +70,6 @@ curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
 ```
 
 :warning:&nbsp;Make sure the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set.
-
-> NOTE: We use curl to demonstrate the overall composition of the Access Token HTTP request. This example can be adapted to any server-side language/framework of your choice.
 
 On success, we receive the following JSON result:
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ The PayPal SDK uses access tokens for authentication.
 To create an access token, follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client id and client secret from the PayPal Developer portal. Then, make the following HTTP request from your server using Basic authentication:
 
 ```bash
-curl -X POST 'https://api.paypal.com/v1/oauth2/token' \
+curl -X POST https://api.paypal.com/v1/oauth2/token \
 -u $CLIENT_ID:$CLIENT_SECRET \
 -H 'Content-Type: application/x-www-form-urlencoded' \
--d '"grant_type=client_credentials&response_type=token&return_authn_schemes=true"'
+-d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'
 ```
 
 Make sure to set environment variables for `CLIENT_ID` and `CLIENT_SECRET` when fetching an access token from the command line.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,11 @@ The PayPal SDK uses access tokens for authentication.
 To create an access token:
 
 1. Follw the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a `CLIENT_ID` and `CLIENT_SECRET` from the PayPal Developer site.
-1. Use the credentials obtained in step 1 to make the following HTTP request with Basic Authentication:
+1. Make an HTTP request using the credentials obtained in step 1 to fetch an access token:
 
+:warning:&nbsp;Make sure the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set.
+
+**Request**
 ```bash
 # for LIVE environment
 curl -X POST https://api.paypal.com/v1/oauth2/token \
@@ -71,9 +74,7 @@ curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
 -d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'
 ```
 
-:warning:&nbsp;Make sure the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set.
-
-On success, we receive the following JSON result:
+**Response**
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ dependencies {
 
 ## Access Token
 
-The PayPal SDK uses access tokens for authentication.
+The PayPal SDK uses access tokens for authentication. You can create an access token in two steps:
 
-To create an access token, follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client id and client secret from the PayPal Developer portal. Then, make the following HTTP request from your server using Basic authentication:
+1. Follw the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a `CLIENT_ID` and `CLIENT_SECRET` from the PayPal Developer site.
+1. Use the credentials obtained in step 1 to make the following HTTP request using Basic Authentication:
 
 ```bash
 # for LIVE environment
@@ -66,9 +67,11 @@ curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
 -d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'
 ```
 
-Make sure to set environment variables for `CLIENT_ID` and `CLIENT_SECRET` when fetching an access token from the command line.
+Make sure that the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set to the values obtained in step 1.
 
-We use curl to demonstrate the composition of the access token HTTP request. This example can be adapted to any server-side language to receive the following JSON result:
+> NOTE: We use curl to demonstrate the overall composition of the Access Token HTTP request. This example can be adapted to any server-side language/framework of your choice.
+
+On success, we receive the following JSON result:
 
 ```json
 {
@@ -81,7 +84,7 @@ We use curl to demonstrate the composition of the access token HTTP request. Thi
 }
 ```
 
-Use the `ACCESS_TOKEN` to create an instance of `CoreConfig` to use with any of the SDK's feature clients.
+Use the value from the `access_token` property to create an instance of `CoreConfig` to use with any of the SDK's feature clients.
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The PayPal SDK uses access tokens for authentication.
 To create an access token:
 
 1. Follw the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client ID and secret from the PayPal Developer site.
-1. Make an HTTP request with [Basic Authentication](https://www.twilio.com/docs/glossary/what-is-basic-authentication) using the credentials obtained in step 1 to fetch an access token:
+1. Make an HTTP request with [Basic Authentication](https://www.twilio.com/docs/glossary/what-is-basic-authentication) using client ID and secret to fetch an access token:
 
 **Request**
 ```bash

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The PayPal SDK uses access tokens for authentication.
 To create an access token:
 
 1. Follw the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client ID and secret from the PayPal Developer site.
-1. Make an HTTP request with [Basic Authentication](https://www.twilio.com/docs/glossary/what-is-basic-authentication) using client ID and secret to fetch an access token:
+1. Make an HTTP request with Basic Authentication using client ID and secret to fetch an access token:
 
 **Request**
 ```bash

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl --location --request POST 'https://api.paypal.com/v1/oauth2/token' \
 -d '"grant_type=client_credentials&response_type=token&return_authn_schemes=true"'
 ```
 
-We use curl to demonstrate the composition of the HTTP request. Make sure to set environment variables for `CLIENT_ID` and `CLIENT_SECRET` when fetching an access token from the command line.
+Make sure to set environment variables for `CLIENT_ID` and `CLIENT_SECRET` when fetching an access token from the command line. We use curl to demonstrate the composition of the HTTP request.
 
 This example can be adapted to any server-side language to receive the following JSON result:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ dependencies {
 
 The PayPal SDK uses access tokens for authentication.
 
-To create an access token, you will first need to follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client id and client secret.
+To create an access token, follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client id and client secret from the PayPal Developer portal.
 
 Then, make the following http request from your server using Basic authentication:
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,14 @@ dependencies {
 
 ## Access Token
 
-The PayPal SDK uses access tokens for authentication. You can create an access token in two steps:
+The PayPal SDK uses access tokens for authentication.
+
+> The follwing example can be adapted to any server-side language/framework of your choice. We use command-line curl to demonstrate the overall composition of the Access Token HTTP request.
+
+To create an access token:
 
 1. Follw the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a `CLIENT_ID` and `CLIENT_SECRET` from the PayPal Developer site.
-1. Use the credentials obtained in step 1 to make the following HTTP request using Basic Authentication:
+1. Use the credentials obtained in step 1 to make the following HTTP request with Basic Authentication:
 
 ```bash
 # for LIVE environment
@@ -69,8 +73,6 @@ curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
 
 :warning:&nbsp;Make sure the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set.
 
-> We use command-line curl to demonstrate the overall composition of the Access Token HTTP request. This example can be adapted to any server-side language/framework of your choice.
-
 On success, we receive the following JSON result:
 
 ```json
@@ -84,7 +86,7 @@ On success, we receive the following JSON result:
 }
 ```
 
-Use the value from the `access_token` property to create an instance of `CoreConfig` to use with any of the SDK's feature clients.
+Use the value for `access_token` in the response to create an instance of `CoreConfig` to use with any of the SDK's feature clients.
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The PayPal SDK uses access tokens for authentication.
 To create an access token, follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client id and client secret from the PayPal Developer portal. Then, make the following HTTP request from your server using Basic authentication:
 
 ```bash
-curl -X POST https://api.paypal.com/v1/oauth2/token \
+curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
 -u $CLIENT_ID:$CLIENT_SECRET \
 -H 'Content-Type: application/x-www-form-urlencoded' \
 -d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
 -d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'
 ```
 
-Make sure that the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set to the values obtained in step 1.
+:warning:&nbsp;Make sure that the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set.
 
 > NOTE: We use curl to demonstrate the overall composition of the Access Token HTTP request. This example can be adapted to any server-side language/framework of your choice.
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ The PayPal SDK uses access tokens for authentication.
 To create an access token, follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client id and client secret from the PayPal Developer portal. Then, make the following HTTP request from your server using Basic authentication:
 
 ```bash
-# for environment: LIVE
+# for LIVE environment
 curl -X POST https://api.paypal.com/v1/oauth2/token \
 -u $CLIENT_ID:$CLIENT_SECRET \
 -H 'Content-Type: application/x-www-form-urlencoded' \
 -d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'
 
-# for environment: SANDBOX
+# for SANDBOX environment
 curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
 -u $CLIENT_ID:$CLIENT_SECRET \
 -H 'Content-Type: application/x-www-form-urlencoded' \

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ The PayPal SDK uses access tokens for authentication.
 To create an access token, follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client id and client secret from the PayPal Developer portal. Then, make the following HTTP request from your server using Basic authentication:
 
 ```bash
+# for environment: LIVE
+curl -X POST https://api.paypal.com/v1/oauth2/token \
+-u $CLIENT_ID:$CLIENT_SECRET \
+-H 'Content-Type: application/x-www-form-urlencoded' \
+-d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'
+
+# for environment: SANDBOX
 curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
 -u $CLIENT_ID:$CLIENT_SECRET \
 -H 'Content-Type: application/x-www-form-urlencoded' \

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ The PayPal SDK uses access tokens for authentication.
 To create an access token, follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client id and client secret from the PayPal Developer portal. Then, make the following HTTP request from your server using Basic authentication:
 
 ```bash
-curl --location --request POST 'https://api.paypal.com/v1/oauth2/token' \
--u $CLIENT_ID:$CLIENT_SECRET
+curl -X POST 'https://api.paypal.com/v1/oauth2/token' \
+-u $CLIENT_ID:$CLIENT_SECRET \
 -H 'Content-Type: application/x-www-form-urlencoded' \
 -d '"grant_type=client_credentials&response_type=token&return_authn_schemes=true"'
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The PayPal SDK uses access tokens for authentication.
 
 To create an access token, follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client id and client secret from the PayPal Developer portal.
 
-Then, make the following http request from your server using Basic authentication:
+Then, make the following HTTP request from your server using Basic authentication:
 
 ```bash
 curl --location --request POST 'https://api.paypal.com/v1/oauth2/token' \
@@ -63,7 +63,7 @@ curl --location --request POST 'https://api.paypal.com/v1/oauth2/token' \
 
 Make sure to set environment variables for `CLIENT_ID` and `CLIENT_SECRET` when fetching an access token from the command line.
 
-We use curl to demonstrate the composition of the HTTP request. This example can be adapted to any server-side language to receive the following JSON result:
+We use curl to demonstrate the composition of the access token HTTP request. This example can be adapted to any server-side language to receive the following JSON result:
 
 ```json
 {
@@ -76,7 +76,7 @@ We use curl to demonstrate the composition of the HTTP request. This example can
 }
 ```
 
-Use the `ACCESS_TOKEN` to create a `CoreConfig` object to use in any of the SDK modules.
+Use the `ACCESS_TOKEN` to create an instance of `CoreConfig` to use with any of the SDK's feature clients.
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ dependencies {
 
 The PayPal SDK uses access tokens for authentication.
 
-To create an access token, follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client id and client secret from the PayPal Developer portal.
-
-Then, make the following HTTP request from your server using Basic authentication:
+To create an access token, follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client id and client secret from the PayPal Developer portal. Then, make the following HTTP request from your server using Basic authentication:
 
 ```bash
 curl --location --request POST 'https://api.paypal.com/v1/oauth2/token' \

--- a/docs/Card/README.md
+++ b/docs/Card/README.md
@@ -32,10 +32,10 @@ dependencies {
 
 ### 2. Initiate the Payments SDK
 
-Create a `CoreConfig` using your client ID from the PayPal Developer Portal:
+Create a `CoreConfig` using an [access token](../../README.md#access-token):
 
 ```kotlin
-val config = CoreConfig("<CLIENT_ID>", environment = Environment.SANDBOX)
+val config = CoreConfig("<ACCESS_TOKEN>", environment = Environment.SANDBOX)
 ```
 
 Create a `CardClient` to approve an order with a Card payment method. Also, set a listener to receive callbacks from the client.

--- a/docs/PayPalNativeCheckout/README.md
+++ b/docs/PayPalNativeCheckout/README.md
@@ -39,10 +39,10 @@ A return URL is required for redirecting users back to the app after authenticat
 
 ### 3. Initiate PayPal Native Checkout
 
-Create a `CoreConfig` using with an `ACCESS_TOKEN` created with the `CLIENT_ID` and `SECRET`:
+Create a `CoreConfig` using an [access token](../../README.md#access-token):
 
 ```kotlin
- val coreConfig = CoreConfig("<ACCESS_TOKEN>", environment= Environment.SANDBOX)
+val coreConfig = CoreConfig("<ACCESS_TOKEN>", environment = Environment.SANDBOX)
 ```
 
 Create a `PayPalClient` with your `RETURN_URL` created above:

--- a/docs/PayPalWebCheckout/README.md
+++ b/docs/PayPalWebCheckout/README.md
@@ -53,10 +53,10 @@ Edit your app's `AndroidManifest.xml` to include an `intent-filter` and set the 
 
 ### 3. Initiate the Payments SDK
 
-Create a `CoreConfig` using your client ID from the PayPal Developer Portal:
+Create a `CoreConfig` using an [access token](../../README.md#access-token):
 
 ```kotlin
-val config = CoreConfig("<CLIENT_ID>", environment = Environment.SANDBOX)
+val config = CoreConfig("<ACCESS_TOKEN>", environment = Environment.SANDBOX)
 ```
 
 Set a return URL using the custom scheme you configured in the `ActivityManifest.xml` [step 2](#2-configure-your-app-to-handle-browser-switching):

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,3 @@
 - [PayPalUI](PayPalUI)
 - [PayPal Web Checkout](PayPalWebCheckout)
 - [PayPal Native Checkout](PayPalNativeCheckout)
-


### PR DESCRIPTION
### Summary of changes

 - This PR updates documentation Access Token request onboarding and make sure `CoreConfig` examples use access tokens instead of client ids.

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
