### PR TITLE
Parse 3DS Liability Shift in Card Approve Order Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * CardPayments
   * Add `liabilityShift` property to `CardResult`
   * Parse `liabilityShift` from deep link return URL in `CardClient#approveOrder()` browser-switched flow
-  * Callback `PayPalSDKError` when CardClient#approveOrder()` 3DS verification fails
+  * Callback `PayPalSDKError` when `CardClient#approveOrder()` 3DS verification fails
 
 ## 1.3.0 (2024-01-09)
 * PaymentButtons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # PayPal Android SDK Release Notes
 
+## unreleased
+
+* CardPayments
+  * Add `liabilityShift` property to `CardResult`
+  * Parse `liabilityShift` from deep link return URL in `CardClient#approveOrder()` browser-switched flow
+  * Callback `PayPalSDKError` when CardClient#approveOrder()` 3DS verification fails
+
 ## 1.3.0 (2024-01-09)
 * PaymentButtons
   * Add `PayPalCreditButtonColor.WHITE` and `.GOLD`
@@ -9,6 +16,7 @@
   * Bump native-checkout version to release `1.2.1`
 
 ## 1.2.0 (2024-01-04) 
+
 * PaymentButtons
   * Supporting custom corner radius on the PayPal Button
 * PayPalWebPayments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 * CardPayments
   * Add `liabilityShift` property to `CardResult`
-  * Parse `liabilityShift` from deep link return URL in `CardClient#approveOrder()` browser-switched flow
   * Callback `PayPalSDKError` when `CardClient#approveOrder()` 3DS verification fails
 
 ## 1.3.0 (2024-01-09)

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -176,12 +176,7 @@ class CardClient internal constructor(
 
     @Throws(PayPalSDKError::class)
     private fun parseApproveOrderDeepLink(orderId: String, deepLinkUrl: Uri?): CardResult {
-        if (deepLinkUrl == null) {
-            throw CardError.threeDSVerificationError
-        }
-
-        val error = deepLinkUrl.getQueryParameter("error")
-        if (error != null) {
+        if (deepLinkUrl == null || deepLinkUrl.getQueryParameter("error") != null) {
             throw CardError.threeDSVerificationError
         }
 
@@ -193,7 +188,6 @@ class CardClient internal constructor(
 
         val liabilityShift = deepLinkUrl.getQueryParameter("liability_shift")
         return CardResult(orderId, deepLinkUrl, liabilityShift)
-
     }
 
     private fun notifyApproveOrderCanceled() {

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -183,10 +183,17 @@ class CardClient internal constructor(
         val error = deepLinkUrl.getQueryParameter("error")
         if (error != null) {
             throw CardError.threeDSVerificationError
-        } else {
-            val liabilityShift = deepLinkUrl.getQueryParameter("liability_shift")
-            return CardResult(orderId, deepLinkUrl, liabilityShift)
         }
+
+        val state = deepLinkUrl.getQueryParameter("state")
+        val code = deepLinkUrl.getQueryParameter("code")
+        if (state == null || code == null) {
+            throw CardError.malformedDeepLinkError
+        }
+
+        val liabilityShift = deepLinkUrl.getQueryParameter("liability_shift")
+        return CardResult(orderId, deepLinkUrl, liabilityShift)
+
     }
 
     private fun notifyApproveOrderCanceled() {

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -160,24 +160,28 @@ class CardClient internal constructor(
 
     private fun handleBrowserSwitchSuccess(browserSwitchResult: BrowserSwitchResult) {
         ApproveOrderMetadata.fromJSON(browserSwitchResult.requestMetadata)?.let { metadata ->
-            CoroutineScope(dispatcher).launch(approveOrderExceptionHandler) {
-                try {
-                    analyticsService.sendAnalyticsEvent(
-                        "card-payments:3ds:get-order-info:succeeded",
-                        metadata.orderId
-                    )
-                    val deepLinkUrl = browserSwitchResult.deepLinkUrl
-                    val result = CardResult(metadata.orderId, deepLinkUrl)
-                    notifyApproveOrderSuccess(result)
-                } catch (error: PayPalSDKError) {
-                    analyticsService.sendAnalyticsEvent(
-                        "card-payments:3ds:get-order-info:failed",
-                        metadata.orderId
-                    )
-                    throw error
-                }
+            try {
+                analyticsService.sendAnalyticsEvent(
+                    "card-payments:3ds:get-order-info:succeeded",
+                    metadata.orderId
+                )
+                val deepLinkUrl = browserSwitchResult.deepLinkUrl
+                val result = parseCardResult(metadata.orderId, deepLinkUrl)
+                notifyApproveOrderSuccess(result)
+            } catch (error: PayPalSDKError) {
+                analyticsService.sendAnalyticsEvent(
+                    "card-payments:3ds:get-order-info:failed",
+                    metadata.orderId
+                )
+                throw error
             }
         }
+    }
+
+    @Throws(PayPalSDKError::class)
+    private fun parseCardResult(orderId: String, deepLinkUrl: Uri?): CardResult {
+        val liabilityShift = deepLinkUrl?.getQueryParameter("liability_shift")
+        return CardResult(orderId, deepLinkUrl, liabilityShift)
     }
 
     private fun notifyApproveOrderCanceled() {

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -176,11 +176,15 @@ class CardClient internal constructor(
 
     @Throws(PayPalSDKError::class)
     private fun parseApproveOrderDeepLink(orderId: String, deepLinkUrl: Uri?): CardResult {
-        val error = deepLinkUrl?.getQueryParameter("error")
+        if (deepLinkUrl == null) {
+            throw CardError.threeDSVerificationError
+        }
+
+        val error = deepLinkUrl.getQueryParameter("error")
         if (error != null) {
             throw CardError.threeDSVerificationError
         } else {
-            val liabilityShift = deepLinkUrl?.getQueryParameter("liability_shift")
+            val liabilityShift = deepLinkUrl.getQueryParameter("liability_shift")
             return CardResult(orderId, deepLinkUrl, liabilityShift)
         }
     }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -161,10 +161,6 @@ class CardClient internal constructor(
     private fun handleBrowserSwitchSuccess(browserSwitchResult: BrowserSwitchResult) {
         ApproveOrderMetadata.fromJSON(browserSwitchResult.requestMetadata)?.let { metadata ->
             try {
-                analyticsService.sendAnalyticsEvent(
-                    "card-payments:3ds:get-order-info:succeeded",
-                    metadata.orderId
-                )
                 val deepLinkUrl = browserSwitchResult.deepLinkUrl
                 val result = parseApproveOrderDeepLink(metadata.orderId, deepLinkUrl)
                 notifyApproveOrderSuccess(result)

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardError.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardError.kt
@@ -9,4 +9,10 @@ internal object CardError {
         code = CardErrorCode.THREEDS_VERIFICATION_FAILED.ordinal,
         errorDescription = "3DS Verification is returning an error."
     )
+
+    // 1.
+    val malformedDeepLinkError = PayPalSDKError(
+        code = CardErrorCode.MALFORMED_DEEPLINK_URL.ordinal,
+        errorDescription = "Malformed deeplink URL."
+    )
 }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardError.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardError.kt
@@ -1,0 +1,12 @@
+package com.paypal.android.cardpayments
+
+import com.paypal.android.corepayments.PayPalSDKError
+
+internal object CardError {
+
+    // 0. An error from 3DS verification
+    val threeDSVerificationError = PayPalSDKError(
+        code = CardErrorCode.THREEDS_VERIFICATION_FAILED.ordinal,
+        errorDescription = "3DS Verification is returning an error."
+    )
+}

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardErrorCode.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardErrorCode.kt
@@ -1,5 +1,6 @@
 package com.paypal.android.cardpayments
 
 internal enum class CardErrorCode {
-    THREEDS_VERIFICATION_FAILED
+    THREEDS_VERIFICATION_FAILED,
+    MALFORMED_DEEPLINK_URL
 }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardErrorCode.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardErrorCode.kt
@@ -1,0 +1,5 @@
+package com.paypal.android.cardpayments
+
+internal enum class CardErrorCode {
+    THREEDS_VERIFICATION_FAILED
+}

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResult.kt
@@ -6,6 +6,7 @@ import android.net.Uri
  * A result returned by [CardClient] when an order was successfully approved with a [Card].
  *
  * @property [orderId] associated order ID.
+ * @property [liabilityShift] Liability shift value returned from 3DS verification
  */
 data class CardResult(
     val orderId: String,
@@ -13,5 +14,6 @@ data class CardResult(
     /**
      * @suppress
      */
-    val deepLinkUrl: Uri? = null
+    val deepLinkUrl: Uri? = null,
+    val liabilityShift: String? = null
 )

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
@@ -176,7 +176,7 @@ class CardClientUnitTest {
         }
 
     @Test
-    fun `handle browser switch result notifies user of error`() =
+    fun `handle browser switch result notifies user of error when deep link contains one`() =
         runTest {
             val sut = createCardClient(testScheduler)
 
@@ -188,6 +188,30 @@ class CardClientUnitTest {
                 BrowserSwitchStatus.SUCCESS,
                 approveOrderMetadata,
                 Uri.parse(successDeepLink)
+            )
+            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+            sut.handleBrowserSwitchResult(activity)
+            advanceUntilIdle()
+
+            val errorSlot = slot<PayPalSDKError>()
+            coVerify(exactly = 1) {
+                approveOrderListener.onApproveOrderFailure(capture(errorSlot))
+            }
+
+            val error = errorSlot.captured
+            assertEquals(0, error.code)
+            assertEquals("3DS Verification is returning an error.", error.errorDescription)
+        }
+
+    @Test
+    fun `handle browser switch result notifies user of error when deep link is null`() =
+        runTest {
+            val sut = createCardClient(testScheduler)
+            val browserSwitchResult = createBrowserSwitchResult(
+                BrowserSwitchStatus.SUCCESS,
+                approveOrderMetadata,
+                deepLinkUrl = null
             )
             every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
 

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
@@ -229,6 +229,64 @@ class CardClientUnitTest {
         }
 
     @Test
+    fun `handle browser switch result notifies user of error when success deep link is missing code parameter`() =
+        runTest {
+            val sut = createCardClient(testScheduler)
+
+            val scheme = "com.paypal.android.demo"
+            val domain = "example.com"
+            val successDeepLink = "$scheme://$domain/return_url?state=undefined&liability_shift=NO"
+
+            val browserSwitchResult = createBrowserSwitchResult(
+                BrowserSwitchStatus.SUCCESS,
+                approveOrderMetadata,
+                Uri.parse(successDeepLink)
+            )
+            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+            sut.handleBrowserSwitchResult(activity)
+            advanceUntilIdle()
+
+            val errorSlot = slot<PayPalSDKError>()
+            coVerify(exactly = 1) {
+                approveOrderListener.onApproveOrderFailure(capture(errorSlot))
+            }
+
+            val error = errorSlot.captured
+            assertEquals(1, error.code)
+            assertEquals("Malformed deeplink URL.", error.errorDescription)
+        }
+
+    @Test
+    fun `handle browser switch result notifies user of error when success deep link is missing state parameter`() =
+        runTest {
+            val sut = createCardClient(testScheduler)
+
+            val scheme = "com.paypal.android.demo"
+            val domain = "example.com"
+            val successDeepLink = "$scheme://$domain/return_url?code=undefined&liability_shift=NO"
+
+            val browserSwitchResult = createBrowserSwitchResult(
+                BrowserSwitchStatus.SUCCESS,
+                approveOrderMetadata,
+                Uri.parse(successDeepLink)
+            )
+            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+            sut.handleBrowserSwitchResult(activity)
+            advanceUntilIdle()
+
+            val errorSlot = slot<PayPalSDKError>()
+            coVerify(exactly = 1) {
+                approveOrderListener.onApproveOrderFailure(capture(errorSlot))
+            }
+
+            val error = errorSlot.captured
+            assertEquals(1, error.code)
+            assertEquals("Malformed deeplink URL.", error.errorDescription)
+        }
+
+    @Test
     fun `handle browser switch result notifies listener of cancelation`() = runTest {
         val sut = createCardClient(testScheduler)
 


### PR DESCRIPTION
### Summary of changes

 - Parse `liability_shift` parameter from `confirm-payment-source` 3DS contingency deep link response
 - Parse `error` parameter from `confirm-payment-source` 3DS contingency deep link response
 - Return `PayPalSDKError` when an error is detected in the 3DS contingency deep link response

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
