### PR TITLE
Use Zulu Java-lang distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
             #After decoding the secret key, place the file in ~ /. Gradle/ secring.gpg
       - name: Decode Signing Key
         uses: ./.github/actions/decode_signing_key_action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
           #After decoding the secret key, place the file in ~ /. Gradle/ secring.gpg
       - name: Decode Signing Key
         uses: ./.github/actions/decode_signing_key_action
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
         with:
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
         with:
@@ -75,7 +75,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
         with:
@@ -90,7 +90,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
         with:
@@ -105,7 +105,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
         with:
@@ -131,7 +131,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Decode Signing Key
         uses: ./.github/actions/decode_signing_key_action
         with:

--- a/.github/workflows/release_snapshot.yml
+++ b/.github/workflows/release_snapshot.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
           #After decoding the secret key, place the file in ~ /. Gradle/ secring.gpg
       - name: Decode Signing Key
         uses: ./.github/actions/decode_signing_key_action
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
         with:
@@ -63,7 +63,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
         with:
@@ -78,7 +78,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
         with:
@@ -93,7 +93,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
         with:
@@ -108,7 +108,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Run Unit Tests
         uses: ./.github/actions/unit_test_module
         with:
@@ -134,7 +134,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Decode Signing Key
         uses: ./.github/actions/decode_signing_key_action
         with:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Run Detekt
         run: ./gradlew detekt
 
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Lint
         run: ./gradlew lint
 
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
 
       # Assemble artifacts from main branch
       - name: Checkout Main Branch
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'microsoft'
+          distribution: 'zulu'
           java-version: '11'
 
       # Run Diffuse analysis

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Generate Code Coverage Reports
         run: ./gradlew jacocoTestReport
       - name: Upload Core coverage to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,6 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'microsoft'
+          distribution: 'zulu'
       - name: Run Unit Tests
         run: ./gradlew --stacktrace testDebug

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ]
 
     ext.versions = [
-            "kotlin"    : "1.6.21",
+            "kotlin"    : "1.8.10",
             "compose"   : "1.0.2",
             "navigation": "2.3.5",
             "hilt"      : "2.38.1"

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ buildscript {
             "androidxTestRunner"          : "androidx.test:runner:1.5.0",
             "androidxTestRules"           : "androidx.test:rules:1.5.0",
             "androidxTestUiAutomator"     : "androidx.test.uiautomator:uiautomator:2.2.0",
-            "mockk"                       : "io.mockk:mockk:1.12.0",
+            "mockk"                       : "io.mockk:mockk:1.13.4",
             "kotlinxAndroidCoroutinesTest": "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.1",
             "robolectric"                 : "org.robolectric:robolectric:4.6.1",
             "jsonAssert"                  : "org.skyscreamer:jsonassert:1.4.0",


### PR DESCRIPTION
### Reason for changes

[This failing Unit Test](https://github.com/paypal/Android-SDK/actions/runs/4324633053/jobs/7549724075) is unable to be replicated on our local machines, so we think the `microsoft` Java-lang distribution is leading to inconsistent behavior.

### Summary of changes

 - Update GH Actions yml files to use `zulu` Java distribution over `microsoft`
 

 ### Checklist

 - ~Added a changelog entry~

### Authors
@sshropshire @scannillo @KunJeongPark 