### PR TITLE
Update `Card` docstrings to match iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PayPal Android SDK Release Notes
 
+## unreleased
+* CardPayments:
+  * Make `Card.securityCode` required
+
 ## 0.0.8 (2023-03-13)
 * `PayPalNativePayments`:
   *  Bump `PayPal Native Checkout` to `0.8.8` and add `return_url`

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/Card.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/Card.kt
@@ -3,30 +3,29 @@ package com.paypal.android.cardpayments
 import com.paypal.android.corepayments.Address
 
 /**
- * Initialize a card object
+ * Represents raw credit or debit card data provided by the customer.
  */
-
 data class Card @JvmOverloads constructor(
 
     /**
-     * The card number
+     * The primary account number (PAN) for the payment card
      */
     var number: String,
 
     /**
-     * 2-digit card expiration month
+     * The 2-digit card expiration month in `MM` format
      */
     val expirationMonth: String,
 
     /**
-     * 4-digit card expiration year
+     * The 4-digit card expiration year in `YYYY` format
      */
     val expirationYear: String,
 
     /**
-     * Optional. The card's security code (CVV, CVC, CVN, CVE, or CID)
+     * The three- or four-digit security code of the card. Also known as the CVV, CVC, CVN, CVE, or CID.
      */
-    var securityCode: String? = null,
+    var securityCode: String,
 
     /**
      * Optional. The card holder's name as it appears on the card
@@ -34,7 +33,7 @@ data class Card @JvmOverloads constructor(
     var cardholderName: String? = null,
 
     /**
-     * Optional. The portable international postal address
+     * Optional. The billing address
      */
     var billingAddress: Address? = null,
 )

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAPIUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAPIUnitTest.kt
@@ -44,7 +44,7 @@ class CardAPIUnitTest {
     private val requestFactory = mockk<CardRequestFactory>()
     private val paymentsJSON = mockk<PaymentsJSON>()
 
-    private val card = Card("4111111111111111", "01", "24")
+    private val card = Card("4111111111111111", "01", "24", "123")
     private val orderID = "sample-order-id"
     private val apiRequest = APIRequest("/sample/path", HttpMethod.POST, null)
 

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
@@ -39,7 +39,7 @@ import strikt.assertions.isEqualTo
 @RunWith(RobolectricTestRunner::class)
 class CardClientUnitTest {
 
-    private val card = Card("4111111111111111", "01", "24")
+    private val card = Card("4111111111111111", "01", "24", "123")
     private val orderID = "sample-order-id"
 
     private val cardRequest = CardRequest(orderID, card, "return_url")

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardRequestFactoryUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardRequestFactoryUnitTest.kt
@@ -82,7 +82,7 @@ class CardRequestFactoryUnitTest {
     @Test
     fun `it omits optional params when they are not set`() {
         val card =
-            Card(number = "4111111111111111", expirationMonth = "01", expirationYear = "2022")
+            Card(number = "4111111111111111", expirationMonth = "01", expirationYear = "2022", "123")
 
         val cardRequest = CardRequest(orderID, card, returnUrl)
         val apiRequest = sut.createConfirmPaymentSourceRequest(cardRequest)
@@ -114,7 +114,7 @@ class CardRequestFactoryUnitTest {
     @Test
     fun `it request 3DS strong consumer authentication with SCA_ALWAYS`() {
         val card =
-            Card(number = "4111111111111111", expirationMonth = "01", expirationYear = "2022")
+            Card(number = "4111111111111111", expirationMonth = "01", expirationYear = "2022", "123")
 
         val cardRequest = CardRequest(orderID, card, returnUrl, SCA.SCA_ALWAYS)
 

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardRequestFactoryUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardRequestFactoryUnitTest.kt
@@ -95,6 +95,7 @@ class CardRequestFactoryUnitTest {
                 "card": {
                   "number": "4111111111111111",
                   "expiry": "2022-01",
+                  "security_code": "123",
                   "attributes": {
                     "verification": {
                       "method": "SCA_WHEN_REQUIRED"
@@ -128,6 +129,7 @@ class CardRequestFactoryUnitTest {
                 "card": {
                   "number": "4111111111111111",
                   "expiry": "2022-01",
+                  "security_code": "123",
                   "attributes": {
                     "verification": {
                       "method": "SCA_ALWAYS"


### PR DESCRIPTION
### Reason for changes

 - [This PR ](https://github.com/paypal/iOS-SDK/pull/135)on iOS revealed inconsistency in docstrings on the `Card` type

### Summary of changes

- Match `Card` docstrings to match iOS
- Make `Card.securityCode` non-optional (matching iOS PPCP & BT)

 ### Checklist

 - [X] Added a changelog entry

### Authors
@scannillo
