### PR TITLE
Demo: Vault without purchase Complete Order

### DIFF
--- a/Demo/src/main/java/com/paypal/android/ui/card/CreateOrderView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CreateOrderView.kt
@@ -1,0 +1,41 @@
+package com.paypal.android.ui.card
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.paypal.android.api.model.Order
+import com.paypal.android.uishared.components.OrderView
+
+@Composable
+fun CreateOrderView(order: Order) {
+    OutlinedCard(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Spacer(modifier = Modifier.size(16.dp))
+        Text(
+            text = "Create Order Result",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(horizontal = 16.dp)
+        )
+        OrderView(order = order)
+    }
+}
+
+@Preview
+@Composable
+fun CreateOrderPreview() {
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxWidth()) {
+            CreateOrderView(order = Order())
+        }
+    }
+}

--- a/Demo/src/main/java/com/paypal/android/ui/vault/VaultUiState.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vault/VaultUiState.kt
@@ -1,7 +1,9 @@
 package com.paypal.android.ui.vault
 
+import com.paypal.android.api.model.Order
 import com.paypal.android.api.model.PaymentToken
 import com.paypal.android.api.model.SetupToken
+import com.paypal.android.cardpayments.OrderIntent
 import com.paypal.android.cardpayments.VaultResult
 
 data class VaultUiState(
@@ -10,9 +12,12 @@ data class VaultUiState(
     val isCreateSetupTokenLoading: Boolean = false,
     val isUpdateSetupTokenLoading: Boolean = false,
     val isCreatePaymentTokenLoading: Boolean = false,
+    val isCreateOrderLoading: Boolean = false,
     val customerId: String = "",
     val cardNumber: String = "",
     val cardExpirationDate: String = "",
     val cardSecurityCode: String = "",
-    val vaultResult: VaultResult? = null
+    val vaultResult: VaultResult? = null,
+    val orderIntent: OrderIntent = OrderIntent.AUTHORIZE,
+    val createdOrder: Order? = null
 )

--- a/Demo/src/main/java/com/paypal/android/ui/vault/VaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vault/VaultViewModel.kt
@@ -1,9 +1,11 @@
 package com.paypal.android.ui.vault
 
 import androidx.lifecycle.ViewModel
+import com.paypal.android.api.model.Order
 import com.paypal.android.api.model.PaymentToken
 import com.paypal.android.api.model.SetupToken
 import com.paypal.android.cardpayments.Card
+import com.paypal.android.cardpayments.OrderIntent
 import com.paypal.android.cardpayments.VaultResult
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -43,6 +45,12 @@ class VaultViewModel : ViewModel() {
             _uiState.update { it.copy(isCreatePaymentTokenLoading = value) }
         }
 
+    var isCreateOrderLoading: Boolean
+        get() = _uiState.value.isCreateOrderLoading
+        set(value) {
+            _uiState.update { it.copy(isCreateOrderLoading = value) }
+        }
+
     var customerId: String
         get() = _uiState.value.customerId
         set(value) {
@@ -71,6 +79,18 @@ class VaultViewModel : ViewModel() {
         get() = _uiState.value.vaultResult
         set(value) {
             _uiState.update { it.copy(vaultResult = value) }
+        }
+
+    var orderIntent: OrderIntent
+        get() = _uiState.value.orderIntent
+        set(value) {
+            _uiState.update { it.copy(orderIntent = value) }
+        }
+
+    var createdOrder: Order?
+        get() = _uiState.value.createdOrder
+        set(value) {
+            _uiState.update { it.copy(createdOrder = value) }
         }
 
     fun prefillCard(card: Card) {

--- a/Demo/src/main/java/com/paypal/android/uishared/components/CreateOrderForm.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/CreateOrderForm.kt
@@ -1,0 +1,110 @@
+package com.paypal.android.uishared.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.paypal.android.R
+import com.paypal.android.cardpayments.OrderIntent
+import com.paypal.android.ui.OptionList
+import com.paypal.android.ui.WireframeButton
+
+@Composable
+fun CreateOrderForm(
+    title: String,
+    orderIntent: OrderIntent = OrderIntent.AUTHORIZE,
+    shouldVault: Boolean = false,
+    vaultCustomerId: String = "",
+    isLoading: Boolean = false,
+    onShouldVaultChanged: (Boolean) -> Unit = {},
+    onVaultCustomerIdChanged: (String) -> Unit = {},
+    onIntentOptionSelected: (OrderIntent) -> Unit = {},
+    onSubmit: () -> Unit = {}
+) {
+    val localFocusManager = LocalFocusManager.current
+
+    val captureValue = stringResource(id = R.string.intent_capture)
+    val authorizeValue = stringResource(id = R.string.intent_authorize)
+    val selectedOrderIntent = when (orderIntent) {
+        OrderIntent.CAPTURE -> captureValue
+        OrderIntent.AUTHORIZE -> authorizeValue
+    }
+    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(8.dp)) {
+            Text(text = title, style = MaterialTheme.typography.titleLarge)
+            Spacer(modifier = Modifier.size(16.dp))
+            OptionList(
+                title = stringResource(id = R.string.intent_title),
+                options = listOf(authorizeValue, captureValue),
+                selectedOption = selectedOrderIntent,
+                onOptionSelected = { option ->
+                    val newOrderIntent = when (option) {
+                        captureValue -> OrderIntent.CAPTURE
+                        authorizeValue -> OrderIntent.CAPTURE
+                        else -> null
+                    }
+                    newOrderIntent?.let { onIntentOptionSelected(it) }
+                }
+            )
+            Spacer(modifier = Modifier.size(16.dp))
+            Row {
+                Text(
+                    text = "Should Vault",
+                    modifier = Modifier
+                        .align(Alignment.CenterVertically)
+                        .weight(1.0f)
+                )
+                Switch(
+                    checked = shouldVault,
+                    onCheckedChange = { onShouldVaultChanged(it) }
+                )
+            }
+            OutlinedTextField(
+                value = vaultCustomerId,
+                label = { Text("VAULT CUSTOMER ID (OPTIONAL)") },
+                onValueChange = { onVaultCustomerIdChanged(it) },
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { localFocusManager.clearFocus() }),
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            WireframeButton(
+                text = "Create Order",
+                isLoading = isLoading,
+                onClick = { onSubmit() },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun CreateOrderFormPreview() {
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            CreateOrderForm(title = "Sample Title")
+        }
+    }
+}

--- a/Demo/src/main/java/com/paypal/android/uishared/components/CreateOrderWithoutVaultForm.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/CreateOrderWithoutVaultForm.kt
@@ -1,26 +1,18 @@
 package com.paypal.android.uishared.components
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.paypal.android.R
@@ -29,19 +21,13 @@ import com.paypal.android.ui.OptionList
 import com.paypal.android.ui.WireframeButton
 
 @Composable
-fun CreateOrderForm(
+fun CreateOrderWithoutVaultForm(
     title: String,
     orderIntent: OrderIntent = OrderIntent.AUTHORIZE,
-    shouldVault: Boolean = false,
-    vaultCustomerId: String = "",
     isLoading: Boolean = false,
-    onShouldVaultChanged: (Boolean) -> Unit = {},
-    onVaultCustomerIdChanged: (String) -> Unit = {},
     onIntentOptionSelected: (OrderIntent) -> Unit = {},
     onSubmit: () -> Unit = {}
 ) {
-    val localFocusManager = LocalFocusManager.current
-
     val captureValue = stringResource(id = R.string.intent_capture)
     val authorizeValue = stringResource(id = R.string.intent_authorize)
     val selectedOrderIntent = when (orderIntent) {
@@ -66,27 +52,6 @@ fun CreateOrderForm(
                 }
             )
             Spacer(modifier = Modifier.size(16.dp))
-            Row {
-                Text(
-                    text = "Should Vault",
-                    modifier = Modifier
-                        .align(Alignment.CenterVertically)
-                        .weight(1.0f)
-                )
-                Switch(
-                    checked = shouldVault,
-                    onCheckedChange = { onShouldVaultChanged(it) }
-                )
-            }
-            OutlinedTextField(
-                value = vaultCustomerId,
-                label = { Text("VAULT CUSTOMER ID (OPTIONAL)") },
-                onValueChange = { onVaultCustomerIdChanged(it) },
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                keyboardActions = KeyboardActions(onDone = { localFocusManager.clearFocus() }),
-                modifier = Modifier.fillMaxWidth()
-            )
-            Spacer(modifier = Modifier.size(8.dp))
             WireframeButton(
                 text = "Create Order",
                 isLoading = isLoading,
@@ -104,7 +69,7 @@ fun CreateOrderForm(
 fun CreateOrderFormPreview() {
     MaterialTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
-            CreateOrderForm(title = "Sample Title")
+            CreateOrderWithoutVaultForm(title = "Sample Title")
         }
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Allow Capture (or Authorization) after vaulting a Payment Token in the Vault Without Purchase flow

 ### Checklist

 ~- [ ] Added a changelog entry~

### UX Walkthrough

https://github.com/paypal/paypal-android/assets/58225613/9370082d-cc61-4f8c-8833-94a3de9a87cf

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
