### PR TITLE
Make `DateString` parsing more DRY

### DIFF
--- a/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/CardFragment.kt
@@ -283,30 +283,12 @@ class CardFragment : Fragment() {
     }
 
     private fun parseCard(uiState: CardViewUiState): Card {
-        // TODO: handle invalid date string
-        var expirationMonth = ""
-        var expirationYear = ""
-
         // expiration date in UI State needs to be formatted because it uses a visual transformation
         val dateString = DateString(uiState.cardExpirationDate)
-        val dateStringComponents = dateString.formatted.split("/")
-        if (dateStringComponents.isNotEmpty()) {
-            expirationMonth = dateStringComponents[0]
-            if (dateStringComponents.size > 1) {
-                val rawYear = dateStringComponents[1]
-                expirationYear = if (rawYear.length == 2) {
-                    // pad with 20 to assume 2000's
-                    "20$rawYear"
-                } else {
-                    rawYear
-                }
-            }
-        }
-
         return Card(
             number = uiState.cardNumber,
-            expirationMonth = expirationMonth,
-            expirationYear = expirationYear,
+            expirationMonth = dateString.formattedMonth,
+            expirationYear = dateString.formattedYear,
             securityCode = uiState.cardSecurityCode
         )
     }

--- a/Demo/src/main/java/com/paypal/android/ui/card/DateString.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/DateString.kt
@@ -70,12 +70,9 @@ data class DateString(private val rawDate: String) {
             formattedMonth = dateStringComponents[0]
             if (dateStringComponents.size > 1) {
                 val rawYear = dateStringComponents[1]
-                formattedYear = if (rawYear.length == 2) {
-                    // pad with 20 to assume 2000's
-                    "20$rawYear"
-                } else {
-                    rawYear
-                }
+
+                // assume date in 2000's and pad with "20" (if necessary)
+                formattedYear = if (rawYear.length == 2) "20$rawYear" else rawYear
             }
         }
 

--- a/Demo/src/main/java/com/paypal/android/ui/card/DateString.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/DateString.kt
@@ -1,5 +1,6 @@
 package com.paypal.android.ui.card
 
+import okhttp3.internal.format
 import java.lang.Integer.min
 
 data class DateString(private val rawDate: String) {
@@ -11,6 +12,8 @@ data class DateString(private val rawDate: String) {
     private val didAddSlash: Boolean
 
     val formatted: String
+    val formattedMonth: String
+    val formattedYear: String
 
     companion object {
         private const val maxMonthLength = 2
@@ -58,6 +61,27 @@ data class DateString(private val rawDate: String) {
         this.didPadZero = padZero
         this.didAddSlash = addSlash
         this.formatted = formatted
+
+        // TODO: handle invalid date string
+        var formattedMonth = ""
+        var formattedYear = ""
+
+        val dateStringComponents = formatted.split("/")
+        if (dateStringComponents.isNotEmpty()) {
+            formattedMonth = dateStringComponents[0]
+            if (dateStringComponents.size > 1) {
+                val rawYear = dateStringComponents[1]
+                formattedYear = if (rawYear.length == 2) {
+                    // pad with 20 to assume 2000's
+                    "20$rawYear"
+                } else {
+                    rawYear
+                }
+            }
+        }
+
+        this.formattedMonth = formattedMonth
+        this.formattedYear = formattedYear
     }
 
     fun mapRawOffsetToFormatted(rawOffset: Int): Int {

--- a/Demo/src/main/java/com/paypal/android/ui/card/DateString.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/card/DateString.kt
@@ -1,6 +1,5 @@
 package com.paypal.android.ui.card
 
-import okhttp3.internal.format
 import java.lang.Integer.min
 
 data class DateString(private val rawDate: String) {

--- a/Demo/src/main/java/com/paypal/android/ui/vault/VaultFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vault/VaultFragment.kt
@@ -151,30 +151,12 @@ class VaultFragment : Fragment() {
     }
 
     private fun parseCard(uiState: VaultUiState): Card {
-        // TODO: handle invalid date string
-        var expirationMonth = ""
-        var expirationYear = ""
-
         // expiration date in UI State needs to be formatted because it uses a visual transformation
         val dateString = DateString(uiState.cardExpirationDate)
-        val dateStringComponents = dateString.formatted.split("/")
-        if (dateStringComponents.isNotEmpty()) {
-            expirationMonth = dateStringComponents[0]
-            if (dateStringComponents.size > 1) {
-                val rawYear = dateStringComponents[1]
-                expirationYear = if (rawYear.length == 2) {
-                    // pad with 20 to assume 2000's
-                    "20$rawYear"
-                } else {
-                    rawYear
-                }
-            }
-        }
-
         return Card(
             number = uiState.cardNumber,
-            expirationMonth = expirationMonth,
-            expirationYear = expirationYear,
+            expirationMonth = dateString.formattedMonth,
+            expirationYear = dateString.formattedYear,
             securityCode = uiState.cardSecurityCode
         )
     }


### PR DESCRIPTION
### Summary of changes

 - This PR cleans up some duplicate logic related to Expiration Date auto formatting
 - The `DateVisualTransformation` code can still use some improvement, but it's best to defer a more in-depth refactor for now since we don't actually ship an Expiration Date UI component in the SDK
 - The main goal is to clean up this piece of code before migrating away from Android Fragments in the Demo app

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
