### PR TITLE
Add Gradle Nexus Publish Plugin

### DIFF
--- a/.github/actions/publish_all_modules/action.yml
+++ b/.github/actions/publish_all_modules/action.yml
@@ -25,13 +25,7 @@ runs:
   using: "composite"
   steps:
     - run: |
-        ./gradlew --stacktrace clean \
-        :Core:publishReleasePublicationToMavenRepository \
-        :Card:publishReleasePublicationToMavenRepository \
-        :PayPalWebCheckout:publishReleasePublicationToMavenRepository \
-        :PayPalNativeCheckout:publishReleasePublicationToMavenRepository \
-        :PayPalDataCollector:publishReleasePublicationToMavenRepository \
-        :PayPalUI:publishReleasePublicationToMavenRepository
+        ./gradlew --stacktrace clean publishToSonatype closeAndReleaseSonatypeStagingRepository
       shell: bash
       env:
         SONATYPE_NEXUS_USERNAME: ${{ inputs.sonatype_usr }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # PayPal Android SDK Release Notes
 
 ## unreleased
-* Add [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin) to release process
 * `Card`:
   * Remove `ThreeDSecureRequest` from `CardRequest`
   * Update `CardRequest` to pass `return_url` and an optional `sca`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # PayPal Android SDK Release Notes
 
 ## unreleased
+* Add [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin) to release process
 * `Card`:
   * Remove `ThreeDSecureRequest` from `CardRequest`
   * Update `CardRequest` to pass `return_url` and an optional `sca`

--- a/Card/build.gradle
+++ b/Card/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion modules.androidMinSdkVersion
         targetSdkVersion modules.androidTargetVersion
         versionCode modules.sdkVersionCode
-        versionName modules.sdkVersionName
+        versionName rootProject.version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/Core/build.gradle
+++ b/Core/build.gradle
@@ -12,13 +12,12 @@ android {
         minSdkVersion modules.androidMinSdkVersion
         targetSdkVersion modules.androidTargetVersion
         versionCode modules.sdkVersionCode
-        versionName modules.sdkVersionName
+        versionName rootProject.version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }
 
     buildTypes {
-
         release {
             version = android.defaultConfig.versionName //had to add this to get the version in the build
             minifyEnabled false

--- a/PayPalDataCollector/build.gradle
+++ b/PayPalDataCollector/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion modules.androidMinSdkVersion
         targetSdkVersion modules.androidTargetVersion
         versionCode modules.sdkVersionCode
-        versionName modules.sdkVersionName
+        versionName rootProject.version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/PayPalNativeCheckout/build.gradle
+++ b/PayPalNativeCheckout/build.gradle
@@ -13,7 +13,7 @@ android {
         minSdkVersion 23
         targetSdkVersion modules.androidTargetVersion
         versionCode modules.sdkVersionCode
-        versionName modules.sdkVersionName
+        versionName rootProject.version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/PayPalUI/build.gradle
+++ b/PayPalUI/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion modules.androidMinSdkVersion
         targetSdkVersion modules.androidTargetVersion
         versionCode modules.sdkVersionCode
-        versionName modules.sdkVersionName
+        versionName rootProject.version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/PayPalWebCheckout/build.gradle
+++ b/PayPalWebCheckout/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion modules.androidMinSdkVersion
         targetSdkVersion modules.androidTargetVersion
         versionCode modules.sdkVersionCode
-        versionName modules.sdkVersionName
+        versionName rootProject.version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdk 21
         targetSdk 31
         versionCode 1
-        versionName "1.0"
+        versionName rootProject.version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ nexusPublishing {
         sonatype {
             username = System.getenv('SONATYPE_NEXUS_USERNAME') ?: ''
             password = System.getenv('SONATYPE_NEXUS_PASSWORD') ?: ''
-            repositoryDescription = "Paypal Android Sdk"
+            repositoryDescription = "Paypal Android SDK"
             packageGroup = "com.paypal"
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,24 @@ buildscript {
 plugins {
     id "io.gitlab.arturbosch.detekt" version "${detektVersion}"
     id 'org.jetbrains.kotlin.android' version '1.5.30' apply false
+    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
+}
+
+version modules.sdkVersionName // we add it here so that nexus automatically chooses staging or snapshot repo
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            username = System.getenv('SONATYPE_NEXUS_USERNAME') ?: ''
+            password = System.getenv('SONATYPE_NEXUS_PASSWORD') ?: ''
+            repositoryDescription = "Paypal Android Sdk"
+            packageGroup = "com.paypal"
+        }
+    }
+    transitionCheckOptions {
+        // give nexus sonatype more time to close the staging repository
+        delayBetween.set(Duration.ofSeconds(20))
+    }
 }
 
 allprojects {

--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -5,57 +5,40 @@ apply plugin: 'signing'
 ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID') ?: ''
 ext["signing.password"] = System.getenv('SIGNING_KEY_PASSWORD') ?: ''
 ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_KEY_FILE') ?: ''
-ext["SONATYPE_NEXUS_USERNAME"] = System.getenv('SONATYPE_NEXUS_USERNAME') ?: ''
-ext["SONATYPE_NEXUS_PASSWORD"] = System.getenv('SONATYPE_NEXUS_PASSWORD') ?: ''
-
 
 afterEvaluate {
-    android.libraryVariants.each { variant ->
-        publishing.publications.create variant.name, MavenPublication, {
-            groupId group
-            version project.version
-            artifactId project.ext.name
-            from components."${variant.name}"
-            artifact androidSourcesJar //TODO: add javadocs
-
-            pom {
-                name = project.ext.pom_name ?: ''
-                packaging = POM_PACKAGING
-                description = project.ext.pom_desc ?: ''
-                url = POM_URL
-                licenses {
-                    license {
-                        name = POM_LICENCE_NAME
-                        url = POM_LICENCE_URL
-                    }
-                }
-                developers {
-                    developer {
-                        id = POM_DEVELOPER_ID
-                        name = POM_DEVELOPER_NAME
-                        email = POM_DEVELOPER_EMAIL
-                    }
-                }
-                scm {
-                    connection = POM_SCM_CONNECTION
-                    developerConnection = POM_SCM_DEV_CONNECTION
-                    url = POM_SCM_URL
-                }
-            }
-        }
-    }
-
     publishing {
-        repositories {
-            maven {
-                credentials {
-                    username SONATYPE_NEXUS_USERNAME
-                    password SONATYPE_NEXUS_PASSWORD
-                }
-                if (project.version.endsWith('-SNAPSHOT')) {
-                    url 'https://oss.sonatype.org/content/repositories/snapshots/'
-                } else {
-                    url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+        publications {
+            release(MavenPublication) {
+                groupId group
+                version project.version
+                artifactId project.ext.name
+                from components.release
+                artifact androidSourcesJar //TODO: add javadocs
+
+                pom {
+                    name = project.ext.pom_name ?: ''
+                    packaging = POM_PACKAGING
+                    description = project.ext.pom_desc ?: ''
+                    url = POM_URL
+                    licenses {
+                        license {
+                            name = POM_LICENCE_NAME
+                            url = POM_LICENCE_URL
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = POM_DEVELOPER_ID
+                            name = POM_DEVELOPER_NAME
+                            email = POM_DEVELOPER_EMAIL
+                        }
+                    }
+                    scm {
+                        connection = POM_SCM_CONNECTION
+                        developerConnection = POM_SCM_DEV_CONNECTION
+                        url = POM_SCM_URL
+                    }
                 }
             }
         }


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Add [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin) to build.gradle. This plugin will allow us to publish, close and release staging repositories automatically as opposed to closing and releasing manually through Nexus Repository Manager.
- [Ticket](https://engineering.paypalcorp.com/jira/browse/DTNOR-608)

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 
