### PR TITLE
Add PayPalDataCollector to NativeCheckout and Bump NXO to 0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PayPal Android SDK Release Notes
 
+## unreleased
+* `PayPalNativeCheckout`:
+  * Fix `MagnesSDK` not found error
+  * Bump NXO to 0.8.7
+
 ## 0.0.6 (2022-12-02)
 * `Card`:
   * Remove `ThreeDSecureRequest` from `CardRequest`

--- a/Demo/src/main/java/com/paypal/android/viewmodels/PayPalNativeViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/viewmodels/PayPalNativeViewModel.kt
@@ -109,7 +109,7 @@ class PayPalNativeViewModel @Inject constructor(
                     )
                 )
             )
-            // TODO: patch order will fail because of bug in NXO. Ticket: https://engineering.paypalcorp.com/jira/browse/DTNOR-607
+            // TODO: patch order will fail because of bug in NXO. Ticket: https://paypal.atlassian.net/browse/DTNOR-607
             shippingChangeActions.patchOrder(patchRequest) {
                 internalState.postValue(NativeCheckoutViewState.OrderPatched)
             }

--- a/PayPalNativeCheckout/build.gradle
+++ b/PayPalNativeCheckout/build.gradle
@@ -41,6 +41,7 @@ android {
 
 dependencies {
     api project(':Core')
+    implementation project(':PayPalDataCollector')
 
     api (deps.nativeCheckout) {
         exclude module: 'data-collector'

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ buildscript {
             "json" : "org.json:json:20220320",
 
             // PayPal
-            "nativeCheckout"              : "com.paypal.checkout:android-sdk:0.8.2",
+            "nativeCheckout"              : "com.paypal.checkout:android-sdk:0.8.7",
 
             // Release modules
             "card"                        : "com.paypal.android:card:${modules.sdkVersionName}",


### PR DESCRIPTION
### Summary of changes

 - We add `PayPalDataCollector` as a dependency in `PayPalNativeCheckout` to avoid a Magnes error
 - Bump Nxo version to 0.8.7

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 
