### PR TITLE
Skip Demo App Assembly During CI Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
           signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
       - name: Assemble
-        run: ./gradlew --stacktrace assemble
+        run: ./gradlew --stacktrace assemble -x :Demo:assemble # we exclude Demo from assemble
         env:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}


### PR DESCRIPTION
### Summary of changes

 - Demo app now requires a signing configuration when a release is built
 - We can skip the `:Demo:assemble` goal in our GitHub Actions release goal
 - It turns out `snapshot_release.yml` does this already. This PR will improve alignment between the `release` and `release_snapshot` workflows

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
