### PR TITLE
Reverse Publish Demo Workflow Order of Operations

### DIFF
--- a/.github/workflows/release_demo.yml
+++ b/.github/workflows/release_demo.yml
@@ -46,5 +46,5 @@ jobs:
           ./gradlew -PdemoAppVersionCodeParam=${UPDATED_VERSION_CODE} setDemoAppVersionCode
 
           git add .
-          git commit -m "Bump demo app version code to ${UPDATED_VERSION_CODE}"
+          git commit -m "Bump demo app version code to ${UPDATED_VERSION_CODE}."
           git push origin HEAD

--- a/.github/workflows/release_demo.yml
+++ b/.github/workflows/release_demo.yml
@@ -4,26 +4,7 @@ env:
   DEMO_KEYSTORE_FILE: /home/runner/demo_keystore.keystore
   DEMO_GCP_SERVICE_ACCOUNT_CREDENTIALS_FILE: /home/runner/demo_gcp_service_account_credentials.json
 jobs:
-  bump_demo_app_version_code:
-    name: Bump Demo App Version
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set github user
-        uses: ./.github/actions/set_github_user
-      - name: Update Version
-        run: |
-          VERSION_CODE=$(./gradlew -q getDemoAppVersionCode)
-          UPDATED_VERSION_CODE=$((${VERSION_CODE} + 1))
-
-          ./gradlew -PdemoAppVersionCodeParam=${UPDATED_VERSION_CODE} setDemoAppVersionCode
-
-          git add .
-          git commit -m "Bump demo app version code to ${UPDATED_VERSION_CODE}"
-          git push origin HEAD
   publish_demo_app:
-    needs: [ bump_demo_app_version_code ]
     name: Publish Demo App
     runs-on: ubuntu-latest
     steps:
@@ -48,3 +29,22 @@ jobs:
           DEMO_KEYSTORE_PASSWORD: ${{ secrets.DEMO_KEYSTORE_PASSWORD }}
           DEMO_KEY_ALIAS: ${{ secrets.DEMO_KEY_ALIAS }}
           DEMO_KEY_PASSWORD: ${{ secrets.DEMO_KEY_PASSWORD }}
+  bump_demo_app_version_code:
+    needs: [ publish_demo_app ]
+    name: Bump Demo App Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Set github user
+        uses: ./.github/actions/set_github_user
+      - name: Update Version
+        run: |
+          VERSION_CODE=$(./gradlew -q getDemoAppVersionCode)
+          UPDATED_VERSION_CODE=$((${VERSION_CODE} + 1))
+
+          ./gradlew -PdemoAppVersionCodeParam=${UPDATED_VERSION_CODE} setDemoAppVersionCode
+
+          git add .
+          git commit -m "Bump demo app version code to ${UPDATED_VERSION_CODE}"
+          git push origin HEAD


### PR DESCRIPTION
### Summary of changes

 - The bump of the version code number was not being updated in the release artifact
 - It appears to be a [general issue](https://github.com/actions/checkout/issues/439) with the GitHub Checkout action
 - Downstream jobs don't receive the recently pushed commit with the bumped version number
 - We can work around this by pushing the version code changes after a release to Google Play (similar to how we do for releases to maven central). 

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
