### PR TITLE
NXO wrapper: Remove `Approval` from `PayPalNativeCheckoutResult`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PayPal Android SDK Release Notes
 
+## unreleased
+* `PayPalNativePayments`:
+  * Remove `Approval` from `PayPalNativeCheckoutResult`, expose only `orderID` and `payerID`
+
 ## 0.0.8 (2023-03-13)
 * `PayPalNativePayments`:
   *  Bump `PayPal Native Checkout` to `0.8.8` and add `return_url`

--- a/Demo/src/main/java/com/paypal/android/ui/paypal/PayPalNativeFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypal/PayPalNativeFragment.kt
@@ -158,9 +158,7 @@ class PayPalNativeFragment : Fragment() {
 
     private fun checkoutComplete(viewState: NativeCheckoutViewState.CheckoutComplete) {
         val content = "Order Id: ${viewState.orderId} \n" +
-                "Payer Id: ${viewState.payerId} \n" +
-                "Payment Id: ${viewState.paymentId} \n" +
-                "Billing Token: ${viewState.billingToken}"
+                "Payer Id: ${viewState.payerId} \n"
         setContent(getString(R.string.approved), content)
         hideProgress()
         with(binding) {

--- a/Demo/src/main/java/com/paypal/android/viewmodels/NativeCheckoutViewState.kt
+++ b/Demo/src/main/java/com/paypal/android/viewmodels/NativeCheckoutViewState.kt
@@ -14,8 +14,6 @@ sealed class NativeCheckoutViewState {
     class CheckoutError(val message: String? = null, val error: ErrorInfo? = null) : NativeCheckoutViewState()
     data class CheckoutComplete(
         val payerId: String?,
-        val orderId: String?,
-        val paymentId: String?,
-        val billingToken: String? = null,
+        val orderId: String?
     ) : NativeCheckoutViewState()
 }

--- a/Demo/src/main/java/com/paypal/android/viewmodels/PayPalNativeViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/viewmodels/PayPalNativeViewModel.kt
@@ -50,12 +50,10 @@ class PayPalNativeViewModel @Inject constructor(
         }
 
         override fun onPayPalCheckoutSuccess(result: PayPalNativeCheckoutResult) {
-            result.approval.data.apply {
+            result.apply {
                 internalState.postValue(NativeCheckoutViewState.CheckoutComplete(
-                    payerId,
-                    orderId,
-                    paymentId,
-                    billingToken
+                    payerID,
+                    orderID
                 ))
             }
         }

--- a/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClient.kt
+++ b/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClient.kt
@@ -88,7 +88,7 @@ class PayPalNativeCheckoutClient internal constructor (
         PayPalCheckout.registerCallbacks(
             onApprove = OnApprove { approval ->
                 val result = approval.run {
-                    PayPalNativeCheckoutResult(this)
+                    PayPalNativeCheckoutResult(this.data.orderId, this.data.payerId)
                 }
                 notifyOnSuccess(result)
             },

--- a/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutResult.kt
+++ b/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutResult.kt
@@ -1,10 +1,15 @@
 package com.paypal.android.paypalnativepayments
 
-import com.paypal.checkout.approve.Approval
-
 /**
  * A result passed to a [PayPalNativeCheckoutListener] when the PayPal flow completes successfully.
  */
 data class PayPalNativeCheckoutResult(
-    val approval: Approval,
+    /**
+     *  The order ID associated with the transaction
+     */
+    val orderID: String?,
+    /**
+     * The Payer ID (or user ID) associated with the transaction
+     */
+    val payerID: String?
 )

--- a/PayPalNativePayments/src/test/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClientTest.kt
+++ b/PayPalNativePayments/src/test/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClientTest.kt
@@ -241,7 +241,11 @@ class PayPalNativeCheckoutClientTest {
 
     @Test
     fun `when OnApprove is invoked, onPayPalSuccess is called`() {
-        val approval = mockk<Approval>()
+        val mockOrderID = "mock_order_id"
+        val mockPayerID = "mock_payer_id"
+        val approval = mockk<Approval>(relaxed = true)
+        every { approval.data.payerId } returns mockPayerID
+        every { approval.data.orderId } returns mockOrderID
         val onApproveSlot = slot<OnApprove>()
         val paypalCheckoutResultSlot = slot<PayPalNativeCheckoutResult>()
 
@@ -262,7 +266,8 @@ class PayPalNativeCheckoutClientTest {
         every {
             payPalClientListener.onPayPalCheckoutSuccess(capture(paypalCheckoutResultSlot))
         } answers {
-            assert(paypalCheckoutResultSlot.captured.approval == approval)
+            assert(paypalCheckoutResultSlot.captured.orderID == mockOrderID)
+            assert(paypalCheckoutResultSlot.captured.payerID == mockOrderID)
         }
 
         verify { payPalClientListener.onPayPalCheckoutSuccess(any()) }


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 [DTNOR-886](https://paypal.atlassian.net/browse/DTNOR-886?atlOrigin=eyJpIjoiNjc2N2NlNGVhZGU1NGIwMGFkOTIwYzJkOTA2NzVlYmMiLCJwIjoiaiJ9)
We hide the `Approval` object from merchants, we only expose `orderID` and `payerID` in `PayPalNativeCheckoutResult`
Demo app and unit test modified accordingly

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 
