### PR TITLE
Add analytic events for PPWeb, PP NXO, and Card flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * `PayPalNativePayments`:
   *  Bump `PayPal Native Checkout` to `0.8.8` and add `return_url`
+* Send analytic events for `PayPalNativePayments`, `PayPalWebPayments`, and `CardPayments` flows
 
 ## 0.0.7 (2023-01-25)
 * Rename `PayPalDataCollector` to `FraudProtection`

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -72,8 +72,7 @@ class CardClient internal constructor(
         try {
             cardAPI.fetchCachedOrRemoteClientID()
         } catch (e: PayPalSDKError) {
-            notifyApproveOrderFailure(APIClientError.clientIDNotFoundError(e.code, e.correlationID))
-            return
+            throw APIClientError.clientIDNotFoundError(e.code, e.correlationID)
         }
 
         val response = cardAPI.confirmPaymentSource(cardRequest)

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -72,7 +72,8 @@ class CardClient internal constructor(
         try {
             cardAPI.fetchCachedOrRemoteClientID()
         } catch (e: PayPalSDKError) {
-            throw APIClientError.clientIDNotFoundError(e.code, e.correlationID)
+            notifyApproveOrderFailure(APIClientError.clientIDNotFoundError(e.code, e.correlationID))
+            return
         }
 
         val response = cardAPI.confirmPaymentSource(cardRequest)

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CardAPI.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CardAPI.kt
@@ -21,8 +21,10 @@ internal class CardAPI(
 
         val error = responseParser.parseError(httpResponse)
         if (error != null) {
+            sendAnalyticsEvent("card-payments:3ds:confirm-payment-source:failed")
             throw error
         } else {
+            sendAnalyticsEvent("card-payments:3ds:confirm-payment-source:succeeded")
             return responseParser.parseConfirmPaymentSourceResponse(httpResponse)
         }
     }
@@ -33,9 +35,15 @@ internal class CardAPI(
 
         val error = responseParser.parseError(httpResponse)
         if (error != null) {
+            sendAnalyticsEvent("card-payments:3ds:get-order-info:failed")
             throw error
         } else {
+            sendAnalyticsEvent("card-payments:3ds:get-order-info:succeeded")
             return responseParser.parseGetOrderInfoResponse(httpResponse)
         }
+    }
+
+    fun sendAnalyticsEvent(name: String) {
+        api.sendAnalyticsEvent(name)
     }
 }

--- a/CorePayments/src/androidTest/java/com/paypal/android/corepayments/HttpIntegrationTest.kt
+++ b/CorePayments/src/androidTest/java/com/paypal/android/corepayments/HttpIntegrationTest.kt
@@ -1,37 +1,37 @@
-//package com.paypal.android.corepayments
-//
-//import androidx.test.ext.junit.runners.AndroidJUnit4
-//import kotlinx.coroutines.ExperimentalCoroutinesApi
-//import kotlinx.coroutines.test.TestCoroutineDispatcher
-//import kotlinx.coroutines.test.runBlockingTest
-//import org.junit.After
-//import org.junit.Assert.assertEquals
-//import org.junit.Before
-//import org.junit.Test
-//import org.junit.runner.RunWith
-//
-//@ExperimentalCoroutinesApi
-//@RunWith(AndroidJUnit4::class)
-//class HttpIntegrationTest {
-//
-//    private lateinit var testDispatcher: TestCoroutineDispatcher
-//
-//    @Before
-//    fun beforeEach() {
-//        testDispatcher = TestCoroutineDispatcher()
-//    }
-//
-//    @After
-//    fun afterEach() {
-//        testDispatcher.cleanupTestCoroutines()
-//    }
-//
-//    @Test
-//    fun send_makesAnHttpRequest() = runBlockingTest {
-//        val request = HttpRequest("https://www.google.com")
-//
-//        val sut = Http(testDispatcher)
-//        val result = sut.send(request)
-//        assertEquals(200, result.status)
-//    }
-//}
+package com.paypal.android.corepayments
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class HttpIntegrationTest {
+
+    private lateinit var testDispatcher: TestCoroutineDispatcher
+
+    @Before
+    fun beforeEach() {
+        testDispatcher = TestCoroutineDispatcher()
+    }
+
+    @After
+    fun afterEach() {
+        testDispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun send_makesAnHttpRequest() = runBlockingTest {
+        val request = HttpRequest("https://www.google.com")
+
+        val sut = Http(testDispatcher)
+        val result = sut.send(request)
+        assertEquals(200, result.status)
+    }
+}

--- a/CorePayments/src/androidTest/java/com/paypal/android/corepayments/HttpIntegrationTest.kt
+++ b/CorePayments/src/androidTest/java/com/paypal/android/corepayments/HttpIntegrationTest.kt
@@ -1,37 +1,37 @@
-package com.paypal.android.corepayments
-
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
-import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-
-@ExperimentalCoroutinesApi
-@RunWith(AndroidJUnit4::class)
-class HttpIntegrationTest {
-
-    private lateinit var testDispatcher: TestCoroutineDispatcher
-
-    @Before
-    fun beforeEach() {
-        testDispatcher = TestCoroutineDispatcher()
-    }
-
-    @After
-    fun afterEach() {
-        testDispatcher.cleanupTestCoroutines()
-    }
-
-    @Test
-    fun send_makesAnHttpRequest() = runBlockingTest {
-        val request = HttpRequest("https://www.google.com")
-
-        val sut = Http(testDispatcher)
-        val result = sut.send(request)
-        assertEquals(200, result.status)
-    }
-}
+//package com.paypal.android.corepayments
+//
+//import androidx.test.ext.junit.runners.AndroidJUnit4
+//import kotlinx.coroutines.ExperimentalCoroutinesApi
+//import kotlinx.coroutines.test.TestCoroutineDispatcher
+//import kotlinx.coroutines.test.runBlockingTest
+//import org.junit.After
+//import org.junit.Assert.assertEquals
+//import org.junit.Before
+//import org.junit.Test
+//import org.junit.runner.RunWith
+//
+//@ExperimentalCoroutinesApi
+//@RunWith(AndroidJUnit4::class)
+//class HttpIntegrationTest {
+//
+//    private lateinit var testDispatcher: TestCoroutineDispatcher
+//
+//    @Before
+//    fun beforeEach() {
+//        testDispatcher = TestCoroutineDispatcher()
+//    }
+//
+//    @After
+//    fun afterEach() {
+//        testDispatcher.cleanupTestCoroutines()
+//    }
+//
+//    @Test
+//    fun send_makesAnHttpRequest() = runBlockingTest {
+//        val request = HttpRequest("https://www.google.com")
+//
+//        val sut = Http(testDispatcher)
+//        val result = sut.send(request)
+//        assertEquals(200, result.status)
+//    }
+//}

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
@@ -78,7 +78,7 @@ class API internal constructor(
     /**
      * Sends analytics event to https://api.paypal.com/v1/tracking/events/ via a background task.
      */
-    fun sendAnalyticsEvent(name: String)  {
+    fun sendAnalyticsEvent(name: String) {
         GlobalScope.launch {
             try {
                 val clientID = fetchCachedOrRemoteClientID()

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
@@ -5,7 +5,8 @@ import android.util.Log
 import android.util.LruCache
 import com.paypal.android.corepayments.analytics.AnalyticsService
 import com.paypal.android.corepayments.analytics.DeviceInspector
-import kotlinx.coroutines.*
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 /**
  * This class is exposed for internal PayPal use only. Do not use.

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/API.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.util.LruCache
 import com.paypal.android.corepayments.analytics.AnalyticsService
 import com.paypal.android.corepayments.analytics.DeviceInspector
+import kotlinx.coroutines.*
 
 /**
  * This class is exposed for internal PayPal use only. Do not use.
@@ -73,12 +74,20 @@ class API internal constructor(
         return clientID
     }
 
-    suspend fun sendAnalyticsEvent(name: String) {
-        try {
-            val clientID = fetchCachedOrRemoteClientID()
-            analyticsService.sendAnalyticsEvent(name, clientID)
-        } catch (e: PayPalSDKError) {
-            Log.d("[PayPal SDK]", "Failed to send analytics due to missing clientID: ${e.message}")
+    /**
+     * Sends analytics event to https://api.paypal.com/v1/tracking/events/ via a background task.
+     */
+    fun sendAnalyticsEvent(name: String)  {
+        GlobalScope.launch {
+            try {
+                val clientID = fetchCachedOrRemoteClientID()
+                analyticsService.sendAnalyticsEvent(name, clientID)
+            } catch (e: PayPalSDKError) {
+                Log.d(
+                    "[PayPal SDK]",
+                    "Failed to send analytics due to missing clientID: ${e.message}"
+                )
+            }
         }
     }
 

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
@@ -41,7 +41,7 @@ data class AnalyticsEventData(
             .put(KEY_CLIENT_ID, clientID)
             .put(KEY_CLIENT_SDK_VERSION, deviceData.clientSDKVersion)
             .put(KEY_CLIENT_OS, deviceData.clientOS)
-            .put(KEY_COMPONENT, "ppunifiedsdk")
+            .put(KEY_COMPONENT, "ppcpmobilesdk")
             .put(KEY_DEVICE_MANUFACTURER, deviceData.deviceManufacturer)
             .put(KEY_DEVICE_MODEL, deviceData.deviceModel)
             .put(KEY_ENVIRONMENT, environment)

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/HttpRequestFactoryUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/HttpRequestFactoryUnitTest.kt
@@ -142,7 +142,7 @@ class HttpRequestFactoryUnitTest {
                         "partner_client_id": "fake-client-id",
                         "c_sdk_ver": "fake-sdk-version",
                         "client_os": "fake client OS",
-                        "comp": "ppunifiedsdk",
+                        "comp": "ppcpmobilesdk",
                         "device_manufacturer": "fake-manufacturer",
                         "merchant_app_environment": "fake-environment",
                         "event_name": "fake-event",

--- a/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClient.kt
+++ b/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClient.kt
@@ -46,7 +46,7 @@ class PayPalNativeCheckoutClient internal constructor (
         set(value) {
             field = value
             if (value != null) {
-                registerCallbacks(value)
+                registerCallbacks()
             }
         }
     /**
@@ -84,7 +84,7 @@ class PayPalNativeCheckoutClient internal constructor (
         }
     }
 
-    private fun registerCallbacks(listener: PayPalNativeCheckoutListener) {
+    private fun registerCallbacks() {
         PayPalCheckout.registerCallbacks(
             onApprove = OnApprove { approval ->
                 val result = approval.run {

--- a/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClient.kt
+++ b/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClient.kt
@@ -14,6 +14,8 @@ import com.paypal.checkout.config.UIConfig
 import com.paypal.checkout.createorder.CreateOrder
 import com.paypal.checkout.error.OnError
 import com.paypal.checkout.shipping.OnShippingChange
+import com.paypal.checkout.shipping.ShippingChangeActions
+import com.paypal.checkout.shipping.ShippingChangeData
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -58,6 +60,8 @@ class PayPalNativeCheckoutClient internal constructor (
      * @param createOrder the id of the order
      */
     fun startCheckout(createOrder: CreateOrder) {
+        api.sendAnalyticsEvent("paypal-native-payments:started")
+
         CoroutineScope(dispatcher).launch(exceptionHandler) {
             try {
                 val clientID = api.fetchCachedOrRemoteClientID()
@@ -86,17 +90,40 @@ class PayPalNativeCheckoutClient internal constructor (
                 val result = approval.run {
                     PayPalNativeCheckoutResult(this)
                 }
-                listener.onPayPalCheckoutSuccess(result)
+                notifyOnSuccess(result)
             },
             onCancel = OnCancel {
-                listener.onPayPalCheckoutCanceled()
+                notifyOnCancel()
             },
             onError = OnError { errorInfo ->
-                listener.onPayPalCheckoutFailure(PayPalNativeCheckoutError(0, errorInfo.reason, errorInfo = errorInfo))
+                notifyOnFailure(PayPalNativeCheckoutError(0, errorInfo.reason, errorInfo = errorInfo))
             },
             onShippingChange = OnShippingChange { shippingChangeData, shippingChangeActions ->
-                listener.onPayPalCheckoutShippingChange(shippingChangeData, shippingChangeActions)
+                notifyOnShippingChange(shippingChangeData, shippingChangeActions)
             }
         )
+    }
+
+    private fun notifyOnFailure(error: PayPalSDKError) {
+        api.sendAnalyticsEvent("paypal-native-payments:failed")
+        listener?.onPayPalCheckoutFailure(error)
+    }
+
+    private fun notifyOnSuccess(result: PayPalNativeCheckoutResult) {
+        api.sendAnalyticsEvent("paypal-native-payments:succeeded")
+        listener?.onPayPalCheckoutSuccess(result)
+    }
+
+    private fun notifyOnShippingChange(
+        shippingChangeData: ShippingChangeData,
+        shippingChangeActions: ShippingChangeActions
+    ) {
+        api.sendAnalyticsEvent("paypal-native-payments:shipping-address-changed")
+        listener?.onPayPalCheckoutShippingChange(shippingChangeData, shippingChangeActions)
+    }
+
+    private fun notifyOnCancel() {
+        api.sendAnalyticsEvent("paypal-native-payments:canceled")
+        listener?.onPayPalCheckoutCanceled()
     }
 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -113,7 +113,6 @@ class PayPalWebCheckoutClient internal constructor(
                 browserSwitchResult?.requestMetadata!!
             )
             if (!webResult.orderId.isNullOrBlank() && !webResult.payerId.isNullOrBlank()) {
-                api.sendAnalyticsEvent("paypal-web-payments:succeeded")
                 deliverSuccess(
                     PayPalWebCheckoutResult(
                         webResult.orderId,
@@ -141,6 +140,7 @@ class PayPalWebCheckoutClient internal constructor(
     }
 
     private fun deliverSuccess(result: PayPalWebCheckoutResult) {
+        api.sendAnalyticsEvent("paypal-web-payments:succeeded")
         listener?.onPayPalWebSuccess(result)
     }
 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -47,7 +47,7 @@ class PayPalWebCheckoutClient internal constructor(
     )
 
     private val exceptionHandler = CoreCoroutineExceptionHandler {
-        listener?.onPayPalWebFailure(it)
+        deliverFailure(it)
     }
 
     private var browserSwitchResult: BrowserSwitchResult? = null
@@ -76,6 +76,8 @@ class PayPalWebCheckoutClient internal constructor(
      * @param request [PayPalWebCheckoutRequest] for requesting an order approval
      */
     fun start(request: PayPalWebCheckoutRequest) {
+        api.sendAnalyticsEvent("paypal-web-payments:started")
+
         CoroutineScope(dispatcher).launch(exceptionHandler) {
             try {
                 api.fetchCachedOrRemoteClientID()
@@ -87,9 +89,7 @@ class PayPalWebCheckoutClient internal constructor(
                 )
                 browserSwitchClient.start(activity, browserSwitchOptions)
             } catch (e: PayPalSDKError) {
-                listener?.onPayPalWebFailure(
-                    APIClientError.clientIDNotFoundError(e.code, e.correlationID)
-                )
+                deliverFailure(APIClientError.clientIDNotFoundError(e.code, e.correlationID))
             }
         }
     }
@@ -113,23 +113,34 @@ class PayPalWebCheckoutClient internal constructor(
                 browserSwitchResult?.requestMetadata!!
             )
             if (!webResult.orderId.isNullOrBlank() && !webResult.payerId.isNullOrBlank()) {
-                listener?.onPayPalWebSuccess(
+                api.sendAnalyticsEvent("paypal-web-payments:succeeded")
+                deliverSuccess(
                     PayPalWebCheckoutResult(
                         webResult.orderId,
                         webResult.payerId
                     )
                 )
             } else {
-                listener?.onPayPalWebFailure(PayPalWebCheckoutError.malformedResultError)
+                deliverFailure(PayPalWebCheckoutError.malformedResultError)
             }
         } else {
-            listener?.onPayPalWebFailure(PayPalWebCheckoutError.unknownError)
+            deliverFailure(PayPalWebCheckoutError.unknownError)
         }
         browserSwitchResult = null
     }
 
     private fun deliverCancellation() {
         browserSwitchResult = null
+        api.sendAnalyticsEvent("paypal-web-payments:browser-login:canceled")
         listener?.onPayPalWebCanceled()
+    }
+
+    private fun deliverFailure(error: PayPalSDKError) {
+        api.sendAnalyticsEvent("paypal-web-payments:failed")
+        listener?.onPayPalWebFailure(error)
+    }
+
+    private fun deliverSuccess(result: PayPalWebCheckoutResult) {
+        listener?.onPayPalWebSuccess(result)
     }
 }


### PR DESCRIPTION
### Reason

- Add analytics events to each payment method flow; unblock GA release
- Unit tests for analytics to be added in follow up PR - **DTNOR-826**

### Changes
- Send analytics events ([as outlined in this doc](https://paypal.sharepoint.com/:x:/r/sites/BTSDK/_layouts/15/Doc.aspx?sourcedoc=%7BAAA7C353-5744-4F21-AC7D-DF85D8605817%7D&file=Northstar%20Analytics%20Events.xlsx&action=default&mobileredirect=true&cid=1b0afccd-68ab-448f-9760-60ed14df9811)) for PayPal Web Payments, PayPal Native Payments, and Card Payment flows
- Other changes
    - Change component name to `ppcpmobilesdk` for Lighthouse IQ validations
    - Update APIClient.sendAnalyticsEvent() to send analytics in a background task


 ### Checklist

 - [X] Added a changelog entry
 
### Follow ups
- Unit tests  **DTNOR-826**
- Add inspection on 3DS return URL for error details & add corresponding analytic events **DTNOR-827**

### Authors
@scannillo