### PR TITLE
Create CoreCoroutineExceptionHandler

### DIFF
--- a/Card/src/main/java/com/paypal/android/card/CardClient.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardClient.kt
@@ -11,9 +11,8 @@ import com.paypal.android.card.api.GetOrderRequest
 import com.paypal.android.card.model.CardResult
 import com.paypal.android.core.API
 import com.paypal.android.core.CoreConfig
-import com.paypal.android.core.PayPalSDKError
+import com.paypal.android.core.CoreCoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -32,17 +31,9 @@ class CardClient internal constructor(
 
     private val lifeCycleObserver = CardLifeCycleObserver(this)
 
-    private val exceptionHandler = CoroutineExceptionHandler { _, exception ->
-        val error = when(exception) {
-            is PayPalSDKError -> exception
-            else -> {
-                val message = exception.localizedMessage?: "Something went wrong"
-                PayPalSDKError(0, message)
-            }
-        }
-        approveOrderListener?.onApproveOrderFailure(error)
+    private val exceptionHandler = CoreCoroutineExceptionHandler {
+        approveOrderListener?.onApproveOrderFailure(it)
     }
-
     /**
      *  CardClient constructor
      *

--- a/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
@@ -206,7 +206,7 @@ class CardClientUnitTest {
             every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
 
             val error = PayPalSDKError(0, "mock_error_message")
-            coEvery { cardAPI.getOrderInfo(any()) } throws  error
+            coEvery { cardAPI.getOrderInfo(any()) } throws error
 
             sut.handleBrowserSwitchResult(activity)
             advanceUntilIdle()

--- a/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
@@ -196,6 +196,28 @@ class CardClientUnitTest {
         verify(exactly = 1) { approveOrderListener.onApproveOrderCanceled() }
     }
 
+    @Test
+    fun `handle browser switch result notifies listener of get order failure`() =
+        runTest {
+            val sut = createCardClient(testScheduler)
+
+            val browserSwitchResult =
+                createBrowserSwitchResult(BrowserSwitchStatus.SUCCESS, approveOrderMetadata)
+            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+            val error = PayPalSDKError(0, "mock_error_message")
+            coEvery { cardAPI.getOrderInfo(any()) } throws  error
+
+            sut.handleBrowserSwitchResult(activity)
+            advanceUntilIdle()
+
+            val errorSlot = slot<PayPalSDKError>()
+            verify(exactly = 1) { approveOrderListener.onApproveOrderFailure(capture(errorSlot)) }
+
+            val capturedError = errorSlot.captured
+            assertEquals("mock_error_message", capturedError.errorDescription)
+        }
+
     private fun createCardClient(testScheduler: TestCoroutineScheduler): CardClient {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val sut = CardClient(activity, cardAPI, browserSwitchClient, dispatcher)

--- a/Core/src/main/java/com/paypal/android/core/CoreCoroutineExceptionHandler.kt
+++ b/Core/src/main/java/com/paypal/android/core/CoreCoroutineExceptionHandler.kt
@@ -1,0 +1,20 @@
+package com.paypal.android.core
+
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+class CoreCoroutineExceptionHandler(private val handler: (PayPalSDKError) -> Unit) :
+    AbstractCoroutineContextElement(CoroutineExceptionHandler), CoroutineExceptionHandler {
+
+    override fun handleException(context: CoroutineContext, exception: Throwable) {
+        val error = when (exception) {
+            is PayPalSDKError -> exception
+            else -> {
+                val message = exception.localizedMessage ?: "Something went wrong"
+                PayPalSDKError(0, message)
+            }
+        }
+        handler(error)
+    }
+}


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 -  This PR creates a CoreCoroutineExceptionHandler that works as a last-resort mechanism for global "catch all" behavior. Essentially, within a corotuine scope that isnt handled, will end up on the CoreCoroutineExceptionHandler, transforming that error into a PayPalSDKError

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
