### PR TITLE
ClientID Caching ability; value required for analytics

### DIFF
--- a/CardPayments/build.gradle
+++ b/CardPayments/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     testImplementation deps.jsonAssert
     testImplementation deps.robolectric
     testImplementation deps.kotlinxAndroidCoroutinesTest
+    testImplementation deps.striktCore
+    testImplementation deps.striktMockk
 
     androidTestImplementation deps.androidxJUnit
     androidTestImplementation deps.androidxEspressoCore

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -70,8 +70,9 @@ class CardClient internal constructor(
         try {
             cardAPI.fetchCachedOrRemoteClientID()
         } catch (e: PayPalSDKError) {
-            val merchantError = APIClientError.clientIDNotFoundError(e.code, e.correlationID)
-            approveOrderListener?.onApproveOrderFailure(merchantError)
+            approveOrderListener?.onApproveOrderFailure(
+                APIClientError.clientIDNotFoundError(e.code, e.correlationID)
+            )
             return
         }
 

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -60,13 +60,12 @@ class CardClient internal constructor(
      */
     fun approveOrder(activity: FragmentActivity, cardRequest: CardRequest) {
         CoroutineScope(dispatcher).launch(exceptionHandler) {
+            cardAPI.fetchClientID()
             confirmPaymentSource(activity, cardRequest)
         }
     }
 
     private suspend fun confirmPaymentSource(activity: FragmentActivity, cardRequest: CardRequest) {
-        cardAPI.fetchClientID()
-
         val response = cardAPI.confirmPaymentSource(cardRequest)
         if (response.payerActionHref == null) {
             val result = response.run {

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -65,6 +65,8 @@ class CardClient internal constructor(
     }
 
     private suspend fun confirmPaymentSource(activity: FragmentActivity, cardRequest: CardRequest) {
+        cardAPI.fetchClientID()
+
         val response = cardAPI.confirmPaymentSource(cardRequest)
         if (response.payerActionHref == null) {
             val result = response.run {

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CardAPI.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CardAPI.kt
@@ -13,10 +13,11 @@ internal class CardAPI(
     private val responseParser: CardResponseParser = CardResponseParser()
 ) {
 
+    @Throws(PayPalSDKError::class)
     suspend fun fetchClientID() {
         try {
             api.fetchCachedOrRemoteClientID()
-        } catch(e: PayPalSDKError) {
+        } catch (e: PayPalSDKError) {
             throw APIClientError.clientIDNotFoundError(e.code, e.correlationID)
         }
     }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CardAPI.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CardAPI.kt
@@ -4,12 +4,22 @@ import com.paypal.android.cardpayments.CardRequest
 import com.paypal.android.cardpayments.CardRequestFactory
 import com.paypal.android.cardpayments.CardResponseParser
 import com.paypal.android.corepayments.API
+import com.paypal.android.corepayments.APIClientError
+import com.paypal.android.corepayments.PayPalSDKError
 
 internal class CardAPI(
     private val api: API,
     private val requestFactory: CardRequestFactory = CardRequestFactory(),
     private val responseParser: CardResponseParser = CardResponseParser()
 ) {
+
+    suspend fun fetchClientID() {
+        try {
+            api.fetchCachedOrRemoteClientID()
+        } catch(e: PayPalSDKError) {
+            throw APIClientError.clientIDNotFoundError(e.correlationID)
+        }
+    }
 
     suspend fun confirmPaymentSource(cardRequest: CardRequest): ConfirmPaymentSourceResponse {
         val apiRequest = requestFactory.createConfirmPaymentSourceRequest(cardRequest)

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CardAPI.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CardAPI.kt
@@ -4,7 +4,6 @@ import com.paypal.android.cardpayments.CardRequest
 import com.paypal.android.cardpayments.CardRequestFactory
 import com.paypal.android.cardpayments.CardResponseParser
 import com.paypal.android.corepayments.API
-import com.paypal.android.corepayments.APIClientError
 import com.paypal.android.corepayments.PayPalSDKError
 
 internal class CardAPI(
@@ -14,12 +13,8 @@ internal class CardAPI(
 ) {
 
     @Throws(PayPalSDKError::class)
-    suspend fun fetchClientID() {
-        try {
-            api.fetchCachedOrRemoteClientID()
-        } catch (e: PayPalSDKError) {
-            throw APIClientError.clientIDNotFoundError(e.code, e.correlationID)
-        }
+    suspend fun fetchCachedOrRemoteClientID() {
+        api.fetchCachedOrRemoteClientID()
     }
 
     suspend fun confirmPaymentSource(cardRequest: CardRequest): ConfirmPaymentSourceResponse {

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CardAPI.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CardAPI.kt
@@ -17,7 +17,7 @@ internal class CardAPI(
         try {
             api.fetchCachedOrRemoteClientID()
         } catch(e: PayPalSDKError) {
-            throw APIClientError.clientIDNotFoundError(e.correlationID)
+            throw APIClientError.clientIDNotFoundError(e.code, e.correlationID)
         }
     }
 

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CardAPI.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CardAPI.kt
@@ -4,7 +4,6 @@ import com.paypal.android.cardpayments.CardRequest
 import com.paypal.android.cardpayments.CardRequestFactory
 import com.paypal.android.cardpayments.CardResponseParser
 import com.paypal.android.corepayments.API
-import com.paypal.android.corepayments.PayPalSDKError
 
 internal class CardAPI(
     private val api: API,
@@ -12,7 +11,6 @@ internal class CardAPI(
     private val responseParser: CardResponseParser = CardResponseParser()
 ) {
 
-    @Throws(PayPalSDKError::class)
     suspend fun fetchCachedOrRemoteClientID() {
         api.fetchCachedOrRemoteClientID()
     }

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAPIUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAPIUnitTest.kt
@@ -4,7 +4,6 @@ import com.paypal.android.cardpayments.api.CardAPI
 import com.paypal.android.corepayments.*
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONException
 import org.junit.Assert.assertEquals
@@ -12,8 +11,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import strikt.api.expectThat
-import strikt.assertions.isEqualTo
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAPIUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAPIUnitTest.kt
@@ -81,24 +81,6 @@ class CardAPIUnitTest {
     }
 
     @Test
-    fun `getClientID() throws proper error if client ID fetch fails`() = runTest {
-        val fakeCode = 123
-        val error = PayPalSDKError(fakeCode, "fake-description", "fake-correlation-id")
-
-        coEvery { api.fetchCachedOrRemoteClientID() } throws error
-
-        lateinit var capturedError: PayPalSDKError
-        try {
-            sut.fetchClientID()
-        } catch (e: PayPalSDKError) {
-            capturedError = e
-        }
-        assertEquals(fakeCode, capturedError?.code)
-        assertEquals("fake-correlation-id", capturedError?.correlationID)
-        assertEquals("Error fetching clientID. Contact developer.paypal.com/support.", capturedError?.errorDescription)
-    }
-
-    @Test
     fun `it sends a confirm payment source api request`() = runTest {
         val httpResponse = HttpResponse(200, emptyMap(), successBody)
         coEvery { api.send(apiRequest) } returns httpResponse

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAPIUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAPIUnitTest.kt
@@ -1,8 +1,17 @@
 package com.paypal.android.cardpayments
 
 import com.paypal.android.cardpayments.api.CardAPI
-import com.paypal.android.corepayments.*
-import io.mockk.*
+import com.paypal.android.corepayments.API
+import com.paypal.android.corepayments.APIRequest
+import com.paypal.android.corepayments.HttpMethod
+import com.paypal.android.corepayments.HttpResponse
+import com.paypal.android.corepayments.OrderStatus
+import com.paypal.android.corepayments.PayPalSDKError
+import com.paypal.android.corepayments.PaymentsJSON
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.json.JSONException

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
@@ -32,8 +32,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import strikt.api.expectThat
-import strikt.assertions.*
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import android.util.LruCache
 import com.paypal.android.corepayments.analytics.AnalyticsService
 import com.paypal.android.corepayments.analytics.DeviceInspector
-import java.lang.Exception
 
 /**
  * This class is exposed for internal PayPal use only. Do not use.

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
@@ -36,8 +36,12 @@ class API internal constructor(
         return http.send(httpRequest)
     }
 
+    /**
+     * Retrieves the merchant's clientID either from the local cache, or via an HTTP request if not cached.
+     * @return Merchant clientID.
+     */
     @Throws(PayPalSDKError::class)
-    suspend fun getClientId(): String {
+    suspend fun fetchCachedOrRemoteClientID(): String {
         configuration.accessToken?.let { accessToken ->
             clientIDCache.get(accessToken)?.let { cachedClientID ->
                 return cachedClientID
@@ -75,7 +79,7 @@ class API internal constructor(
 
     suspend fun sendAnalyticsEvent(name: String) {
         try {
-            val clientID = getClientId()
+            val clientID = fetchCachedOrRemoteClientID()
             analyticsService.sendAnalyticsEvent(name, clientID)
         } catch (e: Exception) {
             Log.d("[PayPal SDK]", "Failed to send analytics due to missing clientID: ${e.message}")

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
@@ -1,9 +1,11 @@
 package com.paypal.android.corepayments
 
 import android.content.Context
+import android.util.Log
 import android.util.LruCache
 import com.paypal.android.corepayments.analytics.AnalyticsService
 import com.paypal.android.corepayments.analytics.DeviceInspector
+import java.lang.Exception
 
 /**
  * This class is exposed for internal PayPal use only. Do not use.
@@ -68,7 +70,12 @@ class API internal constructor(
     }
 
     suspend fun sendAnalyticsEvent(name: String) {
-        analyticsService.sendAnalyticsEvent(name)
+        try {
+            val clientID = getClientId()
+            analyticsService.sendAnalyticsEvent(name, clientID)
+        } catch (e: Exception) {
+            Log.d("[PayPal SDK]", "Failed to send analytics due to missing clientID: ${e.message}")
+        }
     }
 
     companion object {

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
@@ -81,7 +81,7 @@ class API internal constructor(
         try {
             val clientID = fetchCachedOrRemoteClientID()
             analyticsService.sendAnalyticsEvent(name, clientID)
-        } catch (e: Exception) {
+        } catch (e: PayPalSDKError) {
             Log.d("[PayPal SDK]", "Failed to send analytics due to missing clientID: ${e.message}")
         }
     }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
@@ -38,8 +38,10 @@ class API internal constructor(
 
     @Throws(PayPalSDKError::class)
     suspend fun getClientId(): String {
-        clientIDCache.get(configuration.accessToken)?.let {
-            return it
+        configuration.accessToken?.let { accessToken ->
+            clientIDCache.get(accessToken)?.let { cachedClientID ->
+                return cachedClientID
+            }
         }
 
         val apiRequest = APIRequest("v1/oauth2/token", HttpMethod.GET)
@@ -49,7 +51,9 @@ class API internal constructor(
         val correlationID = response.headers["Paypal-Debug-Id"]
         if (response.isSuccessful) {
             val clientID = parseClientId(response.body, correlationID)
-            clientIDCache.put(configuration.accessToken, clientID)
+            configuration.accessToken?.let { accessToken ->
+                clientIDCache.put(accessToken, clientID)
+            }
             return clientID
         }
 

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/APIClientError.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/APIClientError.kt
@@ -64,7 +64,6 @@ object APIClientError {
         errorDescription = "Error fetching clientID. Contact developer.paypal.com/support.",
         correlationID = correlationID
     )
-
 }
 
 internal enum class Code {

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/APIClientError.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/APIClientError.kt
@@ -58,6 +58,13 @@ object APIClientError {
             errorDescription = description
         )
     }
+
+    fun clientIDNotFoundError(correlationID: String?) = PayPalSDKError(
+        code = Code.CHECKOUT_ERROR.ordinal,
+        errorDescription = "Error fetching clientID. Contact developer.paypal.com/support.",
+        correlationID = correlationID
+    )
+
 }
 
 internal enum class Code {

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/APIClientError.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/APIClientError.kt
@@ -59,8 +59,8 @@ object APIClientError {
         )
     }
 
-    fun clientIDNotFoundError(correlationID: String?) = PayPalSDKError(
-        code = Code.CHECKOUT_ERROR.ordinal,
+    fun clientIDNotFoundError(code: Int, correlationID: String?) = PayPalSDKError(
+        code = code,
         errorDescription = "Error fetching clientID. Contact developer.paypal.com/support.",
         correlationID = correlationID
     )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
@@ -3,6 +3,7 @@ package com.paypal.android.corepayments.analytics
 import org.json.JSONObject
 
 data class AnalyticsEventData(
+    val clientID: String,
     val eventName: String,
     val timestamp: Long,
     val sessionID: String,
@@ -12,6 +13,7 @@ data class AnalyticsEventData(
     companion object {
         const val KEY_APP_ID = "app_id"
         const val KEY_APP_NAME = "app_name"
+        const val KEY_CLIENT_ID = "partner_client_id"
         const val KEY_CLIENT_SDK_VERSION = "c_sdk_ver"
         const val KEY_CLIENT_OS = "client_os"
         const val KEY_COMPONENT = "comp"
@@ -34,6 +36,7 @@ data class AnalyticsEventData(
         val eventParams = JSONObject()
             .put(KEY_APP_ID, deviceData.appId)
             .put(KEY_APP_NAME, deviceData.appName)
+            .put(KEY_CLIENT_ID, clientID)
             .put(KEY_CLIENT_SDK_VERSION, deviceData.clientSDKVersion)
             .put(KEY_CLIENT_OS, deviceData.clientOS)
             .put(KEY_COMPONENT, "ppunifiedsdk")

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
@@ -11,11 +11,16 @@ internal class AnalyticsService(
     private val httpRequestFactory: HttpRequestFactory
 ) {
 
-    internal suspend fun sendAnalyticsEvent(name: String) {
+    internal suspend fun sendAnalyticsEvent(name: String, clientID: String) {
         val timestamp = System.currentTimeMillis()
 
-        val analyticsEventData =
-            AnalyticsEventData(name, timestamp, sessionId, deviceInspector.inspect())
+        val analyticsEventData = AnalyticsEventData(
+            clientID,
+            name,
+            timestamp,
+            sessionId,
+            deviceInspector.inspect()
+        )
         val httpRequest = httpRequestFactory.createHttpRequestForAnalytics(analyticsEventData)
 
         val response = http.send(httpRequest)

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/api/EligibilityAPI.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/api/EligibilityAPI.kt
@@ -36,7 +36,7 @@ internal class EligibilityAPI internal constructor(
      */
     suspend fun checkEligibility(): Eligibility {
         val fundingEligibilityQuery = FundingEligibilityQuery(
-            clientId = api.getClientId(),
+            clientId = api.fetchCachedOrRemoteClientID(),
             fundingEligibilityIntent = FundingEligibilityIntent.CAPTURE,
             currencyCode = SupportedCountryCurrencyType.USD,
             enableFunding = listOf(SupportedPaymentMethodsType.VENMO)

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/APIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/APIUnitTest.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.*
@@ -185,7 +186,9 @@ class APIUnitTest {
         }
 
     @Test
-    fun `sendAnalyticsEvent() event delegates it to analytics client`() = runTest {
+    fun `sendAnalyticsEvent() event delegates it to analytics service`() = runTest {
+        API.clientIDCache.put("fake-access-token", "fake-client-id")
+
         coEvery {
             analyticsService.sendAnalyticsEvent(
                 "sample.event.name",

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/APIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/APIUnitTest.kt
@@ -9,7 +9,6 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.*

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/APIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/APIUnitTest.kt
@@ -161,10 +161,15 @@ class APIUnitTest {
 
     @Test
     fun `send analytics event delegates it to analytics client`() = runTest {
-        coEvery { analyticsService.sendAnalyticsEvent("sample.event.name") } just runs
+        coEvery {
+            analyticsService.sendAnalyticsEvent(
+                "sample.event.name",
+                "fake-client-id"
+            )
+        } just runs
         sut.sendAnalyticsEvent("sample.event.name")
         coVerify(exactly = 1) {
-            analyticsService.sendAnalyticsEvent("sample.event.name")
+            analyticsService.sendAnalyticsEvent("sample.event.name", "fake-client-id")
         }
     }
 }

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/APIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/APIUnitTest.kt
@@ -52,7 +52,7 @@ class APIUnitTest {
     }
 
     @Test
-    fun `converts an api request to an http request and sends it`() = runTest {
+    fun `send() converts an api request to an http request and sends it`() = runTest {
         every {
             httpRequestFactory.createHttpRequestFromAPIRequest(apiRequest, configuration)
         } returns httpRequest
@@ -65,7 +65,7 @@ class APIUnitTest {
     }
 
     @Test
-    fun `get client id sends oauth api request when value not in cache`() = runTest {
+    fun `fetchCachedOrRemoteClientID() sends oauth api request when value not in cache`() = runTest {
         val apiRequestSlot = slot<APIRequest>()
         every {
             httpRequestFactory.createHttpRequestFromAPIRequest(
@@ -76,7 +76,7 @@ class APIUnitTest {
 
         coEvery { http.send(httpRequest) } returns clientIdSuccessResponse
 
-        sut.getClientId()
+        sut.fetchCachedOrRemoteClientID()
 
         val apiRequest = apiRequestSlot.captured
         assertEquals(HttpMethod.GET, apiRequest.method)
@@ -84,7 +84,7 @@ class APIUnitTest {
     }
 
     @Test
-    fun `get client id puts value in cache after fetched`() = runTest {
+    fun `fetchCachedOrRemoteClientID() puts value in cache after fetched`() = runTest {
         val apiRequestSlot = slot<APIRequest>()
         every {
             httpRequestFactory.createHttpRequestFromAPIRequest(
@@ -95,33 +95,33 @@ class APIUnitTest {
 
         coEvery { http.send(httpRequest) } returns clientIdSuccessResponse
 
-        sut.getClientId()
+        sut.fetchCachedOrRemoteClientID()
 
         assertEquals(API.clientIDCache.get("fake-access-token"), "sample-client-id")
     }
 
     @Test
-    fun `get client id returns cached value when exists in cache`() = runTest {
+    fun `fetchCachedOrRemoteClientID() returns cached value when exists in cache`() = runTest {
         API.clientIDCache.put("fake-access-token", "cached-id-123")
 
-        val clientID = sut.getClientId()
+        val clientID = sut.fetchCachedOrRemoteClientID()
         assertEquals(clientID, "cached-id-123")
     }
 
     @Test
-    fun `get client id returns client id from JSON`() = runTest {
+    fun `fetchCachedOrRemoteClientID() returns client id from JSON`() = runTest {
         every {
             httpRequestFactory.createHttpRequestFromAPIRequest(any(), any())
         } returns httpRequest
 
         coEvery { http.send(httpRequest) } returns clientIdSuccessResponse
 
-        val result = sut.getClientId()
+        val result = sut.fetchCachedOrRemoteClientID()
         assertEquals("sample-client-id", result)
     }
 
     @Test
-    fun `get client id throws no response data error when http response has no body`() =
+    fun `fetchCachedOrRemoteClientID() throws no response data error when http response has no body`() =
         runTest {
 
             every {
@@ -133,7 +133,7 @@ class APIUnitTest {
 
             var capturedError: PayPalSDKError? = null
             try {
-                sut.getClientId()
+                sut.fetchCachedOrRemoteClientID()
             } catch (e: PayPalSDKError) {
                 capturedError = e
             }
@@ -142,7 +142,7 @@ class APIUnitTest {
         }
 
     @Test
-    fun `get client id throws data parsing error when http response is missing client id`() =
+    fun `fetchCachedOrRemoteClientID() throws data parsing error when http response is missing client id`() =
         runTest {
 
             every {
@@ -155,7 +155,7 @@ class APIUnitTest {
 
             var capturedError: PayPalSDKError? = null
             try {
-                sut.getClientId()
+                sut.fetchCachedOrRemoteClientID()
             } catch (e: PayPalSDKError) {
                 capturedError = e
             }
@@ -164,7 +164,7 @@ class APIUnitTest {
         }
 
     @Test
-    fun `get client id throws server response error when http response is unsuccessful`() =
+    fun `fetchCachedOrRemoteClientID() throws server response error when http response is unsuccessful`() =
         runTest {
 
             every {
@@ -176,7 +176,7 @@ class APIUnitTest {
 
             var capturedError: PayPalSDKError? = null
             try {
-                sut.getClientId()
+                sut.fetchCachedOrRemoteClientID()
             } catch (e: PayPalSDKError) {
                 capturedError = e
             }
@@ -185,7 +185,7 @@ class APIUnitTest {
         }
 
     @Test
-    fun `send analytics event delegates it to analytics client`() = runTest {
+    fun `sendAnalyticsEvent() event delegates it to analytics client`() = runTest {
         coEvery {
             analyticsService.sendAnalyticsEvent(
                 "sample.event.name",

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/HttpRequestFactoryUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/HttpRequestFactoryUnitTest.kt
@@ -113,6 +113,7 @@ class HttpRequestFactoryUnitTest {
     @Test
     fun `createHttpRequestForAnalytics properly constructs HTTP request`() {
         val analyticsEventData = AnalyticsEventData(
+            clientID = "fake-client-id",
             eventName = "fake-event",
             timestamp = 10000,
             sessionID = "fake-session-id",
@@ -137,6 +138,7 @@ class HttpRequestFactoryUnitTest {
                     "event_params": {
                         "app_id": "fake-app-id",
                         "app_name": "fake-app-name",
+                        "partner_client_id": "fake-client-id",
                         "c_sdk_ver": "fake-sdk-version",
                         "client_os": "fake client OS",
                         "comp": "ppunifiedsdk",

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/analytics/AnalyticsServiceTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/analytics/AnalyticsServiceTest.kt
@@ -62,7 +62,7 @@ class AnalyticsServiceTest {
             httpRequestFactory.createHttpRequestForAnalytics(capture(analyticsEventDataSlot))
         } returns httpRequest
 
-        analyticsService.sendAnalyticsEvent("sample.event.name")
+        analyticsService.sendAnalyticsEvent("sample.event.name", "fake-client-id")
 
         val analyticsEventData = analyticsEventDataSlot.captured
         assertEquals("sample.event.name", analyticsEventData.eventName)
@@ -75,7 +75,7 @@ class AnalyticsServiceTest {
             httpRequestFactory.createHttpRequestForAnalytics(any())
         } returns httpRequest
 
-        analyticsService.sendAnalyticsEvent("sample.event.name")
+        analyticsService.sendAnalyticsEvent("sample.event.name", "fake-client-id")
 
         coVerify(exactly = 1) {
             http.send(httpRequest)
@@ -89,7 +89,7 @@ class AnalyticsServiceTest {
         } returns httpRequest
 
         val timeBeforeEventSent = System.currentTimeMillis()
-        analyticsService.sendAnalyticsEvent("sample.event.name")
+        analyticsService.sendAnalyticsEvent("sample.event.name", "fake-client-id")
 
         val actualTimestamp = analyticsEventDataSlot.captured.timestamp
 
@@ -105,7 +105,7 @@ class AnalyticsServiceTest {
             httpRequestFactory.createHttpRequestForAnalytics(capture(analyticsEventDataSlot1))
         } returns httpRequest
 
-        analyticsService.sendAnalyticsEvent("event1")
+        analyticsService.sendAnalyticsEvent("event1", "fake-client-id")
         val analyticsEventData1 = analyticsEventDataSlot1.captured
 
         val analyticsEventDataSlot2 = slot<AnalyticsEventData>()
@@ -114,7 +114,7 @@ class AnalyticsServiceTest {
         } returns httpRequest
 
         val analyticsService2 = AnalyticsService(deviceInspector, http, httpRequestFactory)
-        analyticsService2.sendAnalyticsEvent("event2")
+        analyticsService2.sendAnalyticsEvent("event2", "fake-client-id")
 
         val analyticsEventData2 = analyticsEventDataSlot2.captured
 

--- a/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClient.kt
+++ b/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClient.kt
@@ -53,7 +53,7 @@ class PayPalNativeCheckoutClient internal constructor (
         CoroutineScope(dispatcher).launch(exceptionHandler) {
             val config = CheckoutConfig(
                 application = application,
-                clientId = api.getClientId(),
+                clientId = api.fetchCachedOrRemoteClientID(),
                 environment = getPayPalEnvironment(coreConfig.environment),
                 uiConfig = UIConfig(
                     showExitSurveyDialog = false

--- a/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClient.kt
+++ b/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClient.kt
@@ -68,7 +68,7 @@ class PayPalNativeCheckoutClient internal constructor (
                 listener?.onPayPalCheckoutStart()
                 PayPalCheckout.startCheckout(createOrder)
             } catch (e: PayPalSDKError) {
-                listener?.onPayPalCheckoutFailure(APIClientError.clientIDNotFoundError(e.correlationID))
+                listener?.onPayPalCheckoutFailure(APIClientError.clientIDNotFoundError(e.code, e.correlationID))
             }
         }
     }

--- a/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClient.kt
+++ b/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClient.kt
@@ -68,7 +68,8 @@ class PayPalNativeCheckoutClient internal constructor (
                     environment = getPayPalEnvironment(coreConfig.environment),
                     uiConfig = UIConfig(
                         showExitSurveyDialog = false
-                    )
+                    ),
+                    returnUrl = returnUrl
                 )
                 PayPalCheckout.setConfig(config)
                 listener?.onPayPalCheckoutStart()

--- a/PayPalNativePayments/src/test/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClientTest.kt
+++ b/PayPalNativePayments/src/test/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClientTest.kt
@@ -133,9 +133,7 @@ class PayPalNativeCheckoutClientTest {
 
     @Test
     fun `when getting client id fails is invoked, it calls onPayPalFailure`() = runTest {
-        val mockCode = 0
-        val mockErrorDescription = "mock_error_description"
-        val error = PayPalSDKError(mockCode, mockErrorDescription)
+        val error = PayPalSDKError(123, "fake-description")
         val errorSlot = slot<PayPalSDKError>()
         val payPalCheckoutListener = spyk<PayPalNativeCheckoutListener>()
 
@@ -154,8 +152,8 @@ class PayPalNativeCheckoutClientTest {
             payPalCheckoutListener.onPayPalCheckoutFailure(any())
         }
         expectThat(errorSlot.captured) {
-            get { code }.isEqualTo(mockCode)
-            get { errorDescription }.isEqualTo(mockErrorDescription)
+            get { code }.isEqualTo(123)
+            get { errorDescription }.isEqualTo("Error fetching clientID. Contact developer.paypal.com/support.")
         }
     }
 

--- a/PayPalNativePayments/src/test/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClientTest.kt
+++ b/PayPalNativePayments/src/test/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClientTest.kt
@@ -53,7 +53,7 @@ class PayPalNativeCheckoutClientTest {
     fun setUp() {
         mockkStatic(PayPalCheckout::class)
         every { PayPalCheckout.setConfig(any()) } just runs
-        coEvery { api.getClientId() } returns mockClientId
+        coEvery { api.fetchCachedOrRemoteClientID() } returns mockClientId
     }
 
     @After
@@ -109,7 +109,7 @@ class PayPalNativeCheckoutClientTest {
         val errorSlot = slot<PayPalSDKError>()
         val payPalCheckoutListener = spyk<PayPalNativeCheckoutListener>()
 
-        coEvery { api.getClientId() } throws error
+        coEvery { api.fetchCachedOrRemoteClientID() } throws error
         every {
             payPalCheckoutListener.onPayPalCheckoutFailure(capture(errorSlot))
         } answers { errorSlot.captured }

--- a/PayPalWebPayments/build.gradle
+++ b/PayPalWebPayments/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation deps.kotlinStdLib
     implementation deps.androidxCoreKtx
     implementation deps.androidxAppcompat
+    implementation deps.kotlinxAndroidCoroutines
     implementation deps.material
 
     testImplementation deps.junit

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -4,7 +4,11 @@ import androidx.fragment.app.FragmentActivity
 import com.braintreepayments.api.BrowserSwitchClient
 import com.braintreepayments.api.BrowserSwitchResult
 import com.braintreepayments.api.BrowserSwitchStatus
-import com.paypal.android.corepayments.*
+import com.paypal.android.corepayments.CoreConfig
+import com.paypal.android.corepayments.API
+import com.paypal.android.corepayments.CoreCoroutineExceptionHandler
+import com.paypal.android.corepayments.APIClientError
+import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.paypalwebpayments.errors.PayPalWebCheckoutError
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.*

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -73,17 +73,19 @@ class PayPalWebCheckoutClient internal constructor(
         CoroutineScope(dispatcher).launch(exceptionHandler) {
             try {
                 api.fetchCachedOrRemoteClientID()
+
+                val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(
+                    request.orderID,
+                    coreConfig,
+                    request.fundingSource
+                )
+                browserSwitchClient.start(activity, browserSwitchOptions)
             } catch (e: PayPalSDKError) {
-                listener?.onPayPalWebFailure(APIClientError.clientIDNotFoundError(e.code, e.correlationID))
+                listener?.onPayPalWebFailure(
+                    APIClientError.clientIDNotFoundError(e.code, e.correlationID)
+                )
             }
         }
-
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(
-            request.orderID,
-            coreConfig,
-            request.fundingSource
-        )
-        browserSwitchClient.start(activity, browserSwitchOptions)
     }
 
     internal fun handleBrowserSwitchResult() {

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -11,7 +11,9 @@ import com.paypal.android.corepayments.APIClientError
 import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.paypalwebpayments.errors.PayPalWebCheckoutError
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 /**
  * Use this client to approve an order with a [PayPalWebCheckoutRequest].

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -74,7 +74,7 @@ class PayPalWebCheckoutClient internal constructor(
             try {
                 api.fetchCachedOrRemoteClientID()
             } catch (e: PayPalSDKError) {
-                listener?.onPayPalWebFailure(APIClientError.clientIDNotFoundError(e.correlationID))
+                listener?.onPayPalWebFailure(APIClientError.clientIDNotFoundError(e.code, e.correlationID))
             }
         }
 

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -62,21 +62,18 @@ class PayPalWebCheckoutClientUnitTest {
     }
 
     @Test
-    fun `start() starts browserSwitchClient with correct parameters`() {
-        val payPalClient =
-            PayPalWebCheckoutClient(activity, coreConfig, api, browserSwitchClient, browserSwitchHelper)
-        val payPalRequest = PayPalWebCheckoutRequest("mock_order_id")
+    fun `start() starts browserSwitchClient with correct parameters`() = runTest {
+        val sut = getPayPalCheckoutClient(testScheduler = testScheduler)
         val browserSwitchOptions = mockk<BrowserSwitchOptions>(relaxed = true)
 
-        every {
-            browserSwitchHelper.configurePayPalBrowserSwitchOptions(
-                any(),
-                coreConfig,
-                payPalRequest.fundingSource
-            )
+        coEvery { api.fetchCachedOrRemoteClientID() } returns "fake-client-id"
+
+        coEvery {
+            browserSwitchHelper.configurePayPalBrowserSwitchOptions(any(), any(), any())
         } returns browserSwitchOptions
 
-        payPalClient.start(payPalRequest)
+        sut.start(mockk(relaxed = true))
+        advanceUntilIdle()
 
         verify(exactly = 1) { browserSwitchClient.start(activity, browserSwitchOptions) }
     }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -35,7 +35,7 @@ class PayPalWebCheckoutClientUnitTest {
     private val api = mockk<API>(relaxed = true)
 
     @Test
-    fun `start() throws error if error fetching clientID`() = runTest {
+    fun `start() delivers error if error fetching clientID`() = runTest {
         val fakeCode = 123
         val error = PayPalSDKError(fakeCode, "fake-description")
         val errorSlot = slot<PayPalSDKError>()


### PR DESCRIPTION
Equivalent iOS PR - https://github.com/paypal/iOS-SDK/pull/118
[JIRA](https://paypal.atlassian.net/browse/DTNOR-745)

## Reason for changes

This PR requires a clientID be successfully fetched (or cached) before proceeding with any of the 3 payment method flows (card, paypal web, and paypal native).

### Summary of changes

- Rename `API.getClientId()` --> `API.fetchCachedOrRemoteClientID()` + added docstring
     - Store `clientID` in static LRU Cache of max size 10 items; fetch from cache when possible
     - Key = accessToken, value = clientID
- Add new `APIClientError.clientIDNotFoundError` case
- Add clientID fetch to PayPalWebCheckoutClient, CardClient, PayPalNativeClient & updated respective unit test files
- Add `partner_client_id` to analytics payload metadata

### Next steps
- Will create follow-up tickets for doing an early background fetch for clientID once the merchant passes us their accessToken; but that work can happen post-GA.

 ### Checklist

 - ~Added a changelog entry~

### Authors
@scannillo