### PR TITLE
Rename repo URL 

### DIFF
--- a/MOBILE_CHECKOUT_MIGRATION_GUIDE.md
+++ b/MOBILE_CHECKOUT_MIGRATION_GUIDE.md
@@ -1,6 +1,6 @@
 # PayPal Mobile Checkout SDK: Migration Guide
 
-This guide outlines how to update your integration from using the soon-to-be-deprecated [PayPal Mobile Checkout SDK](https://developer.paypal.com/limited-release/paypal-mobile-checkout/) to the new PayPal Mobile [Android SDK](https://github.com/paypal/Android-SDK/).
+This guide outlines how to update your integration from using the soon-to-be-deprecated [PayPal Mobile Checkout SDK](https://developer.paypal.com/limited-release/paypal-mobile-checkout/) to the new PayPal Mobile [Android SDK](https://github.com/paypal/paypal-android/).
 
 ## Pre-Requisites
 In order to use this migration guide, you must:
@@ -17,7 +17,7 @@ In order to use this migration guide, you must:
 
 1. Add the new SDK to your app
 
-    Add the PayPal SDK to your app-level build.gradle file. See the [CHANGELOG](https://github.com/paypal/Android-SDK/blob/main/CHANGELOG.md) for the most recent version.
+    Add the PayPal SDK to your app-level build.gradle file. See the [CHANGELOG](https://github.com/paypal/paypal-android/blob/main/CHANGELOG.md) for the most recent version.
 
     ```
     dependencies {

--- a/adr/1-remove-graphql-generics/index.md
+++ b/adr/1-remove-graphql-generics/index.md
@@ -36,8 +36,8 @@ The proposed GraphQL refactor will make the code less DRY in some ways, but the 
 
 We will also gain more flexibility by removing abstraction through generics, since the API layer will now have access to the full `HttpRequest` object.
 
-[1]: https://github.com/paypal/Android-SDK/blob/1fa0b256c00dc0b95872c21cc4865e6f58d4dd88/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/fundingEligibility/FundingEligibilityQueryTest.kt#L12
-[2]: https://github.com/paypal/Android-SDK/blob/1fa0b256c00dc0b95872c21cc4865e6f58d4dd88/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/fundingEligibility/FundingEligibilityQuery.kt#L10
+[1]: https://github.com/paypal/paypal-android/blob/1fa0b256c00dc0b95872c21cc4865e6f58d4dd88/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/fundingEligibility/FundingEligibilityQueryTest.kt#L12
+[2]: https://github.com/paypal/paypal-android/blob/1fa0b256c00dc0b95872c21cc4865e6f58d4dd88/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/fundingEligibility/FundingEligibilityQuery.kt#L10
 [3]: https://www.baeldung.com/cs/layered-architecture
 [4]: https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/
 [5]: https://www.apollographql.com/docs/react/data/operation-best-practices/#use-graphql-variables-to-provide-arguments
@@ -46,4 +46,4 @@ We will also gain more flexibility by removing abstraction through generics, sin
 [8]: https://refactoring.guru/design-patterns/strategy
 [9]: https://www.swiftbysundell.com/basics/codable/
 [10]: https://martinfowler.com/bliki/ValueObject.html
-[11]: https://github.com/paypal/Android-SDK/blob/71dcb84d08fd9be88d1df9c404b812d636678891/CorePayments/src/main/java/com/paypal/android/corepayments/api/EligibilityAPI.kt#L21
+[11]: https://github.com/paypal/paypal-android/blob/71dcb84d08fd9be88d1df9c404b812d636678891/CorePayments/src/main/java/com/paypal/android/corepayments/api/EligibilityAPI.kt#L21

--- a/adr/2-remove-core-api-and-http-request-factories/index.md
+++ b/adr/2-remove-core-api-and-http-request-factories/index.md
@@ -49,5 +49,5 @@ Feature Clients will have a dependency on each microservice they use. A side eff
 1. A decrease in code coverage until we pick a suitable dependency injection framework
 
 [1]: https://nakabonne.dev/posts/depth-of-module/
-[2]: https://github.com/paypal/Android-SDK/blob/da0f20c22b0c958f6f5b97a78e4d0814484d5ff2/CorePayments/src/main/java/com/paypal/android/corepayments/HttpRequestFactory.kt#L7
+[2]: https://github.com/paypal/paypal-android/blob/da0f20c22b0c958f6f5b97a78e4d0814484d5ff2/CorePayments/src/main/java/com/paypal/android/corepayments/HttpRequestFactory.kt#L7
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,9 +24,9 @@ POM_PACKAGING=aar
 #TODO: needs to be defined
 POM_URL=not_defined
 
-POM_SCM_URL=https://github.com/paypal/Android-SDK
-POM_SCM_CONNECTION=scm:git@github.com:paypal/Android-SDK.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:paypal/Android-SDK.git
+POM_SCM_URL=https://github.com/paypal/paypal-android
+POM_SCM_CONNECTION=scm:git@github.com:paypal/paypal-android.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:paypal/paypal-android.git
 
 POM_LICENCE_NAME=The Apache License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
### Summary of changes

 - Rename references to repo URL from `www.github.com/paypal/Android-SDK` to `www.github.com/paypal/paypal-android`

 ### Checklist

 - ~Added a changelog entry~

### Authors
@scannillo 
