### PR TITLE
Simplify sendAnalyticEvent unit test

### DIFF
--- a/CorePayments/src/test/java/com/paypal/android/corepayments/APIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/APIUnitTest.kt
@@ -4,9 +4,7 @@ import com.paypal.android.corepayments.analytics.AnalyticsService
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/APIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/APIUnitTest.kt
@@ -188,12 +188,6 @@ class APIUnitTest {
     fun `sendAnalyticsEvent() event delegates it to analytics service`() = runTest {
         API.clientIDCache.put("fake-access-token", "fake-client-id")
 
-        coEvery {
-            analyticsService.sendAnalyticsEvent(
-                "sample.event.name",
-                "fake-client-id"
-            )
-        } just runs
         sut.sendAnalyticsEvent("sample.event.name")
         coVerify(exactly = 1) {
             analyticsService.sendAnalyticsEvent("sample.event.name", "fake-client-id")


### PR DESCRIPTION
### Summary of changes

 - Remove extraneous method stub for `AnalyticsService.sendAnalyticEvent()` in APIUnitTest.kt

 ### Checklist

 - ~Added a changelog entry~

### Authors
@scannillo @jaxdesmarais 
