### PR TITLE
Release script: Publish modules in the same job

### DIFF
--- a/.github/actions/publish_all_modules/action.yml
+++ b/.github/actions/publish_all_modules/action.yml
@@ -31,6 +31,7 @@ runs:
         :PayPalWebCheckout:publishReleasePublicationToMavenRepository \
         :PayPalNativeCheckout:publishReleasePublicationToMavenRepository \
         :PayPalDataCollector:publishReleasePublicationToMavenRepository \
+        :PayPalUI:publishReleasePublicationToMavenRepository
       shell: bash
       env:
         SONATYPE_NEXUS_USERNAME: ${{ inputs.sonatype_usr }}

--- a/.github/actions/publish_all_modules/action.yml
+++ b/.github/actions/publish_all_modules/action.yml
@@ -1,9 +1,6 @@
-description: 'Publishes module'
+name: 'Publish All Modules'
+description: 'Publishes all modules'
 inputs:
-  module:
-    description: 'Module'
-    required: true
-    default: ''
   sonatype_usr:
     description: 'Sonatype user'
     required: true
@@ -27,7 +24,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ./gradlew --stacktrace clean :${{ inputs.module }}:publishReleasePublicationToMavenRepository
+    - run: |
+        ./gradlew --stacktrace clean \
+        :Core:publishReleasePublicationToMavenRepository \
+        :Card:publishReleasePublicationToMavenRepository \
+        :PayPalWebCheckout:publishReleasePublicationToMavenRepository \
+        :PayPalNativeCheckout:publishReleasePublicationToMavenRepository \
+        :PayPalDataCollector:publishReleasePublicationToMavenRepository \
       shell: bash
       env:
         SONATYPE_NEXUS_USERNAME: ${{ inputs.sonatype_usr }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
 
   #Once building is finished, we unit test every module in parallel
   unit_test_core:
-    needs: build_aar
     name: Core Unit Tests
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +51,6 @@ jobs:
           module: Card
 
   unit_test_card:
-    needs: build_aar
     name: Card Unit Tests
     runs-on: ubuntu-latest
     steps:
@@ -68,7 +66,6 @@ jobs:
         with:
           module: Card
   unit_test_paypal:
-    needs: build_aar
     name: PayPal Web Unit Tests
     runs-on: ubuntu-latest
     steps:
@@ -84,7 +81,6 @@ jobs:
         with:
           module: PayPalWebCheckout
   unit_test_paypal_native:
-    needs: build_aar
     name: PayPal Native Unit Tests
     runs-on: ubuntu-latest
     steps:
@@ -110,7 +106,7 @@ jobs:
   # after build and unit tests are finished, publish all modules at once
   # to help reduce the probability of failure when interacting with sonatype servers
   publish_all_modules:
-    needs: [ unit_test_finished ]
+    needs: [ unit_test_finished, build_aar ]
     name: Publish All Modules To Sonatype
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,10 +107,11 @@ jobs:
     steps:
       - run: echo "Unit test finished"
 
-  #Once the version is updated, we publish all modules in parallel
-  publish_core:
+  # after build and unit tests are finished, publish all modules at once
+  # to help reduce the probability of failure when interacting with sonatype servers
+  publish_all_modules:
     needs: [ unit_test_finished ]
-    name: Publish Core
+    name: Publish All Modules To Sonatype
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -125,174 +126,21 @@ jobs:
         with:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
-      - name: Change Version
+      - name: Update Version
         run: |
           ./gradlew -PversionParam=${{ github.event.inputs.version }} changeReleaseVersion
-      - name: Publish Core
-        uses: ./.github/actions/publish_module
+      - name: Publish All Modules
+        uses: ./.github/actions/publish_all_modules
         with:
-          module: Core
           sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           sonatype_pwd: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           signing_key_id: ${{ secrets.SIGNING_KEY_ID }}
           signing_key_pwd: ${{ secrets.SIGNING_KEY_PASSWORD }}
           signing_key_file: ${{ env.SIGNING_KEY_FILE_PATH }}
-  publish_card:
-    needs: [ unit_test_finished ]
-    name: Publish Card
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'microsoft'
-      - name: Decode Signing Key
-        uses: ./.github/actions/decode_signing_key_action
-        with:
-          signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
-          signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
-      - name: Change Version
-        run: |
-          ./gradlew -PversionParam=${{ github.event.inputs.version }} changeReleaseVersion
-      - name: Publish Card
-        uses: ./.github/actions/publish_module
-        with:
-          module: Card
-          sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          sonatype_pwd: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          signing_key_id: ${{ secrets.SIGNING_KEY_ID }}
-          signing_key_pwd: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          signing_key_file: ${{ env.SIGNING_KEY_FILE_PATH }}
-  publish_web_checkout:
-    needs: [ unit_test_finished ]
-    name: Publish PayPal Checkout Web
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'microsoft'
-      - name: Decode Signing Key
-        uses: ./.github/actions/decode_signing_key_action
-        with:
-          signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
-          signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
-      - name: Change Version
-        run: |
-          ./gradlew -PversionParam=${{ github.event.inputs.version }} changeReleaseVersion
-      - name: Publish Checkout Web
-        uses: ./.github/actions/publish_module
-        with:
-          module: PayPalWebCheckout
-          sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          sonatype_pwd: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          signing_key_id: ${{ secrets.SIGNING_KEY_ID }}
-          signing_key_pwd: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          signing_key_file: ${{ env.SIGNING_KEY_FILE_PATH }}
-  publish_native_checkout:
-    needs: [ unit_test_finished ]
-    name: Publish PayPal Native Checkout
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'microsoft'
-      - name: Decode Signing Key
-        uses: ./.github/actions/decode_signing_key_action
-        with:
-          signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
-          signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
-      - name: Change Version
-        run: |
-          ./gradlew -PversionParam=${{ github.event.inputs.version }} changeReleaseVersion
-      - name: Publish Native Checkout
-        uses: ./.github/actions/publish_module
-        with:
-          module: PayPalNativeCheckout
-          sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          sonatype_pwd: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          signing_key_id: ${{ secrets.SIGNING_KEY_ID }}
-          signing_key_pwd: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          signing_key_file: ${{ env.SIGNING_KEY_FILE_PATH }}
-  publish_data_collector:
-    needs: [ unit_test_finished ]
-    name: Publish PayPal DataCollector
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'microsoft'
-      - name: Decode Signing Key
-        uses: ./.github/actions/decode_signing_key_action
-        with:
-          signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
-          signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
-      - name: Change Version
-        run: |
-          ./gradlew -PversionParam=${{ github.event.inputs.version }} changeReleaseVersion
-      - name: Publish PayPal DataCollector
-        uses: ./.github/actions/publish_module
-        with:
-          module: PayPalDataCollector
-          sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          sonatype_pwd: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          signing_key_id: ${{ secrets.SIGNING_KEY_ID }}
-          signing_key_pwd: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          signing_key_file: ${{ env.SIGNING_KEY_FILE_PATH }}
-  publish_ui:
-    needs: [ unit_test_finished ]
-    name: Publish PayPal UI
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'microsoft'
-      - name: Decode Signing Key
-        uses: ./.github/actions/decode_signing_key_action
-        with:
-          signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
-          signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
-      - name: Change Version
-        run: |
-          ./gradlew -PversionParam=${{ github.event.inputs.version }} changeReleaseVersion
-      - name: Publish PayPal UI
-        uses: ./.github/actions/publish_module
-        with:
-          module: PayPalUI
-          sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          sonatype_pwd: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          signing_key_id: ${{ secrets.SIGNING_KEY_ID }}
-          signing_key_pwd: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          signing_key_file: ${{ env.SIGNING_KEY_FILE_PATH }}
-
-  releasing_finished:
-    needs: [ publish_web_checkout, publish_card, publish_core, publish_data_collector, publish_ui, publish_native_checkout ]
-    name: Releases Finished
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Release finished"
 
   # Once all releases are done, we bump version, tag it and prepare next
   bump_version:
-    needs: [ releasing_finished ]
+    needs: [ publish_all_modules ]
     name: Bump Version
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release_snapshot.yml
+++ b/.github/workflows/release_snapshot.yml
@@ -27,7 +27,7 @@ jobs:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
       - name: Release Core Snapshot
-        uses: ./.github/actions/publish_module
+        uses: ./.github/actions/publish_all_modules
         with:
           module: Core
           sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
@@ -52,7 +52,7 @@ jobs:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
       - name: Release Card Snapshot
-        uses: ./.github/actions/publish_module
+        uses: ./.github/actions/publish_all_modules
         with:
           module: Card
           sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
@@ -77,7 +77,7 @@ jobs:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
       - name: Release Checkout Snapshot
-        uses: ./.github/actions/publish_module
+        uses: ./.github/actions/publish_all_modules
         with:
           module: PayPalWebCheckout
           sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
@@ -102,7 +102,7 @@ jobs:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
       - name: Release Native Checkout Snapshot
-        uses: ./.github/actions/publish_module
+        uses: ./.github/actions/publish_all_modules
         with:
           module: PayPalNativeCheckout
           sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
@@ -127,7 +127,7 @@ jobs:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
       - name: Publish PayPal DataCollector
-        uses: ./.github/actions/publish_module
+        uses: ./.github/actions/publish_all_modules
         with:
           module: PayPalDataCollector
           sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
@@ -153,7 +153,7 @@ jobs:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
       - name: Publish PayPal UI
-        uses: ./.github/actions/publish_module
+        uses: ./.github/actions/publish_all_modules
         with:
           module: PayPalUI
           sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}

--- a/.github/workflows/release_snapshot.yml
+++ b/.github/workflows/release_snapshot.yml
@@ -10,8 +10,9 @@ on:
 env:
   SIGNING_KEY_FILE_PATH: /home/runner/secretKey.gpg
 jobs:
-  release_core:
-    name: Release Core Snapshot
+  #First we build
+  build_aar:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -21,22 +22,22 @@ jobs:
         with:
           java-version: '11'
           distribution: 'microsoft'
+          #After decoding the secret key, place the file in ~ /. Gradle/ secring.gpg
       - name: Decode Signing Key
         uses: ./.github/actions/decode_signing_key_action
         with:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
-      - name: Release Core Snapshot
-        uses: ./.github/actions/publish_all_modules
-        with:
-          module: Core
-          sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          sonatype_pwd: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          signing_key_id: ${{ secrets.SIGNING_KEY_ID }}
-          signing_key_pwd: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          signing_key_file: ${{ env.SIGNING_KEY_FILE_PATH }}
-  release_card:
-    name: Release Card Snapshot
+      - name: Assemble
+        run: ./gradlew --stacktrace assemble
+        env:
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+          SIGNING_KEY_FILE: ${{ env.SIGNING_KEY_FILE_PATH }}
+
+  #Once building is finished, we unit test every module in parallel
+  unit_test_core:
+    name: Core Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -46,22 +47,13 @@ jobs:
         with:
           java-version: '11'
           distribution: 'microsoft'
-      - name: Decode Signing Key
-        uses: ./.github/actions/decode_signing_key_action
-        with:
-          signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
-          signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
-      - name: Release Card Snapshot
-        uses: ./.github/actions/publish_all_modules
+      - name: Run Unit Tests
+        uses: ./.github/actions/unit_test_module
         with:
           module: Card
-          sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          sonatype_pwd: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          signing_key_id: ${{ secrets.SIGNING_KEY_ID }}
-          signing_key_pwd: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          signing_key_file: ${{ env.SIGNING_KEY_FILE_PATH }}
-  release_checkout_web:
-    name: Release PayPal Web Checkout Snapshshot
+
+  unit_test_card:
+    name: Card Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -71,22 +63,27 @@ jobs:
         with:
           java-version: '11'
           distribution: 'microsoft'
-      - name: Decode Signing Key
-        uses: ./.github/actions/decode_signing_key_action
+      - name: Run Unit Tests
+        uses: ./.github/actions/unit_test_module
         with:
-          signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
-          signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
-      - name: Release Checkout Snapshot
-        uses: ./.github/actions/publish_all_modules
+          module: Card
+  unit_test_paypal:
+    name: PayPal Web Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'microsoft'
+      - name: Run Unit Tests
+        uses: ./.github/actions/unit_test_module
         with:
           module: PayPalWebCheckout
-          sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          sonatype_pwd: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          signing_key_id: ${{ secrets.SIGNING_KEY_ID }}
-          signing_key_pwd: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          signing_key_file: ${{ env.SIGNING_KEY_FILE_PATH }}
-  release_checkout_native:
-    name: Release PayPal Native Checkout Snapshshot
+  unit_test_paypal_native:
+    name: PayPal Native Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -96,48 +93,23 @@ jobs:
         with:
           java-version: '11'
           distribution: 'microsoft'
-      - name: Decode Signing Key
-        uses: ./.github/actions/decode_signing_key_action
-        with:
-          signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
-          signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
-      - name: Release Native Checkout Snapshot
-        uses: ./.github/actions/publish_all_modules
+      - name: Run Unit Tests
+        uses: ./.github/actions/unit_test_module
         with:
           module: PayPalNativeCheckout
-          sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          sonatype_pwd: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          signing_key_id: ${{ secrets.SIGNING_KEY_ID }}
-          signing_key_pwd: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          signing_key_file: ${{ env.SIGNING_KEY_FILE_PATH }}
-  release_data_collector:
-    name: Release PayPal DataCollector Snapshot
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'microsoft'
-      - name: Decode Signing Key
-        uses: ./.github/actions/decode_signing_key_action
-        with:
-          signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
-          signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
-      - name: Publish PayPal DataCollector
-        uses: ./.github/actions/publish_all_modules
-        with:
-          module: PayPalDataCollector
-          sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          sonatype_pwd: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          signing_key_id: ${{ secrets.SIGNING_KEY_ID }}
-          signing_key_pwd: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          signing_key_file: ${{ env.SIGNING_KEY_FILE_PATH }}
 
-  release_ui:
-    name: Release PayPal UI Snapshot
+  unit_test_finished:
+    needs: [unit_test_card, unit_test_core, unit_test_paypal, unit_test_paypal_native]
+    name: All Unit Test finished
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Unit test finished"
+
+  # after build and unit tests are finished, publish all modules at once
+  # to help reduce the probability of failure when interacting with sonatype servers
+  publish_all_modules:
+    needs: [ unit_test_finished, build_aar ]
+    name: Publish All Modules To Sonatype
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -152,10 +124,9 @@ jobs:
         with:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
-      - name: Publish PayPal UI
+      - name: Publish All Modules
         uses: ./.github/actions/publish_all_modules
         with:
-          module: PayPalUI
           sonatype_usr: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           sonatype_pwd: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           signing_key_id: ${{ secrets.SIGNING_KEY_ID }}


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 -  Publishing each module in a diferent job would cause problems with Sonatype, sometimes spliting modules in diferent staging repos. This publishes each module in sequence to avoid that

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 
