### PR TITLE
Add GH Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Create a report to help us improve
+body:
+- type: input
+  attributes:
+    label: PayPal Android SDK Version
+    placeholder: "e.g. 1.12.0"
+  validations:
+    required: true
+- type: dropdown
+  attributes:
+    label: Environment
+    options:
+      - Sandbox
+      - Live
+      - Both
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Android Version & Device
+    placeholder: "e.g Google Pixel 6a - Android 12.0"
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: PayPal dependencies
+    placeholder: |
+      <!-- Examples -->
+      <!-- implementation 'com.paypal.android:card-payments:x.y.z' -->
+      <!-- implementation 'com.paypal.android:paypal-web-payments:x.y.z' -->
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe the bug
+    description: Description of what the bug is. Please include as many details as possible.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: To reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. Go to '...'
+      2. Click on '....'
+      3. See error
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected behavior
+    description: Description of what you expected to happen.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Screenshots
+    description: If applicable, add screenshots to help explain your problem.
+    placeholder: |
+      Do not reveal sensitive data. For example, credit card numbers & customer credentials.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Developer Support
+    url: https://www.paypal-support.com/
+    about: If you need help troubleshooting your integration, reach out to PayPal Support.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,17 @@
+name: Feature request
+description: Suggest an idea for our SDK
+body:
+- type: textarea
+  attributes:
+    label: Is your feature request related to a problem? Please describe.
+    description: A clear and concise description of what the problem is.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Describe the solution you'd like.
+    description: Description of what you want to happen.
+    placeholder: |
+      Follow the [user story](https://en.wikipedia.org/wiki/User_story) format to clearly describe the use case.
+  validations:
+    required: false


### PR DESCRIPTION
### Summary of changes

 - This PR adds the same[ GH Issue template as braintree_android](https://github.com/braintree/braintree_android/issues/new/choose)
- I excluded the part `Only open a GitHub issue if you've found an issue with our SDK.` because we want to encourage merchants open issues at this point in development.
    - We can re-add this verbiage once SDK adoption picks up.

 ### Checklist

 - ~Added a changelog entry~

### Authors
@scannillo 
