### PR TITLE
Card: Remove ThreeDSecureRequest and only ask for return_url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
       - name: Assemble
-        run: ./gradlew clean assemble -x :Demo:assemble
+        run: ./gradlew --stacktrace assemble -x :Demo:assemble # we exclude Demo module in assemble
         env:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
       - name: Assemble
-        run: ./gradlew --stacktrace assembleDebug
+        run: ./gradlew clean assemble -x :Demo:assemble
         env:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
       - name: Assemble
-        run: ./gradlew --stacktrace assemble
+        run: ./gradlew --stacktrace assembleDebug
         env:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           ref: main
       - name: Assemble Release AAR on Main Branch
-        run: ./gradlew clean assemble -x :Demo:assemble # we exclude Demo module in assemble
+        run: ./gradlew clean assembleRelease -x :Demo:assembleRelease # we exclude Demo module in assemble
       - name: Upload Main Branch Artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -64,8 +64,8 @@ jobs:
       # Assemble artifacts from current branch
       - name: Checkout Current Branch
         uses: actions/checkout@v2
-      - name: Assemble release AAR on Current Branch
-        run: ./gradlew clean assemble -x :Demo:assemble # we exclude Demo module in assemble
+      - name: Assemble Release AAR on Current Branch
+        run: ./gradlew clean assembleRelease -x :Demo:assembleRelease # we exclude Demo module in assemble
       - name: Upload Current Branch Artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -48,30 +48,34 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: main
-      - name: Assemble Release AAR on Main Branch
-        run: ./gradlew clean assembleRelease
+      - name: Assemble Debug AAR on Main Branch
+        run: ./gradlew clean assembleDebug
       - name: Upload Main Branch Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: main-aar
           path: |
-            Core/build/outputs/aar/Core-release.aar
-            Card/build/outputs/aar/Card-release.aar
-            PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-release.aar
+            Core/build/outputs/aar/Core-debug.aar
+            Card/build/outputs/aar/Card-debug.aar
+            PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-debug.aar
+            PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-debug.aar
+            PayPalUI/build/outputs/aar/PayPalUI-debug.aar
 
       # Assemble artifacts from current branch
       - name: Checkout Current Branch
         uses: actions/checkout@v2
-      - name: Assemble Release AAR on Current Branch
-        run: ./gradlew clean assembleRelease
+      - name: Assemble Debug AAR on Current Branch
+        run: ./gradlew clean assembleDebug
       - name: Upload Current Branch Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: current-aar
           path: |
-            Core/build/outputs/aar/Core-release.aar
-            Card/build/outputs/aar/Card-release.aar
-            PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-release.aar
+            Core/build/outputs/aar/Core-debug.aar
+            Card/build/outputs/aar/Card-debug.aar
+            PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-debug.aar
+            PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-debug.aar
+            PayPalUI/build/outputs/aar/PayPalUI-debug.aar
 
       # Set up Diffuse
       - name: Install Diffuse
@@ -86,8 +90,12 @@ jobs:
 
       # Run Diffuse analysis
       - name: Run Diffuse Analysis - Card
-        run: diffuse diff --aar main-aar/Card/build/outputs/aar/Card-release.aar current-aar/Card/build/outputs/aar/Card-release.aar
+        run: diffuse diff --aar main-aar/Card/build/outputs/aar/Card-debug.aar current-aar/Card/build/outputs/aar/Card-debug.aar
       - name: Run Diffuse Analysis - Core
-        run: diffuse diff --aar main-aar/Core/build/outputs/aar/Core-release.aar current-aar/Core/build/outputs/aar/Core-release.aar
-      - name: Run Diffuse Analysis - PayPal
-        run: diffuse diff --aar main-aar/PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-release.aar current-aar/PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-release.aar
+        run: diffuse diff --aar main-aar/Core/build/outputs/aar/Core-debug.aar current-aar/Core/build/outputs/aar/Core-debug.aar
+      - name: Run Diffuse Analysis - PayPalWebCheckout
+        run: diffuse diff --aar main-aar/PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-debug.aar current-aar/PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-debug.aar
+      - name: Run Diffuse Analysis - PayPalNativeCheckout
+        run: diffuse diff --aar main-aar/PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-debug.aar current-aar/PayPalNativeCheckout/build/outputs/aar/PayPalWebCheckout-debug.aar
+      - name: Run Diffuse Analysis - PayPalUI
+        run: diffuse diff --aar main-aar/PayPalUI/build/outputs/aar/PayPalUI-debug.aar current-aar/PayPalUI/build/outputs/aar/PayPalUI-debug.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -48,34 +48,34 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: main
-      - name: Assemble Debug AAR on Main Branch
-        run: ./gradlew clean assembleDebug
+      - name: Assemble Release AAR on Main Branch
+        run: ./gradlew clean assemble -x :Demo:assemble # we exclude Demo module in assemble
       - name: Upload Main Branch Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: main-aar
           path: |
-            Core/build/outputs/aar/Core-debug.aar
-            Card/build/outputs/aar/Card-debug.aar
-            PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-debug.aar
-            PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-debug.aar
-            PayPalUI/build/outputs/aar/PayPalUI-debug.aar
+            Core/build/outputs/aar/Core-release.aar
+            Card/build/outputs/aar/Card-release.aar
+            PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-release.aar
+            PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-release.aar
+            PayPalUI/build/outputs/aar/PayPalUI-release.aar
 
       # Assemble artifacts from current branch
       - name: Checkout Current Branch
         uses: actions/checkout@v2
-      - name: Assemble Debug AAR on Current Branch
-        run: ./gradlew clean assembleDebug
+      - name: Assemble release AAR on Current Branch
+        run: ./gradlew clean assemble -x :Demo:assemble # we exclude Demo module in assemble
       - name: Upload Current Branch Artifacts
         uses: actions/upload-artifact@v2
         with:
           name: current-aar
           path: |
-            Core/build/outputs/aar/Core-debug.aar
-            Card/build/outputs/aar/Card-debug.aar
-            PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-debug.aar
-            PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-debug.aar
-            PayPalUI/build/outputs/aar/PayPalUI-debug.aar
+            Core/build/outputs/aar/Core-release.aar
+            Card/build/outputs/aar/Card-release.aar
+            PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-release.aar
+            PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-release.aar
+            PayPalUI/build/outputs/aar/PayPalUI-release.aar
 
       # Set up Diffuse
       - name: Install Diffuse
@@ -90,12 +90,12 @@ jobs:
 
       # Run Diffuse analysis
       - name: Run Diffuse Analysis - Card
-        run: diffuse diff --aar main-aar/Card/build/outputs/aar/Card-debug.aar current-aar/Card/build/outputs/aar/Card-debug.aar
+        run: diffuse diff --aar main-aar/Card/build/outputs/aar/Card-release.aar current-aar/Card/build/outputs/aar/Card-release.aar
       - name: Run Diffuse Analysis - Core
-        run: diffuse diff --aar main-aar/Core/build/outputs/aar/Core-debug.aar current-aar/Core/build/outputs/aar/Core-debug.aar
+        run: diffuse diff --aar main-aar/Core/build/outputs/aar/Core-release.aar current-aar/Core/build/outputs/aar/Core-release.aar
       - name: Run Diffuse Analysis - PayPalWebCheckout
-        run: diffuse diff --aar main-aar/PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-debug.aar current-aar/PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-debug.aar
+        run: diffuse diff --aar main-aar/PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-release.aar current-aar/PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-release.aar
       - name: Run Diffuse Analysis - PayPalNativeCheckout
-        run: diffuse diff --aar main-aar/PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-debug.aar current-aar/PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-debug.aar
+        run: diffuse diff --aar main-aar/PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-release.aar current-aar/PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-release.aar
       - name: Run Diffuse Analysis - PayPalUI
-        run: diffuse diff --aar main-aar/PayPalUI/build/outputs/aar/PayPalUI-debug.aar current-aar/PayPalUI/build/outputs/aar/PayPalUI-debug.aar
+        run: diffuse diff --aar main-aar/PayPalUI/build/outputs/aar/PayPalUI-release.aar current-aar/PayPalUI/build/outputs/aar/PayPalUI-release.aar

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -96,6 +96,6 @@ jobs:
       - name: Run Diffuse Analysis - PayPalWebCheckout
         run: diffuse diff --aar main-aar/PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-debug.aar current-aar/PayPalWebCheckout/build/outputs/aar/PayPalWebCheckout-debug.aar
       - name: Run Diffuse Analysis - PayPalNativeCheckout
-        run: diffuse diff --aar main-aar/PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-debug.aar current-aar/PayPalNativeCheckout/build/outputs/aar/PayPalWebCheckout-debug.aar
+        run: diffuse diff --aar main-aar/PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-debug.aar current-aar/PayPalNativeCheckout/build/outputs/aar/PayPalNativeCheckout-debug.aar
       - name: Run Diffuse Analysis - PayPalUI
         run: diffuse diff --aar main-aar/PayPalUI/build/outputs/aar/PayPalUI-debug.aar current-aar/PayPalUI/build/outputs/aar/PayPalUI-debug.aar

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,4 +16,4 @@ jobs:
           java-version: '11'
           distribution: 'microsoft'
       - name: Run Unit Tests
-        run: ./gradlew --stacktrace testRelease
+        run: ./gradlew --stacktrace testDebug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## unreleased
 * `Card`:
-  * Update `CardRequest` to require `ThreeDSecureRequest `
+  * Remove `ThreeDSecureRequest` from `CardRequest`
+  * Update `CardRequest` to pass `return_url` and an optional `sca`
 * `PayPalUI`:
   * Fix: remove loading spinner on buttons.
 

--- a/Card/src/main/java/com/paypal/android/card/CardClient.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardClient.kt
@@ -75,7 +75,7 @@ class CardClient internal constructor(
             approveOrderListener?.onApproveOrderThreeDSecureWillLaunch()
 
             // launch the 3DS flow
-            val urlScheme = cardRequest.threeDSecureRequest.run { Uri.parse(returnUrl).scheme }
+            val urlScheme = cardRequest.run { Uri.parse(returnUrl).scheme }
             val approveOrderMetadata =
                 ApproveOrderMetadata(cardRequest.orderID, response.paymentSource)
             val options = BrowserSwitchOptions()

--- a/Card/src/main/java/com/paypal/android/card/CardRequest.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardRequest.kt
@@ -1,9 +1,17 @@
 package com.paypal.android.card
 
-import com.paypal.android.card.threedsecure.ThreeDSecureRequest
+import com.paypal.android.card.threedsecure.SCA
 
-data class CardRequest(
+/**
+ * A card request to process a card payment
+ * @property orderID The order ID to to process the payment
+ * @property card   Card used for payment
+ * @property returnUrl Url to return to app after SCA challenge finishes
+ * @property sca Specify to always launch 3DS or only when required. Defaults to `SCA.SCA_WHEN_REQUIRED`.
+ */
+data class CardRequest @JvmOverloads constructor(
     val orderID: String,
     val card: Card,
-    var threeDSecureRequest: ThreeDSecureRequest
+    val returnUrl: String,
+    val sca: SCA = SCA.SCA_WHEN_REQUIRED
 )

--- a/Card/src/main/java/com/paypal/android/card/CardRequestFactory.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardRequestFactory.kt
@@ -31,18 +31,16 @@ internal class CardRequestFactory {
             }
 
             val bodyJSON = JSONObject()
-            threeDSecureRequest.let {
-                val verificationJSON = JSONObject()
-                    .put("method", it.sca.name)
-                val attributesJSON = JSONObject()
-                    .put("verification", verificationJSON)
-                cardJSON.put("attributes", attributesJSON)
+            val verificationJSON = JSONObject()
+                .put("method", sca.name)
+            val attributesJSON = JSONObject()
+                .put("verification", verificationJSON)
+            cardJSON.put("attributes", attributesJSON)
 
-                val returnURLJSON = JSONObject()
-                    .put("return_url", it.returnUrl)
-                    .put("cancel_url", it.cancelUrl)
-                bodyJSON.put("application_context", returnURLJSON)
-            }
+            val returnURLJSON = JSONObject()
+                .put("return_url", returnUrl)
+                .put("cancel_url", returnUrl) //we can set the same url
+            bodyJSON.put("application_context", returnURLJSON)
 
             val paymentSourceJSON = JSONObject().put("card", cardJSON)
             bodyJSON.put("payment_source", paymentSourceJSON)

--- a/Card/src/main/java/com/paypal/android/card/CardRequestFactory.kt
+++ b/Card/src/main/java/com/paypal/android/card/CardRequestFactory.kt
@@ -39,7 +39,7 @@ internal class CardRequestFactory {
 
             val returnURLJSON = JSONObject()
                 .put("return_url", returnUrl)
-                .put("cancel_url", returnUrl) //we can set the same url
+                .put("cancel_url", returnUrl) // we can set the same url
             bodyJSON.put("application_context", returnURLJSON)
 
             val paymentSourceJSON = JSONObject().put("card", cardJSON)

--- a/Card/src/main/java/com/paypal/android/card/threedsecure/ThreeDSecureRequest.kt
+++ b/Card/src/main/java/com/paypal/android/card/threedsecure/ThreeDSecureRequest.kt
@@ -1,7 +1,0 @@
-package com.paypal.android.card.threedsecure
-
-data class ThreeDSecureRequest @JvmOverloads constructor(
-    val sca: SCA = SCA.SCA_WHEN_REQUIRED,
-    val returnUrl: String,
-    val cancelUrl: String
-)

--- a/Card/src/test/java/com/paypal/android/card/CardAPIUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardAPIUnitTest.kt
@@ -12,12 +12,8 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.runTest
 import org.json.JSONException
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -80,7 +76,7 @@ class CardAPIUnitTest {
     private val correlationId = "expected correlation ID"
     private val headers = mapOf("Paypal-Debug-Id" to correlationId)
 
-    private val testCoroutineDispatcher = TestCoroutineDispatcher()
+    //private val testCoroutineDispatcher = StandardTestDispatcher()
 
     private val cardRequest = CardRequest(
         orderID,
@@ -95,17 +91,16 @@ class CardAPIUnitTest {
         sut = CardAPI(api, requestFactory)
         every { requestFactory.createConfirmPaymentSourceRequest(cardRequest) } returns apiRequest
 
-        Dispatchers.setMain(testCoroutineDispatcher)
+       // Dispatchers.setMain(testCoroutineDispatcher)
     }
 
     @After
     fun afterEach() {
-        Dispatchers.resetMain()
-        testCoroutineDispatcher.cleanupTestCoroutines()
+        //Dispatchers.resetMain()
     }
 
     @Test
-    fun `it sends a confirm payment source api request`() = runBlockingTest {
+    fun `it sends a confirm payment source api request`() = runTest {
         val httpResponse = HttpResponse(200, emptyMap(), successBody)
         coEvery { api.send(apiRequest) } returns httpResponse
 
@@ -114,7 +109,7 @@ class CardAPIUnitTest {
     }
 
     @Test
-    fun `it returns a confirm payment source result`() = runBlockingTest {
+    fun `it returns a confirm payment source result`() = runTest {
         val httpResponse = HttpResponse(200, headers, successBody)
         coEvery { api.send(apiRequest) } returns httpResponse
 
@@ -125,7 +120,7 @@ class CardAPIUnitTest {
     }
 
     @Test
-    fun `it returns an error when the order is not found`() = runBlockingTest {
+    fun `it returns an error when the order is not found`() = runTest {
         val httpResponse = HttpResponse(404, headers, errorBody)
         coEvery { api.send(apiRequest) } returns httpResponse
 
@@ -145,7 +140,7 @@ class CardAPIUnitTest {
 
     @Test
     fun `it returns unknownError when the order api call returns an error body`() =
-        runBlockingTest {
+        runTest {
             // Status: STATUS_UNDETERMINED
             val httpResponse = HttpResponse(-1, headers, errorBody)
             coEvery { api.send(apiRequest) } returns httpResponse
@@ -165,7 +160,7 @@ class CardAPIUnitTest {
 
     @Test
     fun `it returns noResponseData when the order api call returns an empty body`() =
-        runBlockingTest {
+        runTest {
             // Status: ANY
             val httpResponse = HttpResponse(-10, headers, emptyErrorBody)
             coEvery { api.send(apiRequest) } returns httpResponse
@@ -185,7 +180,7 @@ class CardAPIUnitTest {
 
     @Test
     fun `it returns dataParsingError when the order api call returns an error body`() =
-        runBlockingTest {
+        runTest {
             // Status: OK
             val httpResponse = HttpResponse(200, headers, errorBody)
             val parsingException = JSONException("Parsing Error")
@@ -206,7 +201,7 @@ class CardAPIUnitTest {
         }
 
     @Test
-    fun `it returns unknownHost when the order api call returns an error body`() = runBlockingTest {
+    fun `it returns unknownHost when the order api call returns an error body`() = runTest {
         // Status: STATUS_UNKNOWN_HOST
         val httpResponse = HttpResponse(-2, headers, errorBody)
         coEvery { api.send(apiRequest) } returns httpResponse
@@ -225,7 +220,7 @@ class CardAPIUnitTest {
     }
 
     @Test
-    fun `it returns serverError when the order api call returns an error body`() = runBlockingTest {
+    fun `it returns serverError when the order api call returns an error body`() = runTest {
         // Status: SERVER_ERROR
         val httpResponse = HttpResponse(-3, headers, errorBody)
         coEvery { api.send(apiRequest) } returns httpResponse
@@ -245,7 +240,7 @@ class CardAPIUnitTest {
 
     @Test
     fun `when confirmPaymentSource fails to parse response, correlation ID is set in Error`() =
-        runBlockingTest {
+        runTest {
             coEvery { api.send(apiRequest) } returns HttpResponse(200, headers, unexpectedBody)
 
             lateinit var capturedError: PayPalSDKError
@@ -258,7 +253,7 @@ class CardAPIUnitTest {
         }
 
     @Test
-    fun `when confirmPaymentSource is errors, correlation ID is set in Error`() = runBlockingTest {
+    fun `when confirmPaymentSource is errors, correlation ID is set in Error`() = runTest {
         coEvery { api.send(apiRequest) } returns HttpResponse(400, headers, errorBody)
 
         lateinit var capturedError: PayPalSDKError

--- a/Card/src/test/java/com/paypal/android/card/CardAPIUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardAPIUnitTest.kt
@@ -15,7 +15,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.json.JSONException
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -75,8 +74,6 @@ class CardAPIUnitTest {
 
     private val correlationId = "expected correlation ID"
     private val headers = mapOf("Paypal-Debug-Id" to correlationId)
-
-    //private val testCoroutineDispatcher = StandardTestDispatcher()
 
     private val cardRequest = CardRequest(
         orderID,

--- a/Card/src/test/java/com/paypal/android/card/CardAPIUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardAPIUnitTest.kt
@@ -90,13 +90,6 @@ class CardAPIUnitTest {
     fun beforeEach() {
         sut = CardAPI(api, requestFactory)
         every { requestFactory.createConfirmPaymentSourceRequest(cardRequest) } returns apiRequest
-
-       // Dispatchers.setMain(testCoroutineDispatcher)
-    }
-
-    @After
-    fun afterEach() {
-        //Dispatchers.resetMain()
     }
 
     @Test

--- a/Card/src/test/java/com/paypal/android/card/CardAPIUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardAPIUnitTest.kt
@@ -1,7 +1,6 @@
 package com.paypal.android.card
 
 import com.paypal.android.card.api.CardAPI
-import com.paypal.android.card.threedsecure.ThreeDSecureRequest
 import com.paypal.android.core.API
 import com.paypal.android.core.APIRequest
 import com.paypal.android.core.HttpMethod
@@ -86,7 +85,7 @@ class CardAPIUnitTest {
     private val cardRequest = CardRequest(
         orderID,
         card,
-        ThreeDSecureRequest(returnUrl = "return_url", cancelUrl = "cancel_url")
+       "return_url"
     )
 
     private lateinit var sut: CardAPI

--- a/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardClientUnitTest.kt
@@ -13,7 +13,6 @@ import com.paypal.android.card.api.GetOrderInfoResponse
 import com.paypal.android.card.api.GetOrderRequest
 import com.paypal.android.card.model.CardResult
 import com.paypal.android.card.model.PaymentSource
-import com.paypal.android.card.threedsecure.ThreeDSecureRequest
 import com.paypal.android.core.OrderStatus
 import com.paypal.android.core.PayPalSDKError
 import io.mockk.coEvery
@@ -45,9 +44,8 @@ class CardClientUnitTest {
 
     private val card = Card("4111111111111111", "01", "24")
     private val orderID = "sample-order-id"
-    private val threeDSecureRequest = ThreeDSecureRequest(returnUrl = "return_url", cancelUrl = "cancel_url")
 
-    private val cardRequest = CardRequest(orderID, card, threeDSecureRequest)
+    private val cardRequest = CardRequest(orderID, card, "return_url")
 
     private val cardAPI = mockk<CardAPI>(relaxed = true)
     private val confirmPaymentSourceResponse =

--- a/Card/src/test/java/com/paypal/android/card/CardRequestFactoryUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardRequestFactoryUnitTest.kt
@@ -1,7 +1,6 @@
 package com.paypal.android.card
 
 import com.paypal.android.card.threedsecure.SCA
-import com.paypal.android.card.threedsecure.ThreeDSecureRequest
 import com.paypal.android.core.Address
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -15,10 +14,8 @@ import org.skyscreamer.jsonassert.JSONAssert
 class CardRequestFactoryUnitTest {
 
     private val orderID = "sample-order-id"
-    private val threeDSecureRequest = ThreeDSecureRequest(
-        returnUrl = "https://sample.com/return/url",
-        cancelUrl = "https://sample.com/cancel/url"
-    )
+
+    private val returnUrl = "return_url"
 
     private lateinit var sut: CardRequestFactory
 
@@ -45,7 +42,7 @@ class CardRequestFactoryUnitTest {
             )
         )
 
-        val cardRequest = CardRequest(orderID, card, threeDSecureRequest)
+        val cardRequest = CardRequest(orderID, card, returnUrl)
         val apiRequest = sut.createConfirmPaymentSourceRequest(cardRequest)
         assertEquals("v2/checkout/orders/sample-order-id/confirm-payment-source", apiRequest.path)
 
@@ -74,8 +71,8 @@ class CardRequestFactoryUnitTest {
                 }
               },
               "application_context": {
-                "return_url": "https://sample.com/return/url",
-                "cancel_url": "https://sample.com/cancel/url"
+                "return_url": "return_url",
+                "cancel_url": "return_url"
               }             
             }
         """.trimIndent()
@@ -87,7 +84,7 @@ class CardRequestFactoryUnitTest {
         val card =
             Card(number = "4111111111111111", expirationMonth = "01", expirationYear = "2022")
 
-        val cardRequest = CardRequest(orderID, card, threeDSecureRequest)
+        val cardRequest = CardRequest(orderID, card, returnUrl)
         val apiRequest = sut.createConfirmPaymentSourceRequest(cardRequest)
         assertEquals("v2/checkout/orders/sample-order-id/confirm-payment-source", apiRequest.path)
 
@@ -106,8 +103,8 @@ class CardRequestFactoryUnitTest {
                 }
                },
               "application_context": {
-                "return_url": "https://sample.com/return/url",
-                "cancel_url": "https://sample.com/cancel/url"
+                "return_url": "return_url",
+                "cancel_url": "return_url"
               }
             }
         """.trimIndent()
@@ -119,12 +116,8 @@ class CardRequestFactoryUnitTest {
         val card =
             Card(number = "4111111111111111", expirationMonth = "01", expirationYear = "2022")
 
-        val alwaysThreeDSecureRequest = ThreeDSecureRequest(
-            sca = SCA.SCA_ALWAYS,
-            returnUrl = "https://sample.com/return/url",
-            cancelUrl = "https://sample.com/cancel/url"
-        )
-        val cardRequest = CardRequest(orderID, card, alwaysThreeDSecureRequest)
+
+        val cardRequest = CardRequest(orderID, card, returnUrl, SCA.SCA_ALWAYS)
 
         val apiRequest = sut.createConfirmPaymentSourceRequest(cardRequest)
         assertEquals("v2/checkout/orders/sample-order-id/confirm-payment-source", apiRequest.path)
@@ -144,8 +137,8 @@ class CardRequestFactoryUnitTest {
                 }
               },
               "application_context": {
-                "return_url": "https://sample.com/return/url",
-                "cancel_url": "https://sample.com/cancel/url"
+                "return_url": "return_url",
+                "cancel_url": "return_url"
               }
             }
         """.trimIndent()

--- a/Card/src/test/java/com/paypal/android/card/CardRequestFactoryUnitTest.kt
+++ b/Card/src/test/java/com/paypal/android/card/CardRequestFactoryUnitTest.kt
@@ -116,7 +116,6 @@ class CardRequestFactoryUnitTest {
         val card =
             Card(number = "4111111111111111", expirationMonth = "01", expirationYear = "2022")
 
-
         val cardRequest = CardRequest(orderID, card, returnUrl, SCA.SCA_ALWAYS)
 
         val apiRequest = sut.createConfirmPaymentSourceRequest(cardRequest)

--- a/Core/src/test/java/com/paypal/android/core/APIUnitTest.kt
+++ b/Core/src/test/java/com/paypal/android/core/APIUnitTest.kt
@@ -4,14 +4,9 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Before
@@ -31,8 +26,6 @@ class APIUnitTest {
         "Paypal-Debug-Id" to "sample-correlation-id"
     )
 
-    private val testCoroutineDispatcher = TestCoroutineDispatcher()
-
     private val clientIdSuccessResponse by lazy {
         val clientIdBody = JSONObject()
             .put("client_id", "sample-client-id")
@@ -45,18 +38,10 @@ class APIUnitTest {
     @Before
     fun beforeEach() {
         sut = API(configuration, http, httpRequestFactory)
-
-        Dispatchers.setMain(testCoroutineDispatcher)
-    }
-
-    @After
-    fun afterEach() {
-        Dispatchers.resetMain()
-        testCoroutineDispatcher.cleanupTestCoroutines()
     }
 
     @Test
-    fun `converts an api request to an http request and sends it`() = runBlocking {
+    fun `converts an api request to an http request and sends it`() = runTest {
         val url = URL("https://example.com/resolved/path")
 
         val httpRequest = HttpRequest(url, HttpMethod.GET)
@@ -72,7 +57,7 @@ class APIUnitTest {
     }
 
     @Test
-    fun `get client id sends oauth api request`() = runBlocking {
+    fun `get client id sends oauth api request`() = runTest {
         val url = URL("https://example.com/resolved/path")
         val httpRequest = HttpRequest(url, HttpMethod.GET)
 
@@ -94,7 +79,7 @@ class APIUnitTest {
     }
 
     @Test
-    fun `get client id returns client id from JSON`() = runBlocking {
+    fun `get client id returns client id from JSON`() = runTest {
         val url = URL("https://example.com/resolved/path")
         val httpRequest = HttpRequest(url, HttpMethod.GET)
 
@@ -110,7 +95,7 @@ class APIUnitTest {
 
     @Test
     fun `get client id throws no response data error when http response has no body`() =
-        runBlocking {
+        runTest {
             val url = URL("https://example.com/resolved/path")
             val httpRequest = HttpRequest(url, HttpMethod.GET)
 
@@ -133,7 +118,7 @@ class APIUnitTest {
 
     @Test
     fun `get client id throws data parsing error when http response is missing client id`() =
-        runBlocking {
+        runTest {
             val url = URL("https://example.com/resolved/path")
             val httpRequest = HttpRequest(url, HttpMethod.GET)
 
@@ -157,7 +142,7 @@ class APIUnitTest {
 
     @Test
     fun `get client id throws server response error when http response is unsuccessful`() =
-        runBlocking {
+        runTest {
             val url = URL("https://example.com/resolved/path")
             val httpRequest = HttpRequest(url, HttpMethod.GET)
 

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
@@ -19,7 +19,6 @@ import com.paypal.android.card.CardClient
 import com.paypal.android.card.CardRequest
 import com.paypal.android.card.model.CardResult
 import com.paypal.android.card.threedsecure.SCA
-import com.paypal.android.card.threedsecure.ThreeDSecureRequest
 import com.paypal.android.core.Address
 import com.paypal.android.core.CoreConfig
 import com.paypal.android.core.PayPalSDKError
@@ -39,7 +38,6 @@ class CardFragment : Fragment() {
     companion object {
         const val TAG = "CardFragment"
         const val APP_RETURN_URL = "com.paypal.android.demo://example.com/returnUrl"
-        const val APP_CANCEL_URL = "com.paypal.android.demo://example.com/cancelUrl"
     }
 
     @Inject
@@ -199,11 +197,8 @@ class CardFragment : Fragment() {
             CardRequest(
                 order.id!!,
                 card,
-                ThreeDSecureRequest(
-                    sca = sca,
-                    returnUrl = APP_RETURN_URL,
-                    cancelUrl = APP_CANCEL_URL
-                )
+                APP_RETURN_URL,
+                sca
             )
         }
 

--- a/PayPalNativeCheckout/src/test/java/com/paypal/android/checkout/PayPalNativeCheckoutClientTest.kt
+++ b/PayPalNativeCheckout/src/test/java/com/paypal/android/checkout/PayPalNativeCheckoutClientTest.kt
@@ -26,17 +26,12 @@ import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -54,25 +49,18 @@ class PayPalNativeCheckoutClientTest {
 
     private lateinit var sut: PayPalNativeCheckoutClient
 
-    // Ref: https://github.com/Kotlin/kotlinx.coroutines/tree/master/kotlinx-coroutines-test#dispatchersmain-delegation
-    private lateinit var mainThreadSurrogate: ExecutorCoroutineDispatcher
-
 
     @Before
     fun setUp() {
         mockkStatic(PayPalCheckout::class)
         every { PayPalCheckout.setConfig(any()) } just runs
         coEvery { api.getClientId() } returns mockClientId
-        mainThreadSurrogate = newSingleThreadContext("UI thread")
-        Dispatchers.setMain(mainThreadSurrogate)
     }
 
     @After
     fun dispose() {
         unmockkAll()
         resetField(PayPalCheckout::class.java, "isConfigSet", false)
-        Dispatchers.resetMain() // reset the main dispatcher to the original Main dispatcher
-        mainThreadSurrogate.close()
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ buildscript {
             "androidHiltKapt"             : "androidx.hilt:hilt-compiler:1.0.0-alpha03",
 
             // Browser Switch
-            "browserSwitch"               : "com.braintreepayments.api:browser-switch:2.1.1",
+            "browserSwitch"               : "com.braintreepayments.api:browser-switch:2.3.1",
 
             // Testing
             "junit"                       : "junit:junit:4.13.2",

--- a/docs/Card/README.md
+++ b/docs/Card/README.md
@@ -98,26 +98,17 @@ val card = Card(
 )
 ```
 
-Attach the card and the order ID from [step 3](#3-create-an-order) to a `CardRequest`.
-
+Attach the card and the order ID from [step 3](#3-create-an-order) to a `CardRequest`. Strong Consumer Authentication (SCA) is enabled by default, so you need to specify a `return_url` to re direct to your app after the SCA challenge finishes. You can optionally set `sca` to `SCA_ALWAYS` if you want to require 3D Secure for every transaction.
 ```kotlin
-val cardRequest  = CardRequest("<ORDER_ID>", card)
-```
-
-Strong Consumer Authentication (SCA) is enabled by default. You need to pass a `ThreeDSecureRequest` when creating a `CardRequest`. This will require users to provide additional authentication information via 3D Secure. You can optionally set `sca` to `SCA_ALWAYS` if you want to require 3D Secure for every transaction.
-
-To request SCA, add the following to `CardRequest`:
-
-```kotlin
-cardRequest.threeDSecureRequest = ThreeDSecureRequest(
-  sca = SCA.SCA_ALWAYS, // default value is SCA_WHEN_REQUIRED
-  // custom url scheme needs to be configured in AndroidManifest.xml (see below)
-  returnUrl = "myapp://return_url",
-  cancelUrl = "myapp://cancel_url"
+val cardRequest  = CardRequest(
+    orderID = "<ORDER_ID>",
+    card = card,
+    returnUrl = "myapp://return_url", // custom url scheme needs to be configured in AndroidManifest.xml (see below)
+    sca = SCA.SCA_ALWAYS // default value is SCA_WHEN_REQUIRED
 )
 ```
 
-Notice the `myapp://` portion of the `returnUrl` and `cancelUrl` in the above code snippet. This `myapp` custom url scheme must also be registered in your app's `AndroidManifest.xml`.
+Notice the `myapp://` portion of the `returnUrl` in the above code snippet. This `myapp` custom url scheme must also be registered in your app's `AndroidManifest.xml`.
 
 Edit your app's `AndroidManifest.xml` to include an `intent-filter` and set the `android:scheme` on the Activity that will be responsible for handling the deep link back into the app. Also set the activity `launchMode` to `singleTop`:
 > Note: `android:exported` is required if your app compile SDK version is API 31 (Android 12) or later.


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes
[Jira ticket](https://engineering.paypalcorp.com/jira/browse/DTNOR-635)
 -  We dont need to ask merchants for `return` and `cancel` urls, we can only ask for `return` and set the same url in `ApplicationContext`. So we remove `ThreeDSecureRequest` and simply ask for it in `CardReques`. Also update browserSwitch library to latest.
 - Also some test clean up: removing deprecated and unnecessary coroutine code from tests
 - Remove `Demo` module from static analysis and build

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 
