### PR TITLE
Extract `PayPalButtonsView` Composable from `PayPalButtonsFragment`

### DIFF
--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsFragment.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsFragment.kt
@@ -4,42 +4,18 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.paypal.android.R
-import com.paypal.android.paymentbuttons.PayLaterButton
-import com.paypal.android.paymentbuttons.PayPalButton
-import com.paypal.android.paymentbuttons.PayPalCreditButton
-import com.paypal.android.paymentbuttons.PaymentButton
-import com.paypal.android.paymentbuttons.PaymentButtonColor
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class PayPalButtonsFragment : Fragment() {
-
-    private val viewModel by viewModels<PayPalButtonsViewModel>()
 
     @ExperimentalMaterial3Api
     override fun onCreateView(
@@ -52,150 +28,9 @@ class PayPalButtonsFragment : Fragment() {
             setContent {
                 MaterialTheme {
                     Surface(modifier = Modifier.fillMaxSize()) {
-                        val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-                        PayPalButtonsView(uiState)
+                        PayPalButtonsView()
                     }
                 }
-            }
-        }
-    }
-
-    @ExperimentalMaterial3Api
-    @Composable
-    fun PayPalButtonsView(uiState: PayPalButtonsUiState) {
-        val scrollState = rememberScrollState()
-
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp)
-        ) {
-            Text(
-                text = stringResource(id = R.string.pay_pal_button_preview),
-                color = Color.Black,
-                style = MaterialTheme.typography.titleLarge,
-            )
-            Spacer(modifier = Modifier.size(16.dp))
-            PayPalButtonFactory(uiState = uiState)
-            Spacer(modifier = Modifier.size(16.dp))
-            Text(
-                text = stringResource(id = R.string.pay_pal_button_options),
-                color = Color.Black,
-                style = MaterialTheme.typography.titleLarge,
-            )
-            Spacer(modifier = Modifier.size(16.dp))
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1.0f)
-                    .verticalScroll(scrollState)
-            ) {
-                PayPalButtonFundingTypeOptionList(
-                    selectedOption = uiState.fundingType,
-                    onSelection = { value -> viewModel.selectedFundingType = value }
-                )
-                Spacer(modifier = Modifier.size(8.dp))
-                PayPalButtonColorOptionListFactory(uiState = uiState)
-                if (uiState.fundingType == ButtonFundingType.PAYPAL) {
-                    Spacer(modifier = Modifier.size(8.dp))
-                    PayPalButtonLabelOptionList(
-                        selectedOption = uiState.payPalButtonLabel,
-                        onSelection = { value -> viewModel.payPalButtonLabel = value }
-                    )
-                }
-                Spacer(modifier = Modifier.size(8.dp))
-                PaymentButtonShapeOptionList(
-                    selectedOption = uiState.paymentButtonShape,
-                    onSelection = { value -> viewModel.paymentButtonShape = value }
-                )
-                Spacer(modifier = Modifier.size(8.dp))
-                PaymentButtonSizeOptionList(
-                    selectedOption = uiState.paymentButtonSize,
-                    onSelection = { value -> viewModel.paymentButtonSize = value }
-                )
-            }
-        }
-    }
-
-    @Composable
-    fun PayPalButtonFactory(uiState: PayPalButtonsUiState) {
-        when (uiState.fundingType) {
-            ButtonFundingType.PAYPAL -> {
-                AndroidView(
-                    factory = { context ->
-                        PayPalButton(context)
-                    },
-                    update = { button ->
-                        configureButton(button, uiState)
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-
-            ButtonFundingType.PAY_LATER -> {
-                AndroidView(
-                    factory = { context ->
-                        PayLaterButton(context)
-                    },
-                    update = { button ->
-                        configureButton(button, uiState)
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-
-            ButtonFundingType.PAYPAL_CREDIT -> {
-                AndroidView(
-                    factory = { context ->
-                        PayPalCreditButton(context)
-                    },
-                    update = { button ->
-                        configureButton(button, uiState)
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-        }
-    }
-
-    private fun configureButton(
-        button: PaymentButton<out PaymentButtonColor>,
-        uiState: PayPalButtonsUiState
-    ) {
-        button.shape = uiState.paymentButtonShape
-        button.size = uiState.paymentButtonSize
-
-        if (button is PayPalButton) {
-            button.label = uiState.payPalButtonLabel
-        }
-
-        if (button is PayPalCreditButton) {
-            button.color = uiState.payPalCreditButtonColor
-        } else {
-            button.color = uiState.payPalButtonColor
-        }
-    }
-
-    @Composable
-    fun PayPalButtonColorOptionListFactory(uiState: PayPalButtonsUiState) {
-        when (uiState.fundingType) {
-            ButtonFundingType.PAYPAL,
-            ButtonFundingType.PAY_LATER -> {
-                PayPalButtonColorOptionList(
-                    selectedOption = uiState.payPalButtonColor,
-                    onSelection = { value ->
-                        viewModel.payPalButtonColor = value
-                    }
-                )
-            }
-
-            ButtonFundingType.PAYPAL_CREDIT -> {
-                PayPalCreditButtonColorOptionList(
-                    selectedOption = uiState.payPalCreditButtonColor,
-                    onSelection = { value ->
-                        viewModel.payPalCreditButtonColor = value
-                    }
-                )
             }
         }
     }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
@@ -29,6 +29,7 @@ import com.paypal.android.paymentbuttons.PayPalCreditButtonColor
 import com.paypal.android.paymentbuttons.PaymentButton
 import com.paypal.android.paymentbuttons.PaymentButtonColor
 
+@Suppress("LongMethod")
 @ExperimentalMaterial3Api
 @Composable
 fun PayPalButtonsView(viewModel: PayPalButtonsViewModel = viewModel()) {
@@ -69,9 +70,7 @@ fun PayPalButtonsView(viewModel: PayPalButtonsViewModel = viewModel()) {
                 fundingType = uiState.fundingType,
                 payPalButtonColor = uiState.payPalButtonColor,
                 payPalCreditButtonColor = uiState.payPalCreditButtonColor,
-                onPayPalButtonColorChange = { value ->
-                    viewModel.payPalButtonColor = value
-                },
+                onPayPalButtonColorChange = { value -> viewModel.payPalButtonColor = value },
                 onPayPalCreditButtonColorChange = { value ->
                     viewModel.payPalCreditButtonColor = value
                 }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
@@ -1,0 +1,4 @@
+package com.paypal.android.ui.paypalbuttons
+
+class PayPalButtonsView {
+}

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
@@ -1,4 +1,183 @@
 package com.paypal.android.ui.paypalbuttons
 
-class PayPalButtonsView {
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.paypal.android.R
+import com.paypal.android.paymentbuttons.PayLaterButton
+import com.paypal.android.paymentbuttons.PayPalButton
+import com.paypal.android.paymentbuttons.PayPalButtonColor
+import com.paypal.android.paymentbuttons.PayPalCreditButton
+import com.paypal.android.paymentbuttons.PayPalCreditButtonColor
+import com.paypal.android.paymentbuttons.PaymentButton
+import com.paypal.android.paymentbuttons.PaymentButtonColor
+
+@ExperimentalMaterial3Api
+@Composable
+fun PayPalButtonsView(viewModel: PayPalButtonsViewModel = viewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = stringResource(id = R.string.pay_pal_button_preview),
+            color = Color.Black,
+            style = MaterialTheme.typography.titleLarge,
+        )
+        Spacer(modifier = Modifier.size(16.dp))
+        PayPalButtonFactory(uiState = uiState)
+        Spacer(modifier = Modifier.size(16.dp))
+        Text(
+            text = stringResource(id = R.string.pay_pal_button_options),
+            color = Color.Black,
+            style = MaterialTheme.typography.titleLarge,
+        )
+        Spacer(modifier = Modifier.size(16.dp))
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1.0f)
+                .verticalScroll(scrollState)
+        ) {
+            PayPalButtonFundingTypeOptionList(
+                selectedOption = uiState.fundingType,
+                onSelection = { value -> viewModel.selectedFundingType = value }
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            PayPalButtonColorOptionListFactory(
+                fundingType = uiState.fundingType,
+                payPalButtonColor = uiState.payPalButtonColor,
+                payPalCreditButtonColor = uiState.payPalCreditButtonColor,
+                onPayPalButtonColorChange = { value ->
+                    viewModel.payPalButtonColor = value
+                },
+                onPayPalCreditButtonColorChange = { value ->
+                    viewModel.payPalCreditButtonColor = value
+                }
+            )
+            if (uiState.fundingType == ButtonFundingType.PAYPAL) {
+                Spacer(modifier = Modifier.size(8.dp))
+                PayPalButtonLabelOptionList(
+                    selectedOption = uiState.payPalButtonLabel,
+                    onSelection = { value -> viewModel.payPalButtonLabel = value }
+                )
+            }
+            Spacer(modifier = Modifier.size(8.dp))
+            PaymentButtonShapeOptionList(
+                selectedOption = uiState.paymentButtonShape,
+                onSelection = { value -> viewModel.paymentButtonShape = value }
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            PaymentButtonSizeOptionList(
+                selectedOption = uiState.paymentButtonSize,
+                onSelection = { value -> viewModel.paymentButtonSize = value }
+            )
+        }
+    }
+}
+
+@Composable
+fun PayPalButtonFactory(uiState: PayPalButtonsUiState) {
+    when (uiState.fundingType) {
+        ButtonFundingType.PAYPAL -> {
+            AndroidView(
+                factory = { context ->
+                    PayPalButton(context)
+                },
+                update = { button ->
+                    configureButton(button, uiState)
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        ButtonFundingType.PAY_LATER -> {
+            AndroidView(
+                factory = { context ->
+                    PayLaterButton(context)
+                },
+                update = { button ->
+                    configureButton(button, uiState)
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        ButtonFundingType.PAYPAL_CREDIT -> {
+            AndroidView(
+                factory = { context ->
+                    PayPalCreditButton(context)
+                },
+                update = { button ->
+                    configureButton(button, uiState)
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+private fun configureButton(
+    button: PaymentButton<out PaymentButtonColor>,
+    uiState: PayPalButtonsUiState
+) {
+    button.shape = uiState.paymentButtonShape
+    button.size = uiState.paymentButtonSize
+
+    if (button is PayPalButton) {
+        button.label = uiState.payPalButtonLabel
+    }
+
+    if (button is PayPalCreditButton) {
+        button.color = uiState.payPalCreditButtonColor
+    } else {
+        button.color = uiState.payPalButtonColor
+    }
+}
+
+@Composable
+fun PayPalButtonColorOptionListFactory(
+    fundingType: ButtonFundingType,
+    payPalButtonColor: PayPalButtonColor,
+    payPalCreditButtonColor: PayPalCreditButtonColor,
+    onPayPalButtonColorChange: (PayPalButtonColor) -> Unit,
+    onPayPalCreditButtonColorChange: (PayPalCreditButtonColor) -> Unit,
+) {
+    when (fundingType) {
+        ButtonFundingType.PAYPAL,
+        ButtonFundingType.PAY_LATER -> {
+            PayPalButtonColorOptionList(
+                selectedOption = payPalButtonColor,
+                onSelection = onPayPalButtonColorChange,
+            )
+        }
+
+        ButtonFundingType.PAYPAL_CREDIT -> {
+            PayPalCreditButtonColorOptionList(
+                selectedOption = payPalCreditButtonColor,
+                onSelection = onPayPalCreditButtonColorChange,
+            )
+        }
+    }
 }


### PR DESCRIPTION
### Summary of changes

 - `PayPalButtonsFragment` contains the demo for PayPal Buttons
 - We're migrating all `@Compose` functions to their own file before migrating from Jetpack Navigation to Compose Navigation

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
