### PR TITLE
Remove STAGING env; send 'production' over 'live' to FPTI

### DIFF
--- a/CorePayments/src/main/java/com/paypal/android/corepayments/Environment.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/Environment.kt
@@ -8,9 +8,5 @@ enum class Environment(val url: String, val graphQLEndpoint: String) {
     SANDBOX(
         "https://api.sandbox.paypal.com",
         "https://www.sandbox.paypal.com"
-    ),
-    STAGING(
-        "https://api.msmaster.qa.paypal.com",
-        "https://www.msmaster.qa.paypal.com"
     )
 }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventsAPI.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventsAPI.kt
@@ -65,7 +65,7 @@ class TrackingEventsAPI internal constructor(
         const val KEY_COMPONENT = "comp"
         const val KEY_DEVICE_MANUFACTURER = "device_manufacturer"
         const val KEY_DEVICE_MODEL = "mobile_device_model"
-        const val KEY_ENVIRONMENT = "merchant_app_environment"
+        const val KEY_ENVIRONMENT = "merchant_sdk_env"
         const val KEY_EVENT_NAME = "event_name"
         const val KEY_EVENT_SOURCE = "event_source"
         const val KEY_IS_SIMULATOR = "is_simulator"

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
@@ -43,7 +43,7 @@ class AnalyticsService internal constructor(
             try {
                 val deviceData = deviceInspector.inspect()
                 val analyticsEventData = AnalyticsEventData(
-                    environment.name.lowercase(),
+                    if (environment == Environment.SANDBOX) "sandbox" else "production",
                     name,
                     timestamp,
                     orderId

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/EnvironmentUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/EnvironmentUnitTest.kt
@@ -14,9 +14,4 @@ class EnvironmentUnitTest {
     fun `it should return the correct url for the SANDBOX environment`() {
         assertEquals("https://api.sandbox.paypal.com", Environment.SANDBOX.url)
     }
-
-    @Test
-    fun `it should return the correct url for the STAGING environment`() {
-        assertEquals("https://api.msmaster.qa.paypal.com", Environment.STAGING.url)
-    }
 }

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/RestClientUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/RestClientUnitTest.kt
@@ -27,7 +27,6 @@ class RestClientUnitTest {
     private val httpSuccessResponse = HttpResponse(200)
 
     private val sandboxConfig = CoreConfig("fake-sandbox-client-id", Environment.SANDBOX)
-    private val stagingConfig = CoreConfig("fake-staging-client-id", Environment.STAGING)
     private val liveConfig = CoreConfig("fake-live-client-id", Environment.LIVE)
 
     private lateinit var http: Http
@@ -50,17 +49,6 @@ class RestClientUnitTest {
 
         val httpRequest = httpRequestSlot.captured
         assertEquals(URL("https://api.sandbox.paypal.com/sample/path"), httpRequest.url)
-    }
-
-    @Test
-    fun `send() should properly format the url for the staging environment`() = runTest {
-        coEvery { http.send(capture(httpRequestSlot)) } returns httpSuccessResponse
-
-        sut = RestClient(stagingConfig, http, "en_US")
-        sut.send(apiGETRequest)
-
-        val httpRequest = httpRequestSlot.captured
-        assertEquals(URL("https://api.msmaster.qa.paypal.com/sample/path"), httpRequest.url)
     }
 
     @Test

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/TrackingEventsAPIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/TrackingEventsAPIUnitTest.kt
@@ -75,7 +75,7 @@ class TrackingEventsAPIUnitTest {
                         "client_os": "fake client OS",
                         "comp": "ppcpmobilesdk",
                         "device_manufacturer": "fake-manufacturer",
-                        "merchant_app_environment": "fake-environment",
+                        "merchant_sdk_env": "fake-environment",
                         "event_name": "fake-event",
                         "event_source": "mobile-native",
                         "is_simulator": true,

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/analytics/AnalyticsServiceTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/analytics/AnalyticsServiceTest.kt
@@ -107,7 +107,7 @@ class AnalyticsServiceTest {
         advanceUntilIdle()
 
         val analyticsEventData = analyticsEventDataSlot.captured
-        assertEquals("live", analyticsEventData.environment)
+        assertEquals("production", analyticsEventData.environment)
     }
 
     private fun createAnalyticsService(

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/common/GraphQLClientUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/common/GraphQLClientUnitTest.kt
@@ -28,7 +28,6 @@ import java.net.URL
 internal class GraphQLClientUnitTest {
 
     private val sandboxConfig = CoreConfig("fake-client-id", Environment.SANDBOX)
-    private val stagingConfig = CoreConfig("fake-client-id", Environment.STAGING)
     private val liveConfig = CoreConfig("fake-client-id", Environment.LIVE)
 
     private val graphQLRequestBody = JSONObject("""{"fake":"json"}""")

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/common/GraphQLClientUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/common/GraphQLClientUnitTest.kt
@@ -55,17 +55,6 @@ internal class GraphQLClientUnitTest {
     }
 
     @Test
-    fun `send sends an http request to staging environment`() = runTest {
-        sut = GraphQLClient(stagingConfig, http)
-        sut.send(graphQLRequestBody)
-        coVerify { http.send(capture(httpRequestSlot)) }
-
-        val httpRequest = httpRequestSlot.captured
-        assertEquals(URL("https://www.msmaster.qa.paypal.com/graphql"), httpRequest.url)
-        assertEquals("https://www.msmaster.qa.paypal.com", httpRequest.headers["Origin"])
-    }
-
-    @Test
     fun `send sends an http request to live environment`() = runTest {
         sut = GraphQLClient(liveConfig, http)
         sut.send(graphQLRequestBody)

--- a/FraudProtection/src/main/java/com/paypal/android/fraudprotection/PayPalDataCollectorEnvironment.kt
+++ b/FraudProtection/src/main/java/com/paypal/android/fraudprotection/PayPalDataCollectorEnvironment.kt
@@ -5,12 +5,10 @@ package com.paypal.android.fraudprotection
  */
 enum class PayPalDataCollectorEnvironment {
     LIVE,
-    SANDBOX,
-    STAGING
+    SANDBOX
 }
 
 internal fun getMagnesEnvironment(environment: PayPalDataCollectorEnvironment) = when (environment) {
     PayPalDataCollectorEnvironment.LIVE -> lib.android.paypal.com.magnessdk.Environment.LIVE
-    PayPalDataCollectorEnvironment.STAGING -> lib.android.paypal.com.magnessdk.Environment.STAGE
     PayPalDataCollectorEnvironment.SANDBOX -> lib.android.paypal.com.magnessdk.Environment.SANDBOX
 }

--- a/FraudProtection/src/test/java/com/paypal/android/fraudprotection/PayPalDataCollectorUnitTest.kt
+++ b/FraudProtection/src/test/java/com/paypal/android/fraudprotection/PayPalDataCollectorUnitTest.kt
@@ -41,24 +41,6 @@ class PayPalDataCollectorUnitTest {
     }
 
     @Test
-    fun `when environment is STAGING, magnes settings environment is STAGE`() {
-        val appGUID = UUID.randomUUID().toString()
-        val mockMagnesSDK = mockk<MagnesSDK>(relaxed = true)
-        val mockUUIDHelper = mockk<UUIDHelper>(relaxed = true)
-        val magnesSettingsSlot = slot<MagnesSettings>()
-
-        every { mockUUIDHelper.getInstallationGUID(any()) } returns appGUID
-
-        val sut = PayPalDataCollector(PayPalDataCollectorEnvironment.STAGING, mockMagnesSDK, mockUUIDHelper)
-        sut.getClientMetadataId(mockk(relaxed = true))
-
-        verify { mockMagnesSDK.setUp(capture(magnesSettingsSlot)) }
-
-        val magnesSettings = magnesSettingsSlot.captured
-        assertEquals(magnesSettings.environment, Environment.STAGE)
-    }
-
-    @Test
     fun `when environment is LIVE, magnes settings environment is LIVE`() {
         val appGUID = UUID.randomUUID().toString()
         val mockMagnesSDK = mockk<MagnesSDK>(relaxed = true)

--- a/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/Utils.kt
+++ b/PayPalNativePayments/src/main/java/com/paypal/android/paypalnativepayments/Utils.kt
@@ -4,5 +4,4 @@ import com.paypal.android.corepayments.Environment
 internal fun getPayPalEnvironment(environment: Environment) = when (environment) {
     Environment.LIVE -> com.paypal.checkout.config.Environment.LIVE
     Environment.SANDBOX -> com.paypal.checkout.config.Environment.SANDBOX
-    Environment.STAGING -> com.paypal.checkout.config.Environment.STAGE
 }

--- a/PayPalNativePayments/src/test/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClientTest.kt
+++ b/PayPalNativePayments/src/test/java/com/paypal/android/paypalnativepayments/PayPalNativeCheckoutClientTest.kt
@@ -159,31 +159,6 @@ class PayPalNativeCheckoutClientTest {
         }
 
     @Test
-    fun `when checkout is invoked with STAGING env, PayPalCheckout config is set with STAGE`() =
-        runTest {
-            val configSlot = slot<CheckoutConfig>()
-            every { PayPalCheckout.setConfig(capture(configSlot)) } answers { configSlot.captured }
-
-            every {
-                PayPalCheckout.startCheckout(any())
-            } just runs
-
-            val config = CoreConfig("fake-client-id", Environment.STAGING)
-            sut = getPayPalCheckoutClient(config, testScheduler)
-            sut.startCheckout(PayPalNativeCheckoutRequest("order_id"))
-            advanceUntilIdle()
-
-            verify {
-                PayPalCheckout.setConfig(any())
-            }
-            expectThat(configSlot.captured) {
-                get { clientId }.isEqualTo("fake-client-id")
-                get { application }.isEqualTo(mockApplication)
-                get { environment }.isEqualTo(com.paypal.checkout.config.Environment.STAGE)
-            }
-        }
-
-    @Test
     fun `when startCheckout is invoked, PayPalCheckout startCheckout is called`() = runTest {
         val request = PayPalNativeCheckoutRequest("mock_order_id")
         every { PayPalCheckout.startCheckout(any()) } just runs

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/BrowserSwitchHelper.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/BrowserSwitchHelper.kt
@@ -18,7 +18,6 @@ internal class BrowserSwitchHelper(private val urlScheme: String) {
         val baseURL = when (config.environment) {
             Environment.LIVE -> "https://www.paypal.com"
             Environment.SANDBOX -> "https://www.sandbox.paypal.com"
-            Environment.STAGING -> "https://www.msmaster.qa.paypal.com"
         }
         return Uri.parse(baseURL)
             .buildUpon()

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/BrowserSwitchHelperUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/BrowserSwitchHelperUnitTest.kt
@@ -45,34 +45,6 @@ class BrowserSwitchHelperUnitTest {
     }
 
     @Test
-    fun `when configurePayPalBrowserSwitchOptions is executed with STAGING, the correct url is returned`() {
-        val mockOrderId = "fake_order_id"
-        val mockCoreConfig = mockk<CoreConfig>(relaxed = true)
-        val mockFundingSource = PayPalWebCheckoutFundingSource.PAYPAL
-
-        val urlScheme = "com.android.test.scheme"
-        val finalUrl = "https://www.msmaster.qa.paypal.com/checkoutnow?" +
-                "token=$mockOrderId" +
-                "&redirect_uri=$urlScheme" +
-                "%3A%2F%2Fx-callback-url%2Fpaypal-sdk%2Fpaypal-checkout&native_xo=1" +
-                "&fundingSource=${mockFundingSource.value}"
-        val uri = Uri.parse(finalUrl)
-
-        every { mockCoreConfig.environment } returns Environment.STAGING
-
-        val browserSwitchHelper = BrowserSwitchHelper(urlScheme)
-        val browserSwitchOptions = browserSwitchHelper.configurePayPalBrowserSwitchOptions(
-            mockOrderId,
-            mockCoreConfig,
-            mockFundingSource
-        )
-
-        expectThat(browserSwitchOptions) {
-            get { url?.host }.isEqualTo(uri.host)
-        }
-    }
-
-    @Test
     fun `when configurePayPalBrowserSwitchOptions is executed with LIVE, the correct url is returned`() {
         val mockOrderId = "fake_order_id"
         val mockCoreConfig = mockk<CoreConfig>(relaxed = true)


### PR DESCRIPTION
### Reason for changes

- While creating analytics dashboards, we realized that the BT & PPCP SDKs differ in the values we are sending for the `merchant_sdk_env` key to FPTI
    - BT Mobile SDKs are sending: production & sandbox, PPCP mobile SDKs are sending live & sandbox
- The iOS SDK does not offer a "staging" environment. We had issues getting this working locally, so I opted to just remove it in this PR for parity.

### Summary of changes

- Send `production` over `live` in FPTI post body
- Rename `merchant_app_environment` to `merchant_sdk_env`
- Remove `.staging` environment option to align with iOS

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 