### PR TITLE
Add Return URL to Confirm Order Call

### DIFF
--- a/Card/src/main/java/com/paypal/android/card/CardRequestFactory.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardRequestFactory.kt
@@ -30,18 +30,25 @@ internal class CardRequestFactory {
                 cardJSON.put("billing_address", billingAddressJSON)
             }
 
+            val bodyJSON = JSONObject()
             threeDSecureRequest?.also {
                 val verificationJSON = JSONObject()
                     .put("method", it.sca.name)
                 val attributesJSON = JSONObject()
                     .put("verification", verificationJSON)
                 cardJSON.put("attributes", attributesJSON)
+
                 // add return and cancel url when its supported
+                val applicationContextJSON = JSONObject()
+                    .put("return_url", it.returnUrl)
+                    .put("cancel_url", it.cancelUrl)
+                bodyJSON.put("application_context", applicationContextJSON)
             }
 
             val paymentSourceJSON = JSONObject().put("card", cardJSON)
-            val bodyJSON = JSONObject().put("payment_source", paymentSourceJSON)
-            val body = bodyJSON.toString()
+            bodyJSON.put("payment_source", paymentSourceJSON)
+
+            val body = bodyJSON.toString().replace("\\/", "/")
 
             val path = "v2/checkout/orders/$orderID/confirm-payment-source"
             APIRequest(path, HttpMethod.POST, body)

--- a/Card/src/main/java/com/paypal/android/card/CardRequestFactory.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardRequestFactory.kt
@@ -31,7 +31,7 @@ internal class CardRequestFactory {
             }
 
             val bodyJSON = JSONObject()
-            threeDSecureRequest?.also {
+            threeDSecureRequest?.let {
                 val verificationJSON = JSONObject()
                     .put("method", it.sca.name)
                 val attributesJSON = JSONObject()

--- a/Card/src/main/java/com/paypal/android/card/CardRequestFactory.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardRequestFactory.kt
@@ -38,7 +38,6 @@ internal class CardRequestFactory {
                     .put("verification", verificationJSON)
                 cardJSON.put("attributes", attributesJSON)
 
-                // add return and cancel url when its supported
                 val returnURLJSON = JSONObject()
                     .put("return_url", it.returnUrl)
                     .put("cancel_url", it.cancelUrl)

--- a/Card/src/main/java/com/paypal/android/card/CardRequestFactory.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardRequestFactory.kt
@@ -39,10 +39,10 @@ internal class CardRequestFactory {
                 cardJSON.put("attributes", attributesJSON)
 
                 // add return and cancel url when its supported
-                val applicationContextJSON = JSONObject()
+                val returnURLJSON = JSONObject()
                     .put("return_url", it.returnUrl)
                     .put("cancel_url", it.cancelUrl)
-                bodyJSON.put("application_context", applicationContextJSON)
+                bodyJSON.put("application_context", returnURLJSON)
             }
 
             val paymentSourceJSON = JSONObject().put("card", cardJSON)

--- a/Card/src/test/java/com/paypal/android/card/CardRequestFactoryUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardRequestFactoryUnitTest.kt
@@ -120,9 +120,13 @@ class CardRequestFactoryUnitTest {
                     }
                   }
                 }
+              },
+              "application_context": {
+                "return_url": "https://sample.com/return/url",
+                "cancel_url": "https://sample.com/return/url"
               }
             }
         """.trimIndent()
-        JSONAssert.assertEquals(JSONObject(expectedJSON), JSONObject(apiRequest.body!!), false)
+        JSONAssert.assertEquals(JSONObject(expectedJSON), JSONObject(apiRequest.body!!), true)
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
@@ -10,10 +10,8 @@ import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.paypal.android.R
-import com.paypal.android.api.model.Amount
 import com.paypal.android.api.model.CreateOrderRequest
 import com.paypal.android.api.model.Payee
-import com.paypal.android.api.model.PurchaseUnit
 import com.paypal.android.api.services.PayPalDemoApi
 import com.paypal.android.card.ApproveOrderListener
 import com.paypal.android.card.Card
@@ -224,13 +222,6 @@ class CardFragment : Fragment() {
             ),
             payee = Payee(emailAddress = "anpelaez@paypal.com")
         )
-
-        if (shouldRequestThreeDSecure) {
-            createOrderRequest.applicationContext = ApplicationContext(
-                returnURL = APP_RETURN_URL,
-                cancelURL = APP_CANCEL_URL
-            )
-        }
         return createOrderRequest
     }
 

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
@@ -10,9 +10,10 @@ import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.paypal.android.R
-import com.paypal.android.api.model.ApplicationContext
+import com.paypal.android.api.model.Amount
 import com.paypal.android.api.model.CreateOrderRequest
 import com.paypal.android.api.model.Payee
+import com.paypal.android.api.model.PurchaseUnit
 import com.paypal.android.api.services.PayPalDemoApi
 import com.paypal.android.card.ApproveOrderListener
 import com.paypal.android.card.Card


### PR DESCRIPTION
### Summary of changes

 - `confirm-payment-source` endpoint now supports `return_url` and `cancel_url` parameters
 - This PR removes 3DS from order creation and forwards those values from within the SDK

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
