### PR TITLE
Show Test Cards as Modal Popup

### DIFF
--- a/Demo/src/main/java/com/paypal/android/ui/card/ApproveOrderForm.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/ApproveOrderForm.kt
@@ -27,6 +27,7 @@ import com.paypal.android.uishared.components.CardForm
 @Composable
 fun ApproveOrderForm(
     uiState: CardViewUiState,
+    onUseTestCardClick: () -> Unit,
     onCardNumberChange: (String) -> Unit,
     onExpirationDateChange: (String) -> Unit,
     onSecurityCodeChange: (String) -> Unit,
@@ -51,6 +52,7 @@ fun ApproveOrderForm(
                 onCardNumberChange = { onCardNumberChange(it) },
                 onExpirationDateChange = { onExpirationDateChange(it) },
                 onSecurityCodeChange = { onSecurityCodeChange(it) },
+                onUseTestCardClick = { onUseTestCardClick() }
             )
             Spacer(modifier = Modifier.size(16.dp))
             OptionList(
@@ -81,6 +83,7 @@ fun ApproveOrderFormPreview() {
                 onExpirationDateChange = {},
                 onSecurityCodeChange = {},
                 onSCAOptionSelected = {},
+                onUseTestCardClick = {},
                 onSubmit = {}
             )
         }

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
@@ -66,7 +66,6 @@ class CardFragment : Fragment() {
     private lateinit var cardClient: CardClient
     private lateinit var payPalDataCollector: PayPalDataCollector
 
-    private val args: CardFragmentArgs by navArgs()
     private val viewModel by viewModels<CardViewModel>()
 
     @ExperimentalMaterial3Api
@@ -75,7 +74,6 @@ class CardFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        args.prefillCard?.card?.let { viewModel.prefillCard(it) }
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
@@ -170,7 +168,8 @@ class CardFragment : Fragment() {
     }
 
     private fun showTestCards() {
-
+        // TODO: update card data when a prefill card has been selected
+//        args.prefillCard?.card?.let { viewModel.prefillCard(it) }
     }
 
     @OptIn(ExperimentalComposeUiApi::class)

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
@@ -185,6 +185,8 @@ class CardFragment : Fragment() {
         findNavController().navigate(action)
     }
 
+    // TODO: Investigate the best way to break this composable up into smaller individual units
+    @Suppress("LongMethod")
     @OptIn(ExperimentalComposeUiApi::class)
     @ExperimentalMaterial3Api
     @Composable

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
@@ -32,6 +32,7 @@ import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.paypal.android.api.model.Order
 import com.paypal.android.api.services.SDKSampleServerAPI
@@ -78,11 +79,7 @@ class CardFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        setFragmentResultListener(SelectCardFragment.REQUEST_KEY_TEST_CARD) { _, bundle ->
-            bundle.parcelable<TestCard>(SelectCardFragment.DATA_KEY_TEST_CARD)?.let { testCard ->
-                viewModel.prefillCard(testCard)
-            }
-        }
+        registerPrefillCardListener()
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
@@ -98,6 +95,14 @@ class CardFragment : Fragment() {
                         )
                     }
                 }
+            }
+        }
+    }
+
+    private fun registerPrefillCardListener() {
+        setFragmentResultListener(SelectCardFragment.REQUEST_KEY_TEST_CARD) { _, bundle ->
+            bundle.parcelable<TestCard>(SelectCardFragment.DATA_KEY_TEST_CARD)?.let { testCard ->
+                viewModel.prefillCard(testCard)
             }
         }
     }
@@ -177,7 +182,8 @@ class CardFragment : Fragment() {
     }
 
     private fun showTestCards() {
-
+        val action = CardFragmentDirections.actionCardFragmentToSelectCardFragment()
+        findNavController().navigate(action)
     }
 
     @OptIn(ExperimentalComposeUiApi::class)

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
@@ -33,7 +33,6 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
 import com.paypal.android.api.model.Order
 import com.paypal.android.api.services.SDKSampleServerAPI
 import com.paypal.android.cardpayments.ApproveOrderListener
@@ -47,11 +46,11 @@ import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.fraudprotection.PayPalDataCollector
 import com.paypal.android.models.TestCard
-import com.paypal.android.uishared.components.MessageView
 import com.paypal.android.ui.card.validation.CardViewUiState
 import com.paypal.android.ui.selectcard.SelectCardFragment
 import com.paypal.android.uishared.components.CompleteOrderForm
 import com.paypal.android.uishared.components.CreateOrderForm
+import com.paypal.android.uishared.components.MessageView
 import com.paypal.android.utils.parcelable
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
@@ -86,7 +86,8 @@ class CardFragment : Fragment() {
                             uiState = uiState,
                             onCreateOrderSubmit = { createOrder() },
                             onApproveOrderSubmit = { approveOrder() },
-                            onCompleteOrderSubmit = { completeOrder() }
+                            onCompleteOrderSubmit = { completeOrder() },
+                            onUseTestCardClick = { showTestCards() }
                         )
                     }
                 }
@@ -168,6 +169,10 @@ class CardFragment : Fragment() {
         }
     }
 
+    private fun showTestCards() {
+
+    }
+
     @OptIn(ExperimentalComposeUiApi::class)
     @ExperimentalMaterial3Api
     @Composable
@@ -176,6 +181,7 @@ class CardFragment : Fragment() {
         onCreateOrderSubmit: () -> Unit = {},
         onApproveOrderSubmit: () -> Unit = {},
         onCompleteOrderSubmit: () -> Unit = {},
+        onUseTestCardClick: () -> Unit = {}
     ) {
         val scrollState = rememberScrollState()
         LaunchedEffect(uiState) {
@@ -212,6 +218,7 @@ class CardFragment : Fragment() {
                     onExpirationDateChange = { value -> viewModel.cardExpirationDate = value },
                     onSecurityCodeChange = { value -> viewModel.cardSecurityCode = value },
                     onSCAOptionSelected = { value -> viewModel.scaOption = value },
+                    onUseTestCardClick = { onUseTestCardClick() },
                     onSubmit = { onApproveOrderSubmit() }
                 )
             }

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -44,10 +45,13 @@ import com.paypal.android.cardpayments.threedsecure.SCA
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.fraudprotection.PayPalDataCollector
+import com.paypal.android.models.TestCard
 import com.paypal.android.uishared.components.MessageView
 import com.paypal.android.ui.card.validation.CardViewUiState
+import com.paypal.android.ui.selectcard.SelectCardFragment
 import com.paypal.android.uishared.components.CompleteOrderForm
 import com.paypal.android.uishared.components.CreateOrderForm
+import com.paypal.android.utils.parcelable
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -74,6 +78,11 @@ class CardFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        setFragmentResultListener(SelectCardFragment.REQUEST_KEY_TEST_CARD) { _, bundle ->
+            bundle.parcelable<TestCard>(SelectCardFragment.DATA_KEY_TEST_CARD)?.let { testCard ->
+                viewModel.prefillCard(testCard)
+            }
+        }
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
@@ -168,8 +177,7 @@ class CardFragment : Fragment() {
     }
 
     private fun showTestCards() {
-        // TODO: update card data when a prefill card has been selected
-//        args.prefillCard?.card?.let { viewModel.prefillCard(it) }
+
     }
 
     @OptIn(ExperimentalComposeUiApi::class)

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
@@ -2,7 +2,6 @@ package com.paypal.android.ui.card
 
 import androidx.lifecycle.ViewModel
 import com.paypal.android.api.model.Order
-import com.paypal.android.cardpayments.Card
 import com.paypal.android.cardpayments.OrderIntent
 import com.paypal.android.cardpayments.model.CardResult
 import com.paypal.android.models.TestCard

--- a/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardViewModel.kt
@@ -5,6 +5,7 @@ import com.paypal.android.api.model.Order
 import com.paypal.android.cardpayments.Card
 import com.paypal.android.cardpayments.OrderIntent
 import com.paypal.android.cardpayments.model.CardResult
+import com.paypal.android.models.TestCard
 import com.paypal.android.ui.card.validation.CardViewUiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -96,7 +97,8 @@ class CardViewModel : ViewModel() {
             _uiState.update { it.copy(isCompleteOrderLoading = value) }
         }
 
-    fun prefillCard(card: Card) {
+    fun prefillCard(testCard: TestCard) {
+        val card = testCard.card
         _uiState.update { currentState ->
             currentState.copy(
                 cardNumber = card.number,

--- a/Demo/src/main/java/com/paypal/android/ui/createorder/CreateOrderFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/createorder/CreateOrderFragment.kt
@@ -77,16 +77,6 @@ class CreateOrderFragment : Fragment() {
 
             // continue on to feature
             when (val feature = args.feature) {
-                Feature.CARD_APPROVE_ORDER,
-                Feature.CARD_VAULT -> {
-                    navigate(
-                        CreateOrderFragmentDirections.actionCreateOrderFragmentToSelectCardFragment(
-                            feature,
-                            order
-                        )
-                    )
-                }
-
                 Feature.PAYPAL_WEB -> {
                     navigate(
                         CreateOrderFragmentDirections.actionCreateOrderFragmentToPayPalFragment(
@@ -101,6 +91,10 @@ class CreateOrderFragment : Fragment() {
                             order
                         )
                     )
+                }
+
+                else -> {
+                    // TODO: remove once Feature enum is removed
                 }
             }
         }

--- a/Demo/src/main/java/com/paypal/android/ui/features/FeaturesFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/features/FeaturesFragment.kt
@@ -87,9 +87,11 @@ class FeaturesFragment : Fragment() {
                 FeaturesFragmentDirections.actionPaymentMethodsFragmentToCreateOrderFragment(feature)
             }
 
-            Feature.CARD_APPROVE_ORDER,
+            Feature.CARD_APPROVE_ORDER -> {
+                FeaturesFragmentDirections.actionPaymentMethodsFragmentToCardFragment()
+            }
             Feature.CARD_VAULT -> {
-                FeaturesFragmentDirections.actionPaymentMethodsFragmentToSelectCardFragment(feature)
+                FeaturesFragmentDirections.actionPaymentMethodsFragmentToVaultFragment()
             }
         }
         findNavController().navigate(action)

--- a/Demo/src/main/java/com/paypal/android/ui/selectcard/SelectCardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/selectcard/SelectCardFragment.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,7 +17,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
@@ -28,11 +25,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.paypal.android.models.TestCard
 import com.paypal.android.ui.WireframeHeader
-import com.paypal.android.ui.features.Feature
 
 class SelectCardFragment : Fragment() {
 
@@ -54,25 +49,7 @@ class SelectCardFragment : Fragment() {
     }
 
     private fun onTestCardSelected(card: TestCard) {
-        navigateToCardForm(card)
-    }
-
-    private fun navigateToCardForm(testCard: TestCard? = null) {
-        val feature = args.feature
-        if (feature == Feature.CARD_VAULT) {
-            val action = SelectCardFragmentDirections.actionSelectCardFragmentToVaultFragment(
-                feature, testCard
-            )
-            findNavController().navigate(action)
-        } else {
-            val order = args.order
-            val action = SelectCardFragmentDirections.actionSelectCardFragmentToCardFragment(
-                feature,
-                order,
-                testCard
-            )
-            findNavController().navigate(action)
-        }
+        // TODO: return test card as a result
     }
 
     @OptIn(ExperimentalFoundationApi::class)
@@ -85,29 +62,6 @@ class SelectCardFragment : Fragment() {
         LazyColumn(
             modifier = Modifier.fillMaxWidth()
         ) {
-            stickyHeader {
-                WireframeHeader("Manual Card Entry")
-            }
-            item {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(Color(color = 0xFF0079C1)) // PayPal blue
-                        .selectable(
-                            selected = false,
-                            onClick = { navigateToCardForm() }
-                        )
-                ) {
-                    Text(
-                        text = "ENTER CARD MANUALLY️",
-                        color = Color.White,
-                        style = MaterialTheme.typography.headlineSmall,
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .padding(vertical = 26.dp, horizontal = 8.dp),
-                    )
-                }
-            }
             stickyHeader {
                 WireframeHeader("Test Cards without 3DS")
             }

--- a/Demo/src/main/java/com/paypal/android/ui/selectcard/SelectCardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/selectcard/SelectCardFragment.kt
@@ -23,8 +23,11 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.fragment.findNavController
 import com.paypal.android.models.TestCard
 import com.paypal.android.ui.WireframeHeader
 
@@ -50,8 +53,12 @@ class SelectCardFragment : Fragment() {
         }
     }
 
-    private fun onTestCardSelected(card: TestCard) {
-        // TODO: return test card as a result
+    private fun onTestCardSelected(testCard: TestCard) {
+        val bundle = bundleOf(DATA_KEY_TEST_CARD to testCard)
+        setFragmentResult(REQUEST_KEY_TEST_CARD, bundle)
+
+        // go back to previous fragment with test card as a result
+        findNavController().navigateUp()
     }
 
     @OptIn(ExperimentalFoundationApi::class)

--- a/Demo/src/main/java/com/paypal/android/ui/selectcard/SelectCardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/selectcard/SelectCardFragment.kt
@@ -25,13 +25,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.fragment.navArgs
 import com.paypal.android.models.TestCard
 import com.paypal.android.ui.WireframeHeader
 
 class SelectCardFragment : Fragment() {
 
-    private val args: SelectCardFragmentArgs by navArgs()
+    companion object {
+        const val REQUEST_KEY_TEST_CARD = "SELECT_CARD_REQUEST_KEY_TEST_CARD"
+        const val DATA_KEY_TEST_CARD = "SELECT_CARD_DATA_KEY_TEST_CARD"
+    }
 
     @ExperimentalMaterial3Api
     override fun onCreateView(

--- a/Demo/src/main/java/com/paypal/android/ui/vault/AttachCardToSetupTokenForm.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vault/AttachCardToSetupTokenForm.kt
@@ -22,6 +22,7 @@ fun AttachCardToSetupTokenForm(
     onCardNumberChange: (String) -> Unit,
     onExpirationDateChange: (String) -> Unit,
     onSecurityCodeChange: (String) -> Unit,
+    onUseTestCardClick: () -> Unit,
     onSubmit: () -> Unit
 ) {
     OutlinedCard(
@@ -41,6 +42,7 @@ fun AttachCardToSetupTokenForm(
                 onCardNumberChange = { onCardNumberChange(it) },
                 onExpirationDateChange = { onExpirationDateChange(it) },
                 onSecurityCodeChange = { onSecurityCodeChange(it) },
+                onUseTestCardClick = { onUseTestCardClick() }
             )
             Spacer(modifier = Modifier.size(8.dp))
             WireframeButton(

--- a/Demo/src/main/java/com/paypal/android/ui/vault/VaultFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vault/VaultFragment.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.app.BundleCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels

--- a/Demo/src/main/java/com/paypal/android/ui/vault/VaultFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vault/VaultFragment.kt
@@ -86,6 +86,7 @@ class VaultFragment : Fragment() {
                             onCreateSetupTokenSubmit = { createSetupToken() },
                             onAttachCardToSetupTokenSubmit = { attachCardToSetupToken() },
                             onCreatePaymentTokenSubmit = { createPaymentToken() },
+                            onUseTestCardClick = { showTestCards() }
                         )
                     }
                 }
@@ -134,6 +135,10 @@ class VaultFragment : Fragment() {
         }
     }
 
+    private fun showTestCards() {
+
+    }
+
     private fun parseCard(uiState: VaultUiState): Card {
         // TODO: handle invalid date string
         var expirationMonth = ""
@@ -169,6 +174,7 @@ class VaultFragment : Fragment() {
         uiState: VaultUiState,
         onCreateSetupTokenSubmit: () -> Unit,
         onAttachCardToSetupTokenSubmit: () -> Unit,
+        onUseTestCardClick: () -> Unit,
         onCreatePaymentTokenSubmit: () -> Unit
     ) {
         val scrollState = rememberScrollState()
@@ -196,6 +202,7 @@ class VaultFragment : Fragment() {
                     onCardNumberChange = { viewModel.cardNumber = it },
                     onExpirationDateChange = { viewModel.cardExpirationDate = it },
                     onSecurityCodeChange = { viewModel.cardSecurityCode = it },
+                    onUseTestCardClick = { onUseTestCardClick() },
                     onSubmit = { onAttachCardToSetupTokenSubmit() }
                 )
             }
@@ -257,6 +264,7 @@ class VaultFragment : Fragment() {
                     onCreateSetupTokenSubmit = {},
                     onAttachCardToSetupTokenSubmit = {},
                     onCreatePaymentTokenSubmit = {},
+                    onUseTestCardClick = {}
                 )
             }
         }

--- a/Demo/src/main/java/com/paypal/android/ui/vault/VaultFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vault/VaultFragment.kt
@@ -25,11 +25,12 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.app.BundleCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.fragment.navArgs
 import com.paypal.android.api.model.PaymentToken
 import com.paypal.android.api.model.SetupToken
 import com.paypal.android.api.services.SDKSampleServerAPI
@@ -40,12 +41,15 @@ import com.paypal.android.cardpayments.VaultRequest
 import com.paypal.android.cardpayments.VaultResult
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.PayPalSDKError
+import com.paypal.android.models.TestCard
 import com.paypal.android.ui.card.DateString
+import com.paypal.android.ui.selectcard.SelectCardFragment
 import com.paypal.android.uishared.components.PaymentTokenView
 import com.paypal.android.uishared.components.PropertyView
 import com.paypal.android.uishared.components.SetupTokenView
 import com.paypal.android.usecase.CreatePaymentTokenUseCase
 import com.paypal.android.usecase.CreateSetupTokenUseCase
+import com.paypal.android.utils.parcelable
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -72,6 +76,12 @@ class VaultFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        setFragmentResultListener(SelectCardFragment.REQUEST_KEY_TEST_CARD) { _, bundle ->
+            bundle.parcelable<TestCard>(SelectCardFragment.DATA_KEY_TEST_CARD)?.let { testCard ->
+                viewModel.prefillCard(testCard)
+            }
+        }
+
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
@@ -134,7 +144,6 @@ class VaultFragment : Fragment() {
 
     private fun showTestCards() {
         // TODO: update card data when a prefill card has been selected
-//        args.prefillCard?.card?.let { viewModel.prefillCard(it) }
     }
 
     private fun parseCard(uiState: VaultUiState): Card {

--- a/Demo/src/main/java/com/paypal/android/ui/vault/VaultFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vault/VaultFragment.kt
@@ -64,7 +64,6 @@ class VaultFragment : Fragment() {
 
     private lateinit var cardClient: CardClient
 
-    private val args: VaultFragmentArgs by navArgs()
     private val viewModel by viewModels<VaultViewModel>()
 
     @ExperimentalMaterial3Api
@@ -73,8 +72,6 @@ class VaultFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        args.prefillCard?.card?.let { viewModel.prefillCard(it) }
-
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
@@ -136,7 +133,8 @@ class VaultFragment : Fragment() {
     }
 
     private fun showTestCards() {
-
+        // TODO: update card data when a prefill card has been selected
+//        args.prefillCard?.card?.let { viewModel.prefillCard(it) }
     }
 
     private fun parseCard(uiState: VaultUiState): Card {

--- a/Demo/src/main/java/com/paypal/android/ui/vault/VaultFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vault/VaultFragment.kt
@@ -31,6 +31,7 @@ import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import com.paypal.android.api.model.PaymentToken
 import com.paypal.android.api.model.SetupToken
 import com.paypal.android.api.services.SDKSampleServerAPI
@@ -76,12 +77,7 @@ class VaultFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        setFragmentResultListener(SelectCardFragment.REQUEST_KEY_TEST_CARD) { _, bundle ->
-            bundle.parcelable<TestCard>(SelectCardFragment.DATA_KEY_TEST_CARD)?.let { testCard ->
-                viewModel.prefillCard(testCard)
-            }
-        }
-
+        registerPrefillCardListener()
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
@@ -97,6 +93,14 @@ class VaultFragment : Fragment() {
                         )
                     }
                 }
+            }
+        }
+    }
+
+    private fun registerPrefillCardListener() {
+        setFragmentResultListener(SelectCardFragment.REQUEST_KEY_TEST_CARD) { _, bundle ->
+            bundle.parcelable<TestCard>(SelectCardFragment.DATA_KEY_TEST_CARD)?.let { testCard ->
+                viewModel.prefillCard(testCard)
             }
         }
     }
@@ -143,7 +147,8 @@ class VaultFragment : Fragment() {
     }
 
     private fun showTestCards() {
-        // TODO: update card data when a prefill card has been selected
+        val action = VaultFragmentDirections.actionVaultFragmentToSelectCardFragment()
+        findNavController().navigate(action)
     }
 
     private fun parseCard(uiState: VaultUiState): Card {

--- a/Demo/src/main/java/com/paypal/android/ui/vault/VaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vault/VaultViewModel.kt
@@ -5,6 +5,7 @@ import com.paypal.android.api.model.PaymentToken
 import com.paypal.android.api.model.SetupToken
 import com.paypal.android.cardpayments.Card
 import com.paypal.android.cardpayments.VaultResult
+import com.paypal.android.models.TestCard
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -73,7 +74,8 @@ class VaultViewModel : ViewModel() {
             _uiState.update { it.copy(vaultResult = value) }
         }
 
-    fun prefillCard(card: Card) {
+    fun prefillCard(testCard: TestCard) {
+        val card = testCard.card
         _uiState.update { currentState ->
             currentState.copy(
                 cardNumber = card.number,

--- a/Demo/src/main/java/com/paypal/android/ui/vault/VaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vault/VaultViewModel.kt
@@ -3,7 +3,6 @@ package com.paypal.android.ui.vault
 import androidx.lifecycle.ViewModel
 import com.paypal.android.api.model.PaymentToken
 import com.paypal.android.api.model.SetupToken
-import com.paypal.android.cardpayments.Card
 import com.paypal.android.cardpayments.VaultResult
 import com.paypal.android.models.TestCard
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/Demo/src/main/java/com/paypal/android/uishared/components/CardForm.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/CardForm.kt
@@ -3,15 +3,19 @@ package com.paypal.android.uishared.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
@@ -31,9 +35,18 @@ fun CardForm(
     onCardNumberChange: (String) -> Unit,
     onExpirationDateChange: (String) -> Unit,
     onSecurityCodeChange: (String) -> Unit,
+    onUseTestCardClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
+        Button(
+            onClick = { onUseTestCardClick() },
+            modifier = Modifier
+                .align(Alignment.End)
+                .defaultMinSize(minHeight = 50.dp)
+        ) {
+            Text(text = "Use Test Card")
+        }
         OutlinedTextField(
             value = cardNumber,
             label = { Text(stringResource(id = R.string.card_field_card_number)) },
@@ -77,7 +90,8 @@ fun CardFormPreview() {
                 securityCode = "",
                 onCardNumberChange = {},
                 onExpirationDateChange = {},
-                onSecurityCodeChange = {}
+                onSecurityCodeChange = {},
+                onUseTestCardClick = {},
             )
         }
     }

--- a/Demo/src/main/java/com/paypal/android/uishared/components/CardForm.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/CardForm.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api

--- a/Demo/src/main/java/com/paypal/android/utils/BundleParcelableExt.kt
+++ b/Demo/src/main/java/com/paypal/android/utils/BundleParcelableExt.kt
@@ -1,0 +1,11 @@
+package com.paypal.android.utils
+
+import android.os.Build.VERSION.SDK_INT
+import android.os.Bundle
+import android.os.Parcelable
+
+// Ref: https://stackoverflow.com/a/73311814
+inline fun <reified T : Parcelable> Bundle.parcelable(key: String): T? = when {
+    SDK_INT >= 33 -> getParcelable(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getParcelable(key) as? T
+}

--- a/Demo/src/main/java/com/paypal/android/utils/BundleParcelableExt.kt
+++ b/Demo/src/main/java/com/paypal/android/utils/BundleParcelableExt.kt
@@ -1,11 +1,12 @@
 package com.paypal.android.utils
 
+import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.os.Parcelable
 
 // Ref: https://stackoverflow.com/a/73311814
 inline fun <reified T : Parcelable> Bundle.parcelable(key: String): T? = when {
-    SDK_INT >= 33 -> getParcelable(key, T::class.java)
+    SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getParcelable(key, T::class.java)
     else -> @Suppress("DEPRECATION") getParcelable(key) as? T
 }

--- a/Demo/src/main/res/navigation/nav_graph.xml
+++ b/Demo/src/main/res/navigation/nav_graph.xml
@@ -119,18 +119,6 @@
             app:argType="com.paypal.android.ui.features.Feature"
             app:nullable="false" />
         <action
-            android:id="@+id/action_createOrderFragment_to_selectCardFragment"
-            app:destination="@id/selectCardFragment">
-            <argument
-                android:name="feature"
-                app:argType="com.paypal.android.ui.features.Feature"
-                app:nullable="false" />
-            <argument
-                android:name="order"
-                app:argType="com.paypal.android.api.model.Order"
-                app:nullable="false" />
-        </action>
-        <action
             android:id="@+id/action_createOrderFragment_to_payPalFragment"
             app:destination="@id/payPalFragment">
             <argument

--- a/Demo/src/main/res/navigation/nav_graph.xml
+++ b/Demo/src/main/res/navigation/nav_graph.xml
@@ -17,37 +17,27 @@
                 app:nullable="false" />
         </action>
         <action
-            android:id="@+id/action_paymentMethodsFragment_to_selectCardFragment"
-            app:destination="@id/selectCardFragment" />
+            android:id="@+id/action_paymentMethodsFragment_to_cardFragment"
+            app:destination="@id/cardFragment" />
+        <action
+            android:id="@+id/action_paymentMethodsFragment_to_vaultFragment"
+            app:destination="@id/vaultFragment" />
     </fragment>
     <fragment
         android:id="@+id/cardFragment"
         android:name="com.paypal.android.ui.card.CardFragment"
         android:label="CardFragment">
-        <argument
-            android:name="feature"
-            app:argType="com.paypal.android.ui.features.Feature"
-            app:nullable="false" />
-        <argument
-            android:name="order"
-            android:defaultValue="@null"
-            app:argType="com.paypal.android.api.model.Order"
-            app:nullable="true" />
-        <argument
-            android:name="prefillCard"
-            android:defaultValue="@null"
-            app:argType="com.paypal.android.models.TestCard"
-            app:nullable="true" />
+        <action
+            android:id="@+id/action_cardFragment_to_selectCardFragment"
+            app:destination="@id/selectCardFragment" />
     </fragment>
     <fragment
         android:id="@+id/vaultFragment"
         android:name="com.paypal.android.ui.vault.VaultFragment"
         android:label="VaultFragment">
-        <argument
-            android:name="prefillCard"
-            android:defaultValue="@null"
-            app:argType="com.paypal.android.models.TestCard"
-            app:nullable="true" />
+        <action
+            android:id="@+id/action_vaultFragment_to_selectCardFragment"
+            app:destination="@id/selectCardFragment" />
     </fragment>
     <fragment
         android:id="@+id/payPalFragment"
@@ -78,37 +68,6 @@
             android:defaultValue="@null"
             app:argType="com.paypal.android.api.model.Order"
             app:nullable="true" />
-        <action
-            android:id="@+id/action_selectCardFragment_to_cardFragment"
-            app:destination="@id/cardFragment">
-            <argument
-                android:name="feature"
-                app:argType="com.paypal.android.ui.features.Feature"
-                app:nullable="false" />
-            <argument
-                android:name="order"
-                android:defaultValue="@null"
-                app:argType="com.paypal.android.api.model.Order"
-                app:nullable="true" />
-            <argument
-                android:name="prefillCard"
-                android:defaultValue="@null"
-                app:argType="com.paypal.android.models.TestCard"
-                app:nullable="true" />
-        </action>
-        <action
-            android:id="@+id/action_selectCardFragment_to_vaultFragment"
-            app:destination="@id/vaultFragment">
-            <argument
-                android:name="feature"
-                app:argType="com.paypal.android.ui.features.Feature"
-                app:nullable="false" />
-            <argument
-                android:name="prefillCard"
-                android:defaultValue="@null"
-                app:argType="com.paypal.android.models.TestCard"
-                app:nullable="true" />
-        </action>
     </fragment>
     <fragment
         android:id="@+id/createOrderFragment"

--- a/Demo/src/main/res/navigation/nav_graph.xml
+++ b/Demo/src/main/res/navigation/nav_graph.xml
@@ -58,17 +58,7 @@
     <fragment
         android:id="@+id/selectCardFragment"
         android:name="com.paypal.android.ui.selectcard.SelectCardFragment"
-        android:label="SelectCardFragment">
-        <argument
-            android:name="feature"
-            app:argType="com.paypal.android.ui.features.Feature"
-            app:nullable="false" />
-        <argument
-            android:name="order"
-            android:defaultValue="@null"
-            app:argType="com.paypal.android.api.model.Order"
-            app:nullable="true" />
-    </fragment>
+        android:label="SelectCardFragment" />
     <fragment
         android:id="@+id/createOrderFragment"
         android:name="com.paypal.android.ui.createorder.CreateOrderFragment"


### PR DESCRIPTION
### Summary of changes

 - Refactor Demo app to show Test Cards UI as modal popup inline with Approve Order and Vault without Purchase flows

https://github.com/paypal/paypal-android/assets/58225613/1e11aa15-05e5-4b79-8c8d-1ff559824f3d

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
