### PR TITLE
Add corner radius property and slider in the demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PayPal Android SDK Release Notes
 
+## UNRELEASED 
+* PaymentButtons
+  * Supporting custom corner radius on the PayPal Button
+
 ## 1.1.0 (2023-12-05)
 
 * PayPalNativeCheckout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PayPal Android SDK Release Notes
 
-## UNRELEASED 
+## unreleased 
 * PaymentButtons
   * Supporting custom corner radius on the PayPal Button
 

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsUiState.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsUiState.kt
@@ -12,5 +12,6 @@ data class PayPalButtonsUiState(
     val payPalButtonColor: PayPalButtonColor = PayPalButtonColor.GOLD,
     val payPalButtonLabel: PayPalButtonLabel = PayPalButtonLabel.PAYPAL,
     val paymentButtonShape: PaymentButtonShape = PaymentButtonShape.ROUNDED,
-    val paymentButtonSize: PaymentButtonSize = PaymentButtonSize.SMALL
+    val paymentButtonSize: PaymentButtonSize = PaymentButtonSize.SMALL,
+    val customCornerRadius: Float? = null
 )

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
@@ -206,15 +206,7 @@ fun PayPalButtonColorOptionListFactory(
 @Preview
 @Composable
 fun FeaturesViewPreview() {
-    val scrollState = rememberScrollState()
-
     MaterialTheme {
-        Surface(
-            modifier = Modifier
-                .verticalScroll(state = scrollState)
-                .fillMaxSize()
-        ) {
-            PayPalButtonsView()
-        }
+        PayPalButtonsView()
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
@@ -158,7 +158,7 @@ private fun configureButton(
     button: PaymentButton<out PaymentButtonColor>,
     uiState: PayPalButtonsUiState
 ) {
-    button.shape = PaymentButtonShape.RECTANGLE
+    button.shape = uiState.paymentButtonShape
     button.size = uiState.paymentButtonSize
 
     if (button is PayPalButton) {

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
@@ -98,7 +98,7 @@ fun PayPalButtonsView(viewModel: PayPalButtonsViewModel = viewModel()) {
             Spacer(modifier = Modifier.size(8.dp))
             Slider(
                 value = uiState.customCornerRadius ?: 0.0f,
-                valueRange = 0f..100.0f,
+                valueRange = 0f..CORNER_RADIUS_SLIDER_MAX,
                 onValueChange = { value -> viewModel.customCornerRadius = value }
             )
             Spacer(modifier = Modifier.size(8.dp))
@@ -109,6 +109,8 @@ fun PayPalButtonsView(viewModel: PayPalButtonsViewModel = viewModel()) {
         }
     }
 }
+
+const val CORNER_RADIUS_SLIDER_MAX = 100.0f
 
 @Composable
 fun PayPalButtonFactory(uiState: PayPalButtonsUiState) {

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
@@ -104,11 +104,6 @@ fun PayPalButtonsView(viewModel: PayPalButtonsViewModel = viewModel()) {
                 valueRange = 0f..100.0f,
                 onValueChange = { value -> viewModel.customCornerRadius = value }
             )
-
-//            PaymentButtonCustomCornerRadiusOptionList(
-//                selectedOption = "Test",
-//                onSelection = { value -> viewModel.customCornerRadius = null }
-//            )
             Spacer(modifier = Modifier.size(8.dp))
             PaymentButtonSizeOptionList(
                 selectedOption = uiState.paymentButtonSize,

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
@@ -1,5 +1,6 @@
 package com.paypal.android.ui.paypalbuttons
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,12 +11,15 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -28,6 +32,7 @@ import com.paypal.android.paymentbuttons.PayPalCreditButton
 import com.paypal.android.paymentbuttons.PayPalCreditButtonColor
 import com.paypal.android.paymentbuttons.PaymentButton
 import com.paypal.android.paymentbuttons.PaymentButtonColor
+import com.paypal.android.paymentbuttons.PaymentButtonShape
 
 @Suppress("LongMethod")
 @ExperimentalMaterial3Api
@@ -87,6 +92,23 @@ fun PayPalButtonsView(viewModel: PayPalButtonsViewModel = viewModel()) {
                 selectedOption = uiState.paymentButtonShape,
                 onSelection = { value -> viewModel.paymentButtonShape = value }
             )
+            Spacer(modifier = Modifier.size(4.dp))
+            Text(
+                text = "Custom Corner Radius",
+                color = Color.Black,
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            Slider(
+                value = uiState.customCornerRadius ?: 0.0f,
+                valueRange = 0f..100.0f,
+                onValueChange = { value -> viewModel.customCornerRadius = value }
+            )
+
+//            PaymentButtonCustomCornerRadiusOptionList(
+//                selectedOption = "Test",
+//                onSelection = { value -> viewModel.customCornerRadius = null }
+//            )
             Spacer(modifier = Modifier.size(8.dp))
             PaymentButtonSizeOptionList(
                 selectedOption = uiState.paymentButtonSize,
@@ -141,7 +163,7 @@ private fun configureButton(
     button: PaymentButton<out PaymentButtonColor>,
     uiState: PayPalButtonsUiState
 ) {
-    button.shape = uiState.paymentButtonShape
+    button.shape = PaymentButtonShape.RECTANGLE
     button.size = uiState.paymentButtonSize
 
     if (button is PayPalButton) {
@@ -152,6 +174,10 @@ private fun configureButton(
         button.color = uiState.payPalCreditButtonColor
     } else {
         button.color = uiState.payPalButtonColor
+    }
+
+    uiState.customCornerRadius?.let { customCornerRadius ->
+        button.customCornerRadius = customCornerRadius
     }
 }
 
@@ -177,6 +203,23 @@ fun PayPalButtonColorOptionListFactory(
                 selectedOption = payPalCreditButtonColor,
                 onSelection = onPayPalCreditButtonColorChange,
             )
+        }
+    }
+}
+
+@ExperimentalMaterial3Api
+@Preview
+@Composable
+fun FeaturesViewPreview() {
+    val scrollState = rememberScrollState()
+
+    MaterialTheme {
+        Surface(
+            modifier = Modifier
+                .verticalScroll(state = scrollState)
+                .fillMaxSize()
+        ) {
+            PayPalButtonsView()
         }
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsView.kt
@@ -1,6 +1,5 @@
 package com.paypal.android.ui.paypalbuttons
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,7 +11,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -32,7 +30,6 @@ import com.paypal.android.paymentbuttons.PayPalCreditButton
 import com.paypal.android.paymentbuttons.PayPalCreditButtonColor
 import com.paypal.android.paymentbuttons.PaymentButton
 import com.paypal.android.paymentbuttons.PaymentButtonColor
-import com.paypal.android.paymentbuttons.PaymentButtonShape
 
 @Suppress("LongMethod")
 @ExperimentalMaterial3Api

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsViewModel.kt
@@ -46,7 +46,12 @@ class PayPalButtonsViewModel : ViewModel() {
     var paymentButtonShape: PaymentButtonShape
         get() = _uiState.value.paymentButtonShape
         set(value) {
-            _uiState.update { it.copy(paymentButtonShape = value) }
+            _uiState.update {
+                it.copy(
+                    paymentButtonShape = value,
+                    customCornerRadius = null
+                )
+            }
         }
 
     var paymentButtonSize: PaymentButtonSize

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonsViewModel.kt
@@ -38,6 +38,11 @@ class PayPalButtonsViewModel : ViewModel() {
             _uiState.update { it.copy(payPalButtonLabel = value) }
         }
 
+    var customCornerRadius: Float?
+        get() = _uiState.value.customCornerRadius
+        set(value) {
+            _uiState.update { it.copy(customCornerRadius = value) }
+        }
     var paymentButtonShape: PaymentButtonShape
         get() = _uiState.value.paymentButtonShape
         set(value) {

--- a/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
+++ b/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
@@ -72,6 +72,25 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
             prefixTextView.visibility = prefixTextVisibility
         }
 
+    var customCornerRadius: Float? = null
+        set(value) {
+            field = value // Set the field value
+
+            // Determine the corner treatment based on the value
+            val cornerTreatment = if (value == 0.0f) {
+                CutCornerTreatment()
+            } else {
+                RoundedCornerTreatment()
+            }
+
+            // Build the shapeAppearanceModel considering the possibility of a null customCornerRadius
+            shapeAppearanceModel = ShapeAppearanceModel.builder().apply {
+                value?.let {
+                    setAllCornerSizes(it)
+                }
+                setAllCorners(cornerTreatment)
+            }.build()
+        }
     /**
      * Updates the shape of the Payment Button with the provided [PaymentButtonShape]
      * and defaults to [ROUNDED] if one is not provided.
@@ -84,7 +103,7 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
             shapeHasChanged = field != value
             field = value
 
-            val cornerRadius = when (field) {
+            val cornerRadius = customCornerRadius ?: when (field) {
                 PaymentButtonShape.ROUNDED -> {
                     resources.getDimension(R.dimen.paypal_payment_button_corner_radius_rounded)
                 }
@@ -94,9 +113,18 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
                 }
             }
 
-            val cornerTreatment = when (field) {
-                PaymentButtonShape.ROUNDED, PaymentButtonShape.PILL -> RoundedCornerTreatment()
-                PaymentButtonShape.RECTANGLE -> CutCornerTreatment()
+            val cornerTreatment = if (customCornerRadius != null) {
+                if (customCornerRadius == 0.0f) {
+                    CutCornerTreatment()
+                } else {
+                    RoundedCornerTreatment()
+                }
+
+            } else {
+                when (field) {
+                    PaymentButtonShape.ROUNDED, PaymentButtonShape.PILL -> RoundedCornerTreatment()
+                    PaymentButtonShape.RECTANGLE -> CutCornerTreatment()
+                }
             }
 
             shapeAppearanceModel = ShapeAppearanceModel.builder()

--- a/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
+++ b/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
@@ -73,8 +73,7 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
         }
 
     /**
-     * Custom corner radius
-     * Default set to null
+     * Cannot be used with PaymentButtonShape
      */
     var customCornerRadius: Float? = null
         set(value) {
@@ -102,6 +101,8 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
      *
      * If your application is taking advantage of Material Theming then your own shape definitions
      * will be used as the default.
+     *
+     * Cannot be used with customCornerRadius
      */
     var shape: PaymentButtonShape = PaymentButtonShape.ROUNDED
         set(value) {

--- a/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
+++ b/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
@@ -73,6 +73,8 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
         }
 
     /**
+     * Updates the corner radius of the button
+     *
      * Cannot be used with PaymentButtonShape
      */
     var customCornerRadius: Float? = null

--- a/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
+++ b/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
@@ -74,10 +74,13 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
 
     /**
      * Custom corner radius
+     * Default set to null
      */
     var customCornerRadius: Float? = null
         set(value) {
             field = value
+
+            if (value == null) return
 
             val cornerTreatment = if (value == 0.0f) {
                 CutCornerTreatment()
@@ -105,7 +108,9 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
             shapeHasChanged = field != value
             field = value
 
-            val cornerRadius = customCornerRadius ?: when (field) {
+            this.customCornerRadius = null
+
+            val cornerRadius = when (field) {
                 PaymentButtonShape.ROUNDED -> {
                     resources.getDimension(R.dimen.paypal_payment_button_corner_radius_rounded)
                 }
@@ -115,18 +120,9 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
                 }
             }
 
-            val cornerTreatment = if (customCornerRadius != null) {
-                if (customCornerRadius == 0.0f) {
-                    CutCornerTreatment()
-                } else {
-                    RoundedCornerTreatment()
-                }
-
-            } else {
-                when (field) {
-                    PaymentButtonShape.ROUNDED, PaymentButtonShape.PILL -> RoundedCornerTreatment()
-                    PaymentButtonShape.RECTANGLE -> CutCornerTreatment()
-                }
+            val cornerTreatment = when (field) {
+                PaymentButtonShape.ROUNDED, PaymentButtonShape.PILL -> RoundedCornerTreatment()
+                PaymentButtonShape.RECTANGLE -> CutCornerTreatment()
             }
 
             shapeAppearanceModel = ShapeAppearanceModel.builder()

--- a/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
+++ b/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
@@ -72,18 +72,19 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
             prefixTextView.visibility = prefixTextVisibility
         }
 
+    /**
+     * Custom corner radius
+     */
     var customCornerRadius: Float? = null
         set(value) {
-            field = value // Set the field value
+            field = value
 
-            // Determine the corner treatment based on the value
             val cornerTreatment = if (value == 0.0f) {
                 CutCornerTreatment()
             } else {
                 RoundedCornerTreatment()
             }
 
-            // Build the shapeAppearanceModel considering the possibility of a null customCornerRadius
             shapeAppearanceModel = ShapeAppearanceModel.builder().apply {
                 value?.let {
                     setAllCornerSizes(it)
@@ -91,6 +92,7 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
                 setAllCorners(cornerTreatment)
             }.build()
         }
+
     /**
      * Updates the shape of the Payment Button with the provided [PaymentButtonShape]
      * and defaults to [ROUNDED] if one is not provided.


### PR DESCRIPTION
### Summary of changes

 - Support custom corner radius on the PayPal button
 
<img src="https://github.com/paypal/paypal-android/assets/150195168/a268b8c5-a9f6-4989-8b66-6b08938a8445" width="300">

 ### Checklist

 - [x] Added a changelog entry

### Authors
@scannillo 
@warmkesselj 

- 
