### PR TITLE
PayPalNativePayments: change MXO  from `api` to `implementation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   * Remove `Approval` from `PayPalNativeCheckoutResult`, expose only `orderID` and `payerID`
   * Add `PayPalNativeCheckoutRequest` to `startCheckout`, removing `CreateOrder` callback
   * Remove `onPayPalCheckoutShippingChange` method from `PayPalNativeCheckoutListener`.
-  * Add `PayPalNativeShippingListener` to receive events on changes in shipping information. Add `PayPalNativeShippingAddress`, `PayPalNativeShippingMethod` and `PayPalNativeShippingActions`
+  * Add `PayPalNativeShippingListener` to receive events on changes in shipping information. Add `PayPalNativeShippingAddress`, `PayPalNativeShippingMethod` and `PayPalNativePaysheetActions`
+  * Remove `PayPalCheckout` as an `api` dependency
 
 ## 0.0.8 (2023-03-13)
 * `PayPalNativePayments`:

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -81,6 +81,11 @@ dependencies {
     implementation deps.androidxLifecycleRuntimeKtx
     implementation deps.fragmentKtx
 
+    // TODO: remove dependency when we don't relay on nxo models anymore
+    implementation (deps.nativeCheckout) {
+        exclude module: 'data-collector'
+    }
+
     implementation deps.composeUi
     implementation deps.composeUiTooling
     implementation deps.composeRuntimeLivedata

--- a/Demo/src/main/java/com/paypal/android/api/services/SDKSampleServerApi.kt
+++ b/Demo/src/main/java/com/paypal/android/api/services/SDKSampleServerApi.kt
@@ -21,7 +21,7 @@ interface SDKSampleServerApi {
     suspend fun createOrder(@Body jsonObject: JsonObject): Order
 
     @POST("/orders")
-    suspend fun createOrder(@Body order: com.paypal.checkout.order.Order): Order
+    suspend fun createOrder(@Body order: com.paypal.checkout.order.OrderRequest): Order
 
     @POST("/access_tokens")
     suspend fun fetchAccessToken(): AccessToken

--- a/Demo/src/main/java/com/paypal/android/utils/OrderUtils.kt
+++ b/Demo/src/main/java/com/paypal/android/utils/OrderUtils.kt
@@ -13,7 +13,7 @@ import com.paypal.checkout.order.AppContext
 import com.paypal.checkout.order.BreakDown
 import com.paypal.checkout.order.Items
 import com.paypal.checkout.order.Options
-import com.paypal.checkout.order.Order
+import com.paypal.checkout.order.OrderRequest
 import com.paypal.checkout.order.PurchaseUnit
 import com.paypal.checkout.order.Shipping
 import com.paypal.checkout.order.UnitAmount
@@ -28,9 +28,9 @@ object OrderUtils {
         currency: CurrencyCode = CurrencyCode.USD,
         orderIntent: OrderIntent = OrderIntent.CAPTURE,
         processingInstruction: ProcessingInstruction? = null
-    ): Order {
+    ): OrderRequest {
 
-        return Order.Builder()
+        return OrderRequest.Builder()
             .intent(orderIntent)
             .processingInstruction(processingInstruction)
             .appContext(
@@ -99,7 +99,7 @@ object OrderUtils {
                     .itemTotal(
                         UnitAmount.Builder()
                             .currencyCode(currency)
-                            .value("00.00")
+                            .value(value)
                             .build()
                     )
                     .shipping(
@@ -117,7 +117,7 @@ object OrderUtils {
                     .taxTotal(
                         UnitAmount.Builder()
                             .currencyCode(currency)
-                            .value(value)
+                            .value("00.00")
                             .build()
                     )
                     .shippingDiscount(

--- a/PayPalNativePayments/build.gradle
+++ b/PayPalNativePayments/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     api project(':CorePayments')
     implementation project(':FraudProtection')
 
-    api (deps.nativeCheckout) {
+    implementation (deps.nativeCheckout) {
         exclude module: 'data-collector'
     }
 

--- a/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeShippingAddress.kt
+++ b/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/PayPalNativeShippingAddress.kt
@@ -1,7 +1,7 @@
 package com.paypal.android.paypalnativepayments
 
-import com.paypal.checkout.order.Address
-// TODO: this object is diferent in iOS, check with MXO for better consistency (missing addressId)
+import com.paypal.checkout.shipping.ShippingChangeAddress
+
 /**
  * The user's selected shipping address via the PayPal Native Checkout UI.
  */
@@ -33,10 +33,10 @@ data class PayPalNativeShippingAddress internal constructor(
     val countryCode: String?
 ) {
 
-    internal constructor(address: Address) : this(
-        address.adminArea1,
-        address.adminArea2,
-        address.postalCode,
-        address.countryCode
+    internal constructor(shippingChangeAddress: ShippingChangeAddress) : this(
+        shippingChangeAddress.adminArea1,
+        shippingChangeAddress.adminArea2,
+        shippingChangeAddress.postalCode,
+        shippingChangeAddress.countryCode
     )
 }

--- a/PayPalNativePayments/src/test/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClientTest.kt
+++ b/PayPalNativePayments/src/test/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClientTest.kt
@@ -12,7 +12,6 @@ import com.paypal.checkout.cancel.OnCancel
 import com.paypal.checkout.config.CheckoutConfig
 import com.paypal.checkout.error.ErrorInfo
 import com.paypal.checkout.error.OnError
-import com.paypal.checkout.order.Address
 import com.paypal.checkout.order.Options
 import com.paypal.checkout.shipping.OnShippingChange
 import com.paypal.checkout.shipping.ShippingChangeActions

--- a/PayPalNativePayments/src/test/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClientTest.kt
+++ b/PayPalNativePayments/src/test/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClientTest.kt
@@ -16,6 +16,7 @@ import com.paypal.checkout.order.Address
 import com.paypal.checkout.order.Options
 import com.paypal.checkout.shipping.OnShippingChange
 import com.paypal.checkout.shipping.ShippingChangeActions
+import com.paypal.checkout.shipping.ShippingChangeAddress
 import com.paypal.checkout.shipping.ShippingChangeData
 import com.paypal.checkout.shipping.ShippingChangeType
 import io.mockk.coEvery
@@ -333,7 +334,7 @@ class PayPalNativeCheckoutClientTest {
         val shippingData = mockk<ShippingChangeData>(relaxed = true)
 
         every { shippingData.shippingChangeType } returns ShippingChangeType.ADDRESS_CHANGE
-        every { shippingData.shippingAddress } returns Address(countryCode = mockCountryCode)
+        every { shippingData.shippingAddress } returns ShippingChangeAddress(countryCode = mockCountryCode)
 
         every {
             PayPalCheckout.registerCallbacks(

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ buildscript {
             "json" : "org.json:json:20220320",
 
             // PayPal
-            "nativeCheckout"              : "com.paypal.checkout:android-sdk:0.8.8",
+            "nativeCheckout"              : "com.paypal.checkout:android-sdk:0.112.0",
 
             // Release modules
             "cardPayments"                : "com.paypal.android:card-payments:${modules.sdkVersionName}",


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Changes MXO dependency from `api` to `implementation`
 - Added MXO as dependency to demo app because we still rely on their value objects
 - Bump MXO to latest `0.112.0`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 
