### PR TITLE
Card: Vault without Purchase 3DS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * CardPayments
   * Add `liabilityShift` property to `CardResult`
   * Callback `PayPalSDKError` when `CardClient#approveOrder()` 3DS verification fails
+  * Add `CardClient#presentAuthChallenge()`
+  * Add `returnUrl` property to `CardVaultRequest`
+  * Add `authChallenge` property to `CardVaultResult`
+  * Add `CardAuthChallenge` type
 * FraudDetection
   * Bump Magnes dependency to version 5.4.0
 * PaymentButtons

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/ApproveOrderMetadata.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/ApproveOrderMetadata.kt
@@ -4,7 +4,10 @@ import com.paypal.android.cardpayments.model.PaymentSource
 import com.paypal.android.corepayments.PaymentsJSON
 import org.json.JSONObject
 
-internal data class ApproveOrderMetadata(val orderId: String, val paymentSource: PaymentSource?) {
+internal data class ApproveOrderMetadata(
+    val orderId: String,
+    val paymentSource: PaymentSource? = null
+) {
 
     companion object {
 

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthChallenge.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthChallenge.kt
@@ -4,8 +4,22 @@ import android.net.Uri
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
-@Parcelize
-data class CardAuthChallenge(
-    internal val url: Uri,
-    internal val request: CardVaultRequest,
-) : Parcelable
+sealed class CardAuthChallenge() {
+    // Ref: https://stackoverflow.com/a/44420084
+    internal abstract val url: Uri
+    internal abstract val returnUrlScheme: String?
+
+    @Parcelize
+    internal class ApproveOrder(
+        override val url: Uri,
+        val request: CardRequest,
+        override val returnUrlScheme: String? = Uri.parse(request.returnUrl).scheme
+    ) : CardAuthChallenge(), Parcelable
+
+    @Parcelize
+    internal class Vault(
+        override val url: Uri,
+        val request: CardVaultRequest,
+        override val returnUrlScheme: String? = Uri.parse(request.returnUrl).scheme
+    ) : CardAuthChallenge(), Parcelable
+}

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthChallenge.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthChallenge.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
-sealed class CardAuthChallenge() {
+sealed class CardAuthChallenge {
     // Ref: https://stackoverflow.com/a/44420084
     internal abstract val url: Uri
     internal abstract val returnUrlScheme: String?

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthChallenge.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthChallenge.kt
@@ -4,6 +4,10 @@ import android.net.Uri
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
+/**
+ * Pass this object to [CardClient.presentAuthChallenge] to present an authentication challenge
+ * that was received in response to a [CardClient.approveOrder] or [CardClient.vault] call.
+ */
 sealed class CardAuthChallenge {
     // Ref: https://stackoverflow.com/a/44420084
     internal abstract val url: Uri

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthChallenge.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthChallenge.kt
@@ -1,0 +1,11 @@
+package com.paypal.android.cardpayments
+
+import android.net.Uri
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class CardAuthChallenge(
+    internal val url: Uri,
+    internal val request: CardVaultRequest,
+) : Parcelable

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthChallengeLauncher.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthChallengeLauncher.kt
@@ -1,0 +1,108 @@
+package com.paypal.android.cardpayments
+
+import android.net.Uri
+import androidx.fragment.app.FragmentActivity
+import com.braintreepayments.api.BrowserSwitchClient
+import com.braintreepayments.api.BrowserSwitchException
+import com.braintreepayments.api.BrowserSwitchOptions
+import com.braintreepayments.api.BrowserSwitchResult
+import com.braintreepayments.api.BrowserSwitchStatus
+import com.paypal.android.corepayments.PayPalSDKError
+import org.json.JSONObject
+
+internal class CardAuthChallengeLauncher(
+    private val browserSwitchClient: BrowserSwitchClient = BrowserSwitchClient(),
+) {
+
+    companion object {
+        private const val METADATA_KEY_REQUEST_TYPE = "request_type"
+        private const val METADATA_KEY_ORDER_ID = "order_id"
+        private const val METADATA_KEY_SETUP_TOKEN_ID = "setup_token_id"
+
+        private const val REQUEST_TYPE_CHECKOUT = "checkout"
+        private const val REQUEST_TYPE_VAULT = "vault"
+
+        private const val URL_PARAM_APPROVAL_SESSION_ID = "approval_session_id"
+    }
+
+    fun presentAuthChallenge(
+        activity: FragmentActivity,
+        authChallenge: CardAuthChallenge
+    ): PayPalSDKError? {
+        // preform 3DS browser switch
+        val vaultRequest = authChallenge.request
+        val returnUrlScheme = vaultRequest.run { Uri.parse(returnUrl).scheme!! }
+        val metadata = JSONObject()
+            .put(METADATA_KEY_REQUEST_TYPE, REQUEST_TYPE_VAULT)
+            .put(METADATA_KEY_SETUP_TOKEN_ID, vaultRequest.setupTokenId)
+
+        val options = BrowserSwitchOptions()
+            .url(authChallenge.url)
+            .returnUrlScheme(returnUrlScheme)
+            .metadata(metadata)
+        return launchBrowserSwitch(activity, options)
+    }
+
+    private fun launchBrowserSwitch(
+        activity: FragmentActivity,
+        options: BrowserSwitchOptions
+    ): PayPalSDKError? {
+        var error: PayPalSDKError? = null
+        try {
+            browserSwitchClient.start(activity, options)
+        } catch (e: BrowserSwitchException) {
+            error = CardError.browserSwitchError(e)
+        }
+        return error
+    }
+
+    fun deliverBrowserSwitchResult(activity: FragmentActivity) =
+        browserSwitchClient.deliverResult(activity)?.let { browserSwitchResult ->
+            val requestType =
+                browserSwitchResult.requestMetadata?.optString(METADATA_KEY_REQUEST_TYPE)
+            if (requestType == REQUEST_TYPE_VAULT) {
+                parseVaultResult(browserSwitchResult)
+            } else {
+                // TODO: migrate approve order to use auth challenge launcher pattern internally
+//                parseWebCheckoutResult(browserSwitchResult)
+            }
+        }
+
+    private fun parseVaultResult(browserSwitchResult: BrowserSwitchResult) =
+        when (browserSwitchResult.status) {
+            BrowserSwitchStatus.SUCCESS -> parseVaultSuccessResult(browserSwitchResult)
+            BrowserSwitchStatus.CANCELED -> CardStatus.VaultCanceled
+            else -> null
+        }
+
+    private fun parseVaultSuccessResult(browserSwitchResult: BrowserSwitchResult): CardStatus {
+        val deepLinkUrl = browserSwitchResult.deepLinkUrl
+        val requestMetadata = browserSwitchResult.requestMetadata
+
+        return if (deepLinkUrl == null || requestMetadata == null) {
+            CardStatus.VaultError(CardError.unknownError)
+        } else {
+            // TODO: see if there's a way that we can require the merchant to make their
+            // return and cancel urls conform to a strict schema
+
+            // NOTE: this assumes that when the merchant created a setup token, they used a
+            // return_url with word "success" in it (or a cancel_url with the word "cancel" in it)
+            val deepLinkUrlString = deepLinkUrl.toString()
+            val didSucceed = deepLinkUrlString.contains("success")
+            if (didSucceed) {
+                val setupTokenId = browserSwitchResult.requestMetadata?.getString(
+                    METADATA_KEY_SETUP_TOKEN_ID
+                )
+                val result = CardVaultResult(setupTokenId!!, "SCA_COMPLETE")
+                CardStatus.VaultSuccess(result)
+            } else {
+                val didCancel = deepLinkUrlString.contains("cancel")
+                if (didCancel) {
+                    CardStatus.VaultCanceled
+                } else {
+                    CardStatus.VaultError(CardError.unknownError)
+                }
+            }
+        }
+    }
+}

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthLauncher.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthLauncher.kt
@@ -88,7 +88,7 @@ internal class CardAuthLauncher(
     private fun parseApproveOrderResult(browserSwitchResult: BrowserSwitchResult): CardStatus? {
         val orderId = browserSwitchResult.requestMetadata?.optString(METADATA_KEY_ORDER_ID)
         return if (orderId == null) {
-            CardStatus.ApproveOrderError(CardError.unknownError)
+            CardStatus.ApproveOrderError(CardError.unknownError, orderId)
         } else {
             when (browserSwitchResult.status) {
                 BrowserSwitchStatus.SUCCESS ->
@@ -137,12 +137,12 @@ internal class CardAuthLauncher(
         val deepLinkUrl = browserSwitchResult.deepLinkUrl
 
         return if (deepLinkUrl == null || deepLinkUrl.getQueryParameter("error") != null) {
-            CardStatus.ApproveOrderError(CardError.threeDSVerificationError)
+            CardStatus.ApproveOrderError(CardError.threeDSVerificationError, orderId)
         } else {
             val state = deepLinkUrl.getQueryParameter("state")
             val code = deepLinkUrl.getQueryParameter("code")
             if (state == null || code == null) {
-                CardStatus.ApproveOrderError(CardError.malformedDeepLinkError)
+                CardStatus.ApproveOrderError(CardError.malformedDeepLinkError, orderId)
             } else {
                 val liabilityShift = deepLinkUrl.getQueryParameter("liability_shift")
                 val result = CardResult(orderId, deepLinkUrl, liabilityShift)

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthLauncher.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthLauncher.kt
@@ -10,7 +10,7 @@ import com.braintreepayments.api.BrowserSwitchStatus
 import com.paypal.android.corepayments.PayPalSDKError
 import org.json.JSONObject
 
-internal class CardAuthChallengeLauncher(
+internal class CardAuthLauncher(
     private val browserSwitchClient: BrowserSwitchClient = BrowserSwitchClient(),
 ) {
 

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -94,7 +94,7 @@ class CardClient internal constructor(
                 } else {
                     analyticsService.sendAnalyticsEvent(
                         "card-payments:3ds:confirm-payment-source:challenge-required",
-                        orderId
+                        cardRequest.orderId
                     )
                     approveOrderListener?.onApproveOrderThreeDSecureWillLaunch()
 
@@ -158,16 +158,16 @@ class CardClient internal constructor(
                 is CardStatus.VaultSuccess -> notifyVaultSuccess(status.result)
                 is CardStatus.VaultError -> notifyVaultFailure(status.error)
                 is CardStatus.VaultCanceled -> notifyVaultCancelation()
-                is CardStatus.ApproveOrderError -> notifyApproveOrderFailure(status.error)
+                is CardStatus.ApproveOrderError ->
+                    notifyApproveOrderFailure(status.error, status.orderId)
+
                 is CardStatus.ApproveOrderSuccess -> notifyApproveOrderSuccess(status.result)
-                is CardStatus.ApproveOrderCanceled -> notifyApproveOrderCanceled()
+                is CardStatus.ApproveOrderCanceled -> notifyApproveOrderCanceled(status.orderId)
             }
         }
     }
 
-    private fun notifyApproveOrderCanceled(browserSwitchResult: BrowserSwitchResult) {
-        val metadata = ApproveOrderMetadata.fromJSON(browserSwitchResult.requestMetadata)
-        val orderId = metadata?.orderId
+    private fun notifyApproveOrderCanceled(orderId: String?) {
         analyticsService.sendAnalyticsEvent("card-payments:3ds:challenge:user-canceled", orderId)
         approveOrderListener?.onApproveOrderCanceled()
     }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -30,6 +30,7 @@ class CardClient internal constructor(
 
     var approveOrderListener: ApproveOrderListener? = null
 
+    // NEXT MAJOR VERSION: rename to vaultListener
     /**
      * @suppress
      */

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -139,7 +139,13 @@ class CardClient internal constructor(
 
     fun presentAuthChallenge(activity: FragmentActivity, authChallenge: CardAuthChallenge) {
         authChallengeLauncher.presentAuthChallenge(activity, authChallenge)?.let { launchError ->
-            // TODO: notify auth challenger presentation failure
+            when (authChallenge) {
+                is CardAuthChallenge.ApproveOrder ->
+                    approveOrderListener?.onApproveOrderFailure(launchError)
+
+                is CardAuthChallenge.Vault ->
+                    cardVaultListener?.onVaultFailure(launchError)
+            }
         }
     }
 

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.json.JSONObject
 
 /**
  * Use this client to approve an order with a [Card].
@@ -30,7 +29,7 @@ class CardClient internal constructor(
     private val paymentMethodTokensAPI: DataVaultPaymentMethodTokensAPI,
     private val analyticsService: AnalyticsService,
     private val browserSwitchClient: BrowserSwitchClient,
-    private val authChallengeLauncher: CardAuthChallengeLauncher,
+    private val authChallengeLauncher: CardAuthLauncher,
     private val dispatcher: CoroutineDispatcher
 ) {
 
@@ -65,7 +64,7 @@ class CardClient internal constructor(
                 DataVaultPaymentMethodTokensAPI(configuration),
                 AnalyticsService(activity.applicationContext, configuration),
                 BrowserSwitchClient(),
-                CardAuthChallengeLauncher(),
+                CardAuthLauncher(),
                 Dispatchers.Main
             )
 

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -137,6 +137,9 @@ class CardClient internal constructor(
         }
     }
 
+    /**
+     * Present an auth challenge received from a [CardClient.approveOrder] or [CardClient.vault] result.
+     */
     fun presentAuthChallenge(activity: FragmentActivity, authChallenge: CardAuthChallenge) {
         authChallengeLauncher.presentAuthChallenge(activity, authChallenge)?.let { launchError ->
             when (authChallenge) {

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -158,7 +158,7 @@ class CardClient internal constructor(
             when (status) {
                 is CardStatus.VaultSuccess -> notifyVaultSuccess(status.result)
                 is CardStatus.VaultError -> notifyVaultFailure(status.error)
-                CardStatus.VaultCanceled -> notifyVaultCancelation()
+                is CardStatus.VaultCanceled -> notifyVaultCancelation()
                 is CardStatus.ApproveOrderError -> notifyApproveOrderFailure(status.error)
                 is CardStatus.ApproveOrderSuccess -> notifyApproveOrderSuccess(status.result)
                 is CardStatus.ApproveOrderCanceled -> notifyApproveOrderCanceled()

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardError.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardError.kt
@@ -1,5 +1,6 @@
 package com.paypal.android.cardpayments
 
+import com.braintreepayments.api.BrowserSwitchException
 import com.paypal.android.corepayments.PayPalSDKError
 
 internal object CardError {
@@ -14,5 +15,17 @@ internal object CardError {
     val malformedDeepLinkError = PayPalSDKError(
         code = CardErrorCode.MALFORMED_DEEPLINK_URL.ordinal,
         errorDescription = "Malformed deeplink URL."
+    )
+
+    // 2. An unknown error occurred.
+    val unknownError = PayPalSDKError(
+        code = CardErrorCode.UNKNOWN.ordinal,
+        errorDescription = "An unknown error occurred. Contact developer.paypal.com/support."
+    )
+
+    // 3. An unknown error occurred.
+    fun browserSwitchError(cause: BrowserSwitchException) = PayPalSDKError(
+        code = CardErrorCode.BROWSER_SWITCH.ordinal,
+        errorDescription = cause.message ?: "Unable to Browser Switch"
     )
 }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardErrorCode.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardErrorCode.kt
@@ -2,5 +2,7 @@ package com.paypal.android.cardpayments
 
 internal enum class CardErrorCode {
     THREEDS_VERIFICATION_FAILED,
-    MALFORMED_DEEPLINK_URL
+    MALFORMED_DEEPLINK_URL,
+    UNKNOWN,
+    BROWSER_SWITCH
 }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardStatus.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardStatus.kt
@@ -4,7 +4,7 @@ import com.paypal.android.corepayments.PayPalSDKError
 
 internal sealed class CardStatus {
 
-    class ApproveOrderError(val error: PayPalSDKError) : CardStatus()
+    class ApproveOrderError(val error: PayPalSDKError, val orderId: String?) : CardStatus()
     class ApproveOrderSuccess(val result: CardResult) : CardStatus()
     class ApproveOrderCanceled(val orderId: String?) : CardStatus()
 

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardStatus.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardStatus.kt
@@ -4,10 +4,9 @@ import com.paypal.android.corepayments.PayPalSDKError
 
 internal sealed class CardStatus  {
 
-// TODO: migrate approve order to use auth challenge launcher pattern internally
-//    class CheckoutError(val error: PayPalSDKError) : PayPalWebStatus()
-//    class CheckoutSuccess(val result: PayPalWebCheckoutResult) : PayPalWebStatus()
-//    class CheckoutCanceled(val orderId: String?) : PayPalWebStatus()
+    class ApproveOrderError(val error: PayPalSDKError) : CardStatus()
+    class ApproveOrderSuccess(val result: CardResult) : CardStatus()
+    class ApproveOrderCanceled(val orderId: String?) : CardStatus()
 
     class VaultError(val error: PayPalSDKError) : CardStatus()
     class VaultSuccess(val result: CardVaultResult) : CardStatus()

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardStatus.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardStatus.kt
@@ -2,7 +2,7 @@ package com.paypal.android.cardpayments
 
 import com.paypal.android.corepayments.PayPalSDKError
 
-internal sealed class CardStatus  {
+internal sealed class CardStatus {
 
     class ApproveOrderError(val error: PayPalSDKError) : CardStatus()
     class ApproveOrderSuccess(val result: CardResult) : CardStatus()
@@ -10,5 +10,5 @@ internal sealed class CardStatus  {
 
     class VaultError(val error: PayPalSDKError) : CardStatus()
     class VaultSuccess(val result: CardVaultResult) : CardStatus()
-    object VaultCanceled : CardStatus()
+    class VaultCanceled(val setupTokenId: String?) : CardStatus()
 }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardStatus.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardStatus.kt
@@ -1,0 +1,15 @@
+package com.paypal.android.cardpayments
+
+import com.paypal.android.corepayments.PayPalSDKError
+
+internal sealed class CardStatus  {
+
+// TODO: migrate approve order to use auth challenge launcher pattern internally
+//    class CheckoutError(val error: PayPalSDKError) : PayPalWebStatus()
+//    class CheckoutSuccess(val result: PayPalWebCheckoutResult) : PayPalWebStatus()
+//    class CheckoutCanceled(val orderId: String?) : PayPalWebStatus()
+
+    class VaultError(val error: PayPalSDKError) : CardStatus()
+    class VaultSuccess(val result: CardVaultResult) : CardStatus()
+    object VaultCanceled : CardStatus()
+}

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultRequest.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultRequest.kt
@@ -15,5 +15,6 @@ import kotlinx.parcelize.Parcelize
 data class CardVaultRequest(
     val setupTokenId: String,
     val card: Card,
-    val returnUrl: String,
+    // NOTE: This needs to null by default to prevent a breaking change
+    val returnUrl: String? = "",
 ) : Parcelable

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultRequest.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultRequest.kt
@@ -16,6 +16,5 @@ import kotlinx.parcelize.Parcelize
 data class CardVaultRequest(
     val setupTokenId: String,
     val card: Card,
-    // NOTE: This needs to be null by default to prevent a breaking change
     val returnUrl: String? = "",
 ) : Parcelable

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultRequest.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultRequest.kt
@@ -15,4 +15,5 @@ import kotlinx.parcelize.Parcelize
 data class CardVaultRequest(
     val setupTokenId: String,
     val card: Card,
+    val returnUrl: String,
 ) : Parcelable

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultRequest.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultRequest.kt
@@ -15,6 +15,6 @@ import kotlinx.parcelize.Parcelize
 data class CardVaultRequest(
     val setupTokenId: String,
     val card: Card,
-    // NOTE: This needs to null by default to prevent a breaking change
+    // NOTE: This needs to be null by default to prevent a breaking change
     val returnUrl: String? = "",
 ) : Parcelable

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultRequest.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultRequest.kt
@@ -10,6 +10,7 @@ import kotlinx.parcelize.Parcelize
  *
  * @property setupTokenId id for the setup token to update.
  * @property card card payment source to attach to the setup token.
+ * @property returnUrl return url for deep linking back into the merchant app after an auth challenge
  */
 @Parcelize
 data class CardVaultRequest(

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
@@ -1,8 +1,5 @@
 package com.paypal.android.cardpayments
 
-import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
-
 /**
  * @suppress
  *

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
@@ -14,6 +14,5 @@ package com.paypal.android.cardpayments
 data class CardVaultResult(
     val setupTokenId: String,
     val status: String,
-    // NOTE: This technically needs to null by default to prevent a breaking change
     val authChallenge: CardAuthChallenge? = null
 )

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
@@ -8,10 +8,10 @@ package com.paypal.android.cardpayments
  * @param setupTokenId the id for the setup token that was recently updated
  * @param status the status of the updated setup token
  */
+// NEXT MAJOR VERSION: make `CardVaultResult` constructor private
 data class CardVaultResult(
     val setupTokenId: String,
     val status: String,
     // NOTE: This technically needs to null by default to prevent a breaking change
-    // NEXT MAJOR VERSION: make `CardVaultResult` constructor private
     val authChallenge: CardAuthChallenge? = null
 )

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
@@ -14,5 +14,6 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class CardVaultResult(
     val setupTokenId: String,
-    val status: String
+    val status: String,
+    internal val approveHref: String? = null
 ) : Parcelable

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
@@ -7,7 +7,8 @@ package com.paypal.android.cardpayments
  *
  * @param setupTokenId the id for the setup token that was recently updated
  * @param status the status of the updated setup token
- * @param authChallenge an authentication challenge; will be non-null when 3DS authentication is required to complete a vault
+ * @param authChallenge an authentication challenge; will be non-null when 3DS authentication
+ * is required to complete a vault
  */
 // NEXT MAJOR VERSION: make `CardVaultResult` constructor private
 data class CardVaultResult(

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
@@ -15,5 +15,7 @@ import kotlinx.parcelize.Parcelize
 data class CardVaultResult(
     val setupTokenId: String,
     val status: String,
+    // NOTE: This technically needs to null by default to prevent a breaking change
+    // NEXT MAJOR VERSION: make `CardVaultResult` constructor private
     val authChallenge: CardAuthChallenge? = null
 ) : Parcelable

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
@@ -15,5 +15,5 @@ import kotlinx.parcelize.Parcelize
 data class CardVaultResult(
     val setupTokenId: String,
     val status: String,
-    internal val approveHref: String? = null
+    val authChallenge: CardAuthChallenge? = null
 ) : Parcelable

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
@@ -11,11 +11,10 @@ import kotlinx.parcelize.Parcelize
  * @param setupTokenId the id for the setup token that was recently updated
  * @param status the status of the updated setup token
  */
-@Parcelize
 data class CardVaultResult(
     val setupTokenId: String,
     val status: String,
     // NOTE: This technically needs to null by default to prevent a breaking change
     // NEXT MAJOR VERSION: make `CardVaultResult` constructor private
     val authChallenge: CardAuthChallenge? = null
-) : Parcelable
+)

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardVaultResult.kt
@@ -7,6 +7,7 @@ package com.paypal.android.cardpayments
  *
  * @param setupTokenId the id for the setup token that was recently updated
  * @param status the status of the updated setup token
+ * @param authChallenge an authentication challenge; will be non-null when 3DS authentication is required to complete a vault
  */
 // NEXT MAJOR VERSION: make `CardVaultResult` constructor private
 data class CardVaultResult(

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/DataVaultPaymentMethodTokensAPI.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/DataVaultPaymentMethodTokensAPI.kt
@@ -20,7 +20,7 @@ internal class DataVaultPaymentMethodTokensAPI internal constructor(
         ResourceLoader()
     )
 
-    suspend fun updateSetupToken(context: Context, setupTokenId: String, card: Card): CardVaultResult {
+    suspend fun updateSetupToken(context: Context, setupTokenId: String, card: Card): UpdateSetupTokenResult {
         val query = resourceLoader.loadRawResource(context, R.raw.graphql_query_update_setup_token)
 
         val cardNumber = card.number.replace("\\s".toRegex(), "")
@@ -58,15 +58,15 @@ internal class DataVaultPaymentMethodTokensAPI internal constructor(
         val graphQLResponse =
             graphQLClient.send(graphQLRequest, queryName = "UpdateVaultSetupToken")
         graphQLResponse.data?.let { responseJSON ->
-            val setupToken = responseJSON.getJSONObject("updateVaultSetupToken")
-            val status = setupToken.getString("status")
+            val setupTokenJSON = responseJSON.getJSONObject("updateVaultSetupToken")
+            val status = setupTokenJSON.getString("status")
             val approveHref = if (status == "PAYER_ACTION_REQUIRED") {
-                findLinkHref(responseJSON, "approve")
+                findLinkHref(setupTokenJSON, "approve")
             } else {
                 null
             }
-            return CardVaultResult(
-                setupTokenId = setupToken.getString("id"),
+            return UpdateSetupTokenResult(
+                setupTokenId = setupTokenJSON.getString("id"),
                 status = status,
                 approveHref = approveHref
             )

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/UpdateSetupTokenResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/UpdateSetupTokenResult.kt
@@ -1,0 +1,7 @@
+package com.paypal.android.cardpayments
+
+internal data class UpdateSetupTokenResult(
+    val setupTokenId: String,
+    val status: String,
+    val approveHref: String?
+)

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
@@ -17,7 +17,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class CardAuthLauncherUnitTest {
 
     private lateinit var browserSwitchClient: BrowserSwitchClient
@@ -45,7 +48,7 @@ class CardAuthLauncherUnitTest {
 
         every { browserSwitchClient.start(any(), any()) } throws browserSwitchException
 
-        val returnUrl = "merchant.app://return.com/destination"
+        val returnUrl = "merchant.app://return.com/deep-link"
         val cardRequest = CardRequest("fake-order-id", card, returnUrl)
         val cardAuthChallenge = CardAuthChallenge.ApproveOrder(url, cardRequest)
 
@@ -59,7 +62,7 @@ class CardAuthLauncherUnitTest {
         val slot = slot<BrowserSwitchOptions>()
         every { browserSwitchClient.start(activity, capture(slot)) } just runs
 
-        val returnUrl = "merchant.app://return.com/destination"
+        val returnUrl = "merchant.app://return.com/deep-link"
         val cardRequest = CardRequest("fake-order-id", card, returnUrl)
         val cardAuthChallenge = CardAuthChallenge.ApproveOrder(url, cardRequest)
 
@@ -72,7 +75,7 @@ class CardAuthLauncherUnitTest {
         assertEquals("approve_order", metadata?.getString("request_type"))
         assertEquals("fake-order-id", metadata?.getString("order_id"))
         assertEquals("merchant.app", browserSwitchOptions.returnUrlScheme)
-        assertEquals(Uri.parse("merchant.app://return.com/destination"), browserSwitchOptions.url)
+        assertEquals(Uri.parse("https://fake.com/destination"), browserSwitchOptions.url)
     }
 
     @Test
@@ -80,7 +83,7 @@ class CardAuthLauncherUnitTest {
         val slot = slot<BrowserSwitchOptions>()
         every { browserSwitchClient.start(activity, capture(slot)) } just runs
 
-        val returnUrl = "merchant.app://return.com/destination"
+        val returnUrl = "merchant.app://return.com/deep-link"
         val vaultRequest = CardVaultRequest("fake-setup-token-id", card, returnUrl)
         val vaultAuthRequest = CardAuthChallenge.Vault(url, vaultRequest)
 
@@ -93,7 +96,7 @@ class CardAuthLauncherUnitTest {
         assertEquals("vault", metadata?.getString("request_type"))
         assertEquals("fake-setup-token-id", metadata?.getString("setup_token_id"))
         assertEquals("merchant.app", browserSwitchOptions.returnUrlScheme)
-        assertEquals(Uri.parse("merchant.app://return.com/destination"), browserSwitchOptions.url)
+        assertEquals(Uri.parse("https://fake.com/destination"), browserSwitchOptions.url)
     }
 
     // TODO: migrate from approve order flow

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
@@ -239,6 +239,25 @@ class CardAuthLauncherUnitTest {
         assertEquals("SCA_COMPLETE", vaultResult.status)
     }
 
+    @Test
+    fun `deliverBrowserSwitchResult() returns vault canceled when deep link url contains the word cancel`() {
+        sut = CardAuthLauncher(browserSwitchClient)
+
+        val scheme = "com.paypal.android.demo"
+        val domain = "example.com"
+        val successDeepLink = "$scheme://$domain/canceled"
+
+        val browserSwitchResult = createBrowserSwitchResult(
+            BrowserSwitchStatus.SUCCESS,
+            vaultMetadata,
+            Uri.parse(successDeepLink)
+        )
+        every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+        val status = sut.deliverBrowserSwitchResult(activity) as CardStatus.VaultCanceled
+        assertEquals("fake-setup-token-id", status.setupTokenId)
+    }
+
     private fun createBrowserSwitchResult(
         @BrowserSwitchStatus status: Int,
         metadata: JSONObject? = null,

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
@@ -7,12 +7,12 @@ import com.braintreepayments.api.BrowserSwitchException
 import com.braintreepayments.api.BrowserSwitchOptions
 import com.braintreepayments.api.BrowserSwitchResult
 import com.braintreepayments.api.BrowserSwitchStatus
-import com.paypal.android.cardpayments.model.PaymentSource
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -33,8 +33,9 @@ class CardAuthLauncherUnitTest {
     private val url = Uri.parse("https://fake.com/destination")
     private val card = Card("4111111111111111", "01", "25", "123")
 
-    private val paymentSource = PaymentSource("1111", "Visa")
-    private val approveOrderMetadata = ApproveOrderMetadata("sample-order-id", paymentSource)
+    private val approveOrderMetadata = JSONObject()
+        .put("request_type", "approve_order")
+        .put("order_id", "fake-order-id")
 
     @Before
     fun beforeEach() {
@@ -99,162 +100,123 @@ class CardAuthLauncherUnitTest {
         assertEquals(Uri.parse("https://fake.com/destination"), browserSwitchOptions.url)
     }
 
-    // TODO: migrate from approve order flow
-//    @Test
-//    fun `handle browser switch result notifies user of success with liability shift`() =
-//        runTest {
-//            val sut = createCardClient(testScheduler)
-//
-//            val scheme = "com.paypal.android.demo"
-//            val domain = "example.com"
-//            val successDeepLink =
-//                "$scheme://$domain/return_url?state=undefined&code=undefined&liability_shift=NO"
-//
-//            val browserSwitchResult = createBrowserSwitchResult(
-//                BrowserSwitchStatus.SUCCESS,
-//                approveOrderMetadata,
-//                Uri.parse(successDeepLink)
-//            )
-//            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
-//
-//            sut.handleBrowserSwitchResult(activity)
-//            advanceUntilIdle()
-//
-//            val cardResultSlot = slot<CardResult>()
-//            coVerify(exactly = 1) {
-//                approveOrderListener.onApproveOrderSuccess(capture(cardResultSlot))
-//            }
-//
-//            val cardResult = cardResultSlot.captured
-//            assertEquals("sample-order-id", cardResult.orderId)
-//            assertEquals("NO", cardResult.liabilityShift)
-//        }
-    // TODO: migrate from approve order flow
-//    @Test
-//    fun `handle browser switch result notifies user of error when deep link contains one`() =
-//        runTest {
-//            val sut = createCardClient(testScheduler)
-//
-//            val scheme = "com.paypal.android.demo"
-//            val domain = "example.com"
-//            val successDeepLink = "$scheme://$domain/return_url?error=error"
-//
-//            val browserSwitchResult = createBrowserSwitchResult(
-//                BrowserSwitchStatus.SUCCESS,
-//                approveOrderMetadata,
-//                Uri.parse(successDeepLink)
-//            )
-//            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
-//
-//            sut.handleBrowserSwitchResult(activity)
-//            advanceUntilIdle()
-//
-//            val errorSlot = slot<PayPalSDKError>()
-//            coVerify(exactly = 1) {
-//                approveOrderListener.onApproveOrderFailure(capture(errorSlot))
-//            }
-//
-//            val error = errorSlot.captured
-//            assertEquals(0, error.code)
-//            assertEquals("3DS Verification is returning an error.", error.errorDescription)
-//        }
-    // TODO: migrate from approve order flow
-//    @Test
-//    fun `handle browser switch result notifies user of error when deep link is null`() =
-//        runTest {
-//            val sut = createCardClient(testScheduler)
-//            val browserSwitchResult = createBrowserSwitchResult(
-//                BrowserSwitchStatus.SUCCESS,
-//                approveOrderMetadata,
-//                deepLinkUrl = null
-//            )
-//            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
-//
-//            sut.handleBrowserSwitchResult(activity)
-//            advanceUntilIdle()
-//
-//            val errorSlot = slot<PayPalSDKError>()
-//            coVerify(exactly = 1) {
-//                approveOrderListener.onApproveOrderFailure(capture(errorSlot))
-//            }
-//
-//            val error = errorSlot.captured
-//            assertEquals(0, error.code)
-//            assertEquals("3DS Verification is returning an error.", error.errorDescription)
-//        }
-    // TODO: migrate from approve order flow
-//    @Test
-//    fun `handle browser switch result notifies user of error when success deep link is missing code parameter`() =
-//        runTest {
-//            val sut = createCardClient(testScheduler)
-//
-//            val scheme = "com.paypal.android.demo"
-//            val domain = "example.com"
-//            val successDeepLink = "$scheme://$domain/return_url?state=undefined&liability_shift=NO"
-//
-//            val browserSwitchResult = createBrowserSwitchResult(
-//                BrowserSwitchStatus.SUCCESS,
-//                approveOrderMetadata,
-//                Uri.parse(successDeepLink)
-//            )
-//            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
-//
-//            sut.handleBrowserSwitchResult(activity)
-//            advanceUntilIdle()
-//
-//            val errorSlot = slot<PayPalSDKError>()
-//            coVerify(exactly = 1) {
-//                approveOrderListener.onApproveOrderFailure(capture(errorSlot))
-//            }
-//
-//            val error = errorSlot.captured
-//            assertEquals(1, error.code)
-//            assertEquals("Malformed deeplink URL.", error.errorDescription)
-//        }
-    // TODO: migrate from approve order flow
-//    @Test
-//    fun `handle browser switch result notifies user of error when success deep link is missing state parameter`() =
-//        runTest {
-//            val sut = createCardClient(testScheduler)
-//
-//            val scheme = "com.paypal.android.demo"
-//            val domain = "example.com"
-//            val successDeepLink = "$scheme://$domain/return_url?code=undefined&liability_shift=NO"
-//
-//            val browserSwitchResult = createBrowserSwitchResult(
-//                BrowserSwitchStatus.SUCCESS,
-//                approveOrderMetadata,
-//                Uri.parse(successDeepLink)
-//            )
-//            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
-//
-//            sut.handleBrowserSwitchResult(activity)
-//            advanceUntilIdle()
-//
-//            val errorSlot = slot<PayPalSDKError>()
-//            coVerify(exactly = 1) {
-//                approveOrderListener.onApproveOrderFailure(capture(errorSlot))
-//            }
-//
-//            val error = errorSlot.captured
-//            assertEquals(1, error.code)
-//            assertEquals("Malformed deeplink URL.", error.errorDescription)
-//        }
-    // TODO: migrate from approve order flow
-//    @Test
-//    fun `handle browser switch result notifies listener of cancelation`() = runTest {
-//        val sut = createCardClient(testScheduler)
-//
-//        val browserSwitchResult = createBrowserSwitchResult(BrowserSwitchStatus.CANCELED)
-//        every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
-//
-//        sut.handleBrowserSwitchResult(activity)
-//        verify(exactly = 1) { approveOrderListener.onApproveOrderCanceled() }
-//    }
+    @Test
+    fun `deliverBrowserSwitchResult() returns approve order success when liability shift available`() {
+        sut = CardAuthLauncher(browserSwitchClient)
+
+        val scheme = "com.paypal.android.demo"
+        val domain = "example.com"
+        val successDeepLink =
+            "$scheme://$domain/return_url?state=undefined&code=undefined&liability_shift=NO"
+
+        val browserSwitchResult = createBrowserSwitchResult(
+            BrowserSwitchStatus.SUCCESS,
+            approveOrderMetadata,
+            Uri.parse(successDeepLink)
+        )
+        every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+        val status = sut.deliverBrowserSwitchResult(activity) as CardStatus.ApproveOrderSuccess
+        val cardResult = status.result
+        assertEquals("fake-order-id", cardResult.orderId)
+        assertEquals("NO", cardResult.liabilityShift)
+    }
+
+    @Test
+    fun `deliverBrowserSwitchResult() returns approve order error when deep link contains an error`() {
+        sut = CardAuthLauncher(browserSwitchClient)
+
+        val scheme = "com.paypal.android.demo"
+        val domain = "example.com"
+        val successDeepLink = "$scheme://$domain/return_url?error=error"
+
+        val browserSwitchResult = createBrowserSwitchResult(
+            BrowserSwitchStatus.SUCCESS,
+            approveOrderMetadata,
+            Uri.parse(successDeepLink)
+        )
+        every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+        val status = sut.deliverBrowserSwitchResult(activity) as CardStatus.ApproveOrderError
+        val error = status.error
+        assertEquals(0, error.code)
+        assertEquals("3DS Verification is returning an error.", error.errorDescription)
+    }
+
+    @Test
+    fun `deliverBrowserSwitchResult() returns approve order error when deep link is null`() {
+        sut = CardAuthLauncher(browserSwitchClient)
+
+        val browserSwitchResult = createBrowserSwitchResult(
+            BrowserSwitchStatus.SUCCESS,
+            approveOrderMetadata,
+            deepLinkUrl = null
+        )
+        every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+        val status = sut.deliverBrowserSwitchResult(activity) as CardStatus.ApproveOrderError
+        val error = status.error
+        assertEquals(0, error.code)
+        assertEquals("3DS Verification is returning an error.", error.errorDescription)
+    }
+
+    @Test
+    fun `deliverBrowserSwitchResult() returns approve order error when deep link is missing code parameter`() {
+        sut = CardAuthLauncher(browserSwitchClient)
+
+        val scheme = "com.paypal.android.demo"
+        val domain = "example.com"
+        val successDeepLink = "$scheme://$domain/return_url?state=undefined&liability_shift=NO"
+
+        val browserSwitchResult = createBrowserSwitchResult(
+            BrowserSwitchStatus.SUCCESS,
+            approveOrderMetadata,
+            Uri.parse(successDeepLink)
+        )
+        every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+        val status = sut.deliverBrowserSwitchResult(activity) as CardStatus.ApproveOrderError
+        val error = status.error
+        assertEquals(1, error.code)
+        assertEquals("Malformed deeplink URL.", error.errorDescription)
+    }
+
+    @Test
+    fun `deliverBrowserSwitchResult() returns approve order error when deep link is missing state parameter`() {
+        sut = CardAuthLauncher(browserSwitchClient)
+
+        val scheme = "com.paypal.android.demo"
+        val domain = "example.com"
+        val successDeepLink = "$scheme://$domain/return_url?code=undefined&liability_shift=NO"
+
+        val browserSwitchResult = createBrowserSwitchResult(
+            BrowserSwitchStatus.SUCCESS,
+            approveOrderMetadata,
+            Uri.parse(successDeepLink)
+        )
+        every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+        val status = sut.deliverBrowserSwitchResult(activity) as CardStatus.ApproveOrderError
+        val error = status.error
+        assertEquals(1, error.code)
+        assertEquals("Malformed deeplink URL.", error.errorDescription)
+    }
+
+    @Test
+    fun `deliverBrowserSwitchResult() returns approve order canceled when browser switch was canceled`() {
+        sut = CardAuthLauncher(browserSwitchClient)
+
+        val browserSwitchResult =
+            createBrowserSwitchResult(BrowserSwitchStatus.CANCELED, approveOrderMetadata)
+        every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+        val status = sut.deliverBrowserSwitchResult(activity) as CardStatus.ApproveOrderCanceled
+        assertEquals("fake-order-id", status.orderId)
+    }
 
     private fun createBrowserSwitchResult(
         @BrowserSwitchStatus status: Int,
-        metadata: ApproveOrderMetadata? = null,
+        metadata: JSONObject? = null,
         deepLinkUrl: Uri? = null
     ): BrowserSwitchResult {
 
@@ -262,7 +224,7 @@ class CardAuthLauncherUnitTest {
         every { browserSwitchResult.status } returns status
         every { browserSwitchResult.deepLinkUrl } returns deepLinkUrl
 
-        every { browserSwitchResult.requestMetadata } returns metadata?.toJSON()
+        every { browserSwitchResult.requestMetadata } returns metadata
         return browserSwitchResult
     }
 }

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
@@ -1,0 +1,5 @@
+package com.paypal.android.cardpayments
+
+class CardAuthLauncherUnitTest {
+
+}

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
@@ -1,5 +1,265 @@
 package com.paypal.android.cardpayments
 
+import android.net.Uri
+import androidx.fragment.app.FragmentActivity
+import com.braintreepayments.api.BrowserSwitchClient
+import com.braintreepayments.api.BrowserSwitchException
+import com.braintreepayments.api.BrowserSwitchOptions
+import com.braintreepayments.api.BrowserSwitchResult
+import com.braintreepayments.api.BrowserSwitchStatus
+import com.paypal.android.cardpayments.model.PaymentSource
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
 class CardAuthLauncherUnitTest {
 
+    private lateinit var browserSwitchClient: BrowserSwitchClient
+    private lateinit var sut: CardAuthLauncher
+
+    // TODO: consider using androidx.test activity instead of mockk
+    // Ref: https://robolectric.org/androidx_test/#activities
+    private val activity: FragmentActivity = mockk(relaxed = true)
+
+    private val url = Uri.parse("https://fake.com/destination")
+    private val card = Card("4111111111111111", "01", "25", "123")
+
+    private val paymentSource = PaymentSource("1111", "Visa")
+    private val approveOrderMetadata = ApproveOrderMetadata("sample-order-id", paymentSource)
+
+    @Before
+    fun beforeEach() {
+        browserSwitchClient = mockk(relaxed = true)
+    }
+
+    @Test
+    fun `presentAuthChallenge() returns an error when it cannot browser switch`() {
+        val browserSwitchException = mockk<BrowserSwitchException>()
+        every { browserSwitchException.message } returns "error message from browser switch"
+
+        every { browserSwitchClient.start(any(), any()) } throws browserSwitchException
+
+        val returnUrl = "merchant.app://return.com/destination"
+        val cardRequest = CardRequest("fake-order-id", card, returnUrl)
+        val cardAuthChallenge = CardAuthChallenge.ApproveOrder(url, cardRequest)
+
+        sut = CardAuthLauncher(browserSwitchClient)
+        val error = sut.presentAuthChallenge(activity, authChallenge = cardAuthChallenge)
+        assertEquals("error message from browser switch", error?.errorDescription)
+    }
+
+    @Test
+    fun `presentAuthChallenge() browser switches to approve order auth challenge url`() {
+        val slot = slot<BrowserSwitchOptions>()
+        every { browserSwitchClient.start(activity, capture(slot)) } just runs
+
+        val returnUrl = "merchant.app://return.com/destination"
+        val cardRequest = CardRequest("fake-order-id", card, returnUrl)
+        val cardAuthChallenge = CardAuthChallenge.ApproveOrder(url, cardRequest)
+
+        sut = CardAuthLauncher(browserSwitchClient)
+        val error = sut.presentAuthChallenge(activity, authChallenge = cardAuthChallenge)
+        assertNull(error)
+
+        val browserSwitchOptions = slot.captured
+        val metadata = browserSwitchOptions.metadata
+        assertEquals("approve_order", metadata?.getString("request_type"))
+        assertEquals("fake-order-id", metadata?.getString("order_id"))
+        assertEquals("merchant.app", browserSwitchOptions.returnUrlScheme)
+        assertEquals(Uri.parse("merchant.app://return.com/destination"), browserSwitchOptions.url)
+    }
+
+    @Test
+    fun `presentAuthChallenge() browser switches to vault auth challenge url`() {
+        val slot = slot<BrowserSwitchOptions>()
+        every { browserSwitchClient.start(activity, capture(slot)) } just runs
+
+        val returnUrl = "merchant.app://return.com/destination"
+        val vaultRequest = CardVaultRequest("fake-setup-token-id", card, returnUrl)
+        val vaultAuthRequest = CardAuthChallenge.Vault(url, vaultRequest)
+
+        sut = CardAuthLauncher(browserSwitchClient)
+        val error = sut.presentAuthChallenge(activity, authChallenge = vaultAuthRequest)
+        assertNull(error)
+
+        val browserSwitchOptions = slot.captured
+        val metadata = browserSwitchOptions.metadata
+        assertEquals("vault", metadata?.getString("request_type"))
+        assertEquals("fake-setup-token-id", metadata?.getString("setup_token_id"))
+        assertEquals("merchant.app", browserSwitchOptions.returnUrlScheme)
+        assertEquals(Uri.parse("merchant.app://return.com/destination"), browserSwitchOptions.url)
+    }
+
+    // TODO: migrate from approve order flow
+//    @Test
+//    fun `handle browser switch result notifies user of success with liability shift`() =
+//        runTest {
+//            val sut = createCardClient(testScheduler)
+//
+//            val scheme = "com.paypal.android.demo"
+//            val domain = "example.com"
+//            val successDeepLink =
+//                "$scheme://$domain/return_url?state=undefined&code=undefined&liability_shift=NO"
+//
+//            val browserSwitchResult = createBrowserSwitchResult(
+//                BrowserSwitchStatus.SUCCESS,
+//                approveOrderMetadata,
+//                Uri.parse(successDeepLink)
+//            )
+//            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+//
+//            sut.handleBrowserSwitchResult(activity)
+//            advanceUntilIdle()
+//
+//            val cardResultSlot = slot<CardResult>()
+//            coVerify(exactly = 1) {
+//                approveOrderListener.onApproveOrderSuccess(capture(cardResultSlot))
+//            }
+//
+//            val cardResult = cardResultSlot.captured
+//            assertEquals("sample-order-id", cardResult.orderId)
+//            assertEquals("NO", cardResult.liabilityShift)
+//        }
+    // TODO: migrate from approve order flow
+//    @Test
+//    fun `handle browser switch result notifies user of error when deep link contains one`() =
+//        runTest {
+//            val sut = createCardClient(testScheduler)
+//
+//            val scheme = "com.paypal.android.demo"
+//            val domain = "example.com"
+//            val successDeepLink = "$scheme://$domain/return_url?error=error"
+//
+//            val browserSwitchResult = createBrowserSwitchResult(
+//                BrowserSwitchStatus.SUCCESS,
+//                approveOrderMetadata,
+//                Uri.parse(successDeepLink)
+//            )
+//            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+//
+//            sut.handleBrowserSwitchResult(activity)
+//            advanceUntilIdle()
+//
+//            val errorSlot = slot<PayPalSDKError>()
+//            coVerify(exactly = 1) {
+//                approveOrderListener.onApproveOrderFailure(capture(errorSlot))
+//            }
+//
+//            val error = errorSlot.captured
+//            assertEquals(0, error.code)
+//            assertEquals("3DS Verification is returning an error.", error.errorDescription)
+//        }
+    // TODO: migrate from approve order flow
+//    @Test
+//    fun `handle browser switch result notifies user of error when deep link is null`() =
+//        runTest {
+//            val sut = createCardClient(testScheduler)
+//            val browserSwitchResult = createBrowserSwitchResult(
+//                BrowserSwitchStatus.SUCCESS,
+//                approveOrderMetadata,
+//                deepLinkUrl = null
+//            )
+//            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+//
+//            sut.handleBrowserSwitchResult(activity)
+//            advanceUntilIdle()
+//
+//            val errorSlot = slot<PayPalSDKError>()
+//            coVerify(exactly = 1) {
+//                approveOrderListener.onApproveOrderFailure(capture(errorSlot))
+//            }
+//
+//            val error = errorSlot.captured
+//            assertEquals(0, error.code)
+//            assertEquals("3DS Verification is returning an error.", error.errorDescription)
+//        }
+    // TODO: migrate from approve order flow
+//    @Test
+//    fun `handle browser switch result notifies user of error when success deep link is missing code parameter`() =
+//        runTest {
+//            val sut = createCardClient(testScheduler)
+//
+//            val scheme = "com.paypal.android.demo"
+//            val domain = "example.com"
+//            val successDeepLink = "$scheme://$domain/return_url?state=undefined&liability_shift=NO"
+//
+//            val browserSwitchResult = createBrowserSwitchResult(
+//                BrowserSwitchStatus.SUCCESS,
+//                approveOrderMetadata,
+//                Uri.parse(successDeepLink)
+//            )
+//            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+//
+//            sut.handleBrowserSwitchResult(activity)
+//            advanceUntilIdle()
+//
+//            val errorSlot = slot<PayPalSDKError>()
+//            coVerify(exactly = 1) {
+//                approveOrderListener.onApproveOrderFailure(capture(errorSlot))
+//            }
+//
+//            val error = errorSlot.captured
+//            assertEquals(1, error.code)
+//            assertEquals("Malformed deeplink URL.", error.errorDescription)
+//        }
+    // TODO: migrate from approve order flow
+//    @Test
+//    fun `handle browser switch result notifies user of error when success deep link is missing state parameter`() =
+//        runTest {
+//            val sut = createCardClient(testScheduler)
+//
+//            val scheme = "com.paypal.android.demo"
+//            val domain = "example.com"
+//            val successDeepLink = "$scheme://$domain/return_url?code=undefined&liability_shift=NO"
+//
+//            val browserSwitchResult = createBrowserSwitchResult(
+//                BrowserSwitchStatus.SUCCESS,
+//                approveOrderMetadata,
+//                Uri.parse(successDeepLink)
+//            )
+//            every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+//
+//            sut.handleBrowserSwitchResult(activity)
+//            advanceUntilIdle()
+//
+//            val errorSlot = slot<PayPalSDKError>()
+//            coVerify(exactly = 1) {
+//                approveOrderListener.onApproveOrderFailure(capture(errorSlot))
+//            }
+//
+//            val error = errorSlot.captured
+//            assertEquals(1, error.code)
+//            assertEquals("Malformed deeplink URL.", error.errorDescription)
+//        }
+    // TODO: migrate from approve order flow
+//    @Test
+//    fun `handle browser switch result notifies listener of cancelation`() = runTest {
+//        val sut = createCardClient(testScheduler)
+//
+//        val browserSwitchResult = createBrowserSwitchResult(BrowserSwitchStatus.CANCELED)
+//        every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+//
+//        sut.handleBrowserSwitchResult(activity)
+//        verify(exactly = 1) { approveOrderListener.onApproveOrderCanceled() }
+//    }
+
+    private fun createBrowserSwitchResult(
+        @BrowserSwitchStatus status: Int,
+        metadata: ApproveOrderMetadata? = null,
+        deepLinkUrl: Uri? = null
+    ): BrowserSwitchResult {
+
+        val browserSwitchResult = mockk<BrowserSwitchResult>(relaxed = true)
+        every { browserSwitchResult.status } returns status
+        every { browserSwitchResult.deepLinkUrl } returns deepLinkUrl
+
+        every { browserSwitchResult.requestMetadata } returns metadata?.toJSON()
+        return browserSwitchResult
+    }
 }

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
@@ -177,7 +177,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun `handleBrowserSwitchResult notifies merchant of approve order success`() = runTest {
+    fun `handleBrowserSwitchResult() notifies merchant of approve order success`() = runTest {
         val sut = createCardClient(testScheduler)
         sut.approveOrderListener = approveOrderListener
 
@@ -194,7 +194,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun `handleBrowserSwitchResult notifies merchant of approve order failure`() = runTest {
+    fun `handleBrowserSwitchResult() notifies merchant of approve order failure`() = runTest {
         val sut = createCardClient(testScheduler)
         sut.approveOrderListener = approveOrderListener
 
@@ -211,7 +211,7 @@ class CardClientUnitTest {
     }
 
     @Test
-    fun `handleBrowserSwitchResult notifies merchant of approve order cancelation`() = runTest {
+    fun `handleBrowserSwitchResult() notifies merchant of approve order cancelation`() = runTest {
         val sut = createCardClient(testScheduler)
         sut.approveOrderListener = approveOrderListener
 
@@ -222,6 +222,20 @@ class CardClientUnitTest {
         sut.handleBrowserSwitchResult(activity)
         verify(exactly = 1) { sut.approveOrderListener?.onApproveOrderCanceled() }
     }
+
+    @Test
+    fun `handleBrowserSwitchResult() doesn't deliver result when browserSwitchResult is null`() =
+        runTest {
+            val sut = createCardClient(testScheduler)
+            sut.approveOrderListener = approveOrderListener
+            sut.cardVaultListener = cardVaultListener
+
+            every { cardAuthLauncher.deliverBrowserSwitchResult(activity) } returns null
+
+            sut.handleBrowserSwitchResult(activity)
+            verify { sut.approveOrderListener?.wasNot(Called) }
+            verify { sut.cardVaultListener?.wasNot(Called) }
+        }
 
     private fun createCardClient(testScheduler: TestCoroutineScheduler): CardClient {
         val dispatcher = StandardTestDispatcher(testScheduler)

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
@@ -45,7 +45,7 @@ class CardClientUnitTest {
     private val cardVaultRequest =
         CardVaultRequest(setupTokenId = "fake-setup-token-id", card = card)
 
-    private val authChallengeLauncher = mockk<CardAuthChallengeLauncher>(relaxed = true)
+    private val authChallengeLauncher = mockk<CardAuthLauncher>(relaxed = true)
 
     private val checkoutOrdersAPI = mockk<CheckoutOrdersAPI>(relaxed = true)
     private val paymentMethodTokensAPI = mockk<DataVaultPaymentMethodTokensAPI>(relaxed = true)

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
@@ -201,7 +201,7 @@ class CardClientUnitTest {
         val error = PayPalSDKError(123, "fake-error-description")
         every {
             cardAuthLauncher.deliverBrowserSwitchResult(activity)
-        } returns CardStatus.ApproveOrderError(error)
+        } returns CardStatus.ApproveOrderError(error, "fake-order-id")
 
         sut.handleBrowserSwitchResult(activity)
 

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardRequestFactoryUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardRequestFactoryUnitTest.kt
@@ -119,13 +119,12 @@ class CardRequestFactoryUnitTest {
 
     @Test
     fun `it request 3DS strong consumer authentication with SCA_ALWAYS`() {
-        val card =
-            Card(
-                number = "4111111111111111",
-                expirationMonth = "01",
-                expirationYear = "2022",
-                "123"
-            )
+        val card = Card(
+            number = "4111111111111111",
+            expirationMonth = "01",
+            expirationYear = "2022",
+            "123"
+        )
 
         val cardRequest = CardRequest(orderId, card, returnUrl, SCA.SCA_ALWAYS)
 

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/DataVaultPaymentMethodTokensAPIUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/DataVaultPaymentMethodTokensAPIUnitTest.kt
@@ -162,4 +162,9 @@ class DataVaultPaymentMethodTokensAPIUnitTest {
         assertEquals("fake-setup-token-id-from-result", result.setupTokenId)
         assertEquals("fake-status", result.status)
     }
+
+    @Test
+    fun updateSetupToken_returnsVaultResultWithPayerActionURL() = runTest {
+        // TODO: implement
+    }
 }

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/DataVaultPaymentMethodTokensAPIUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/DataVaultPaymentMethodTokensAPIUnitTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -137,13 +138,17 @@ class DataVaultPaymentMethodTokensAPIUnitTest {
     }
 
     @Test
-    fun updateSetupToken_returnsVaultResult() = runTest {
+    fun updateSetupToken_returnsStatusApprovedVaultResult() = runTest {
         // language=JSON
         val json = """
             {
               "updateVaultSetupToken": {
                 "id": "fake-setup-token-id-from-result",
-                "status": "fake-status"
+                "status": "APPROVED",
+                "links": [
+                    { "rel": "self", "href": "https://fake.com/self/url" },
+                    { "rel": "confirm", "href": "https://fake.com/confirm/url" }
+                ]
               }
             }
         """.trimIndent()
@@ -160,11 +165,39 @@ class DataVaultPaymentMethodTokensAPIUnitTest {
         val result = sut.updateSetupToken(context, "fake-setup-token-id", card)
 
         assertEquals("fake-setup-token-id-from-result", result.setupTokenId)
-        assertEquals("fake-status", result.status)
+        assertEquals("APPROVED", result.status)
+        assertNull(result.approveHref)
     }
 
     @Test
     fun updateSetupToken_returnsVaultResultWithPayerActionURL() = runTest {
-        // TODO: implement
+        // language=JSON
+        val json = """
+            {
+                "updateVaultSetupToken": {
+                    "id": "fake-setup-token-id-from-result",
+                    "status": "PAYER_ACTION_REQUIRED",
+                    "links": [
+                        { "rel": "self", "href": "https://fake.com/self/url" },
+                        { "rel": "approve", "href": "https://fake.com/approval/url" }
+                    ]
+                }
+            }
+        """.trimIndent()
+        val graphQLResponse = GraphQLResponse(JSONObject(json))
+        coEvery { graphQLClient.send(any(), "UpdateVaultSetupToken") } returns graphQLResponse
+
+        val card = Card(
+            number = "4111111111111111",
+            expirationMonth = "01",
+            expirationYear = "24",
+            securityCode = "123"
+        )
+        sut = DataVaultPaymentMethodTokensAPI(coreConfig, graphQLClient, resourceLoader)
+        val result = sut.updateSetupToken(context, "fake-setup-token-id", card)
+
+        assertEquals("fake-setup-token-id-from-result", result.setupTokenId)
+        assertEquals("PAYER_ACTION_REQUIRED", result.status)
+        assertEquals("https://fake.com/approval/url", result.approveHref)
     }
 }

--- a/Demo/src/main/java/com/paypal/android/api/model/CardSetupToken.kt
+++ b/Demo/src/main/java/com/paypal/android/api/model/CardSetupToken.kt
@@ -4,4 +4,5 @@ data class CardSetupToken(
     val id: String,
     val customerId: String,
     val status: String,
+    val verificationStatus: String? = null,
 )

--- a/Demo/src/main/java/com/paypal/android/api/services/SDKSampleServerAPI.kt
+++ b/Demo/src/main/java/com/paypal/android/api/services/SDKSampleServerAPI.kt
@@ -83,6 +83,11 @@ class SDKSampleServerAPI {
 
         @POST("/payment_tokens")
         suspend fun createPaymentToken(@Body jsonObject: JsonObject): ResponseBody
+
+        @GET("/setup-tokens/{setupTokenId}")
+        suspend fun getSetupToken(
+            @Path("setupTokenId") setupTokenId: String,
+        ): ResponseBody
     }
 
     private val serviceMap: Map<MerchantIntegration, RetrofitService>
@@ -187,6 +192,24 @@ class SDKSampleServerAPI {
             id = responseJSON.getString("id"),
             customerId = customerJSON.getString("id"),
             status = responseJSON.getString("status"),
+        )
+    }
+
+    suspend fun getSetupToken(
+        setupTokenId: String,
+        merchantIntegration: MerchantIntegration = SELECTED_MERCHANT_INTEGRATION
+    ) = safeApiCall {
+        val response = findService(merchantIntegration).getSetupToken(setupTokenId)
+        val responseJSON = JSONObject(response.string())
+        val customerJSON = responseJSON.getJSONObject("customer")
+        val cardJSON = responseJSON
+            .getJSONObject("payment_source")
+            .getJSONObject("card")
+        CardSetupToken(
+            id = responseJSON.getString("id"),
+            customerId = customerJSON.getString("id"),
+            status = responseJSON.getString("status"),
+            verificationStatus = cardJSON.getString("verification_status")
         )
     }
 

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonColorOptionList.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonColorOptionList.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.paypal.android.R
 import com.paypal.android.paymentbuttons.PayPalButtonColor
-import com.paypal.android.ui.OptionList
+import com.paypal.android.uishared.components.OptionList
 
 @Composable
 fun PayPalButtonColorOptionList(

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonFundingTypeOptionList.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonFundingTypeOptionList.kt
@@ -3,7 +3,7 @@ package com.paypal.android.ui.paypalbuttons
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.paypal.android.R
-import com.paypal.android.ui.OptionList
+import com.paypal.android.uishared.components.OptionList
 
 @Composable
 fun PayPalButtonFundingTypeOptionList(

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonLabelOptionList.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalButtonLabelOptionList.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.paypal.android.R
 import com.paypal.android.paymentbuttons.PayPalButtonLabel
-import com.paypal.android.ui.OptionList
+import com.paypal.android.uishared.components.OptionList
 
 @Composable
 fun PayPalButtonLabelOptionList(

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalCreditButtonColorOptionList.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PayPalCreditButtonColorOptionList.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.paypal.android.R
 import com.paypal.android.paymentbuttons.PayPalCreditButtonColor
-import com.paypal.android.ui.OptionList
+import com.paypal.android.uishared.components.OptionList
 
 @Composable
 fun PayPalCreditButtonColorOptionList(

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PaymentButtonShapeOptionList.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PaymentButtonShapeOptionList.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.paypal.android.R
 import com.paypal.android.paymentbuttons.PaymentButtonShape
-import com.paypal.android.ui.OptionList
+import com.paypal.android.uishared.components.OptionList
 
 @Composable
 fun PaymentButtonShapeOptionList(

--- a/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PaymentButtonSizeOptionList.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalbuttons/PaymentButtonSizeOptionList.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.paypal.android.R
 import com.paypal.android.paymentbuttons.PaymentButtonSize
-import com.paypal.android.ui.OptionList
+import com.paypal.android.uishared.components.OptionList
 
 @Composable
 fun PaymentButtonSizeOptionList(

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardUiState.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardUiState.kt
@@ -4,6 +4,7 @@ import com.paypal.android.api.model.CardPaymentToken
 import com.paypal.android.api.model.CardSetupToken
 import com.paypal.android.cardpayments.CardAuthChallenge
 import com.paypal.android.cardpayments.CardVaultResult
+import com.paypal.android.cardpayments.threedsecure.SCA
 import com.paypal.android.uishared.state.ActionState
 
 data class VaultCardUiState(
@@ -15,7 +16,7 @@ data class VaultCardUiState(
     val cardNumber: String = "",
     val cardExpirationDate: String = "",
     val cardSecurityCode: String = "",
-    val shouldRequest3DS: Boolean = false,
+    val scaOption: SCA = SCA.SCA_WHEN_REQUIRED,
 ) {
     val isCreateSetupTokenSuccessful: Boolean
         get() = createSetupTokenState is ActionState.Success

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardUiState.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardUiState.kt
@@ -2,6 +2,7 @@ package com.paypal.android.ui.vaultcard
 
 import com.paypal.android.api.model.CardPaymentToken
 import com.paypal.android.api.model.CardSetupToken
+import com.paypal.android.cardpayments.CardAuthChallenge
 import com.paypal.android.cardpayments.CardVaultResult
 import com.paypal.android.uishared.state.ActionState
 
@@ -19,4 +20,7 @@ data class VaultCardUiState(
 
     val isVaultCardSuccessful: Boolean
         get() = vaultCardState is ActionState.Success
+
+    val authChallenge: CardAuthChallenge? =
+        (vaultCardState as? ActionState.Success)?.value?.authChallenge
 }

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardUiState.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardUiState.kt
@@ -12,6 +12,7 @@ data class VaultCardUiState(
     val cardNumber: String = "",
     val cardExpirationDate: String = "",
     val cardSecurityCode: String = "",
+    val shouldRequest3DS: Boolean = false,
 ) {
     val isCreateSetupTokenSuccessful: Boolean
         get() = createSetupTokenState is ActionState.Success

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardUiState.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardUiState.kt
@@ -8,8 +8,10 @@ import com.paypal.android.uishared.state.ActionState
 
 data class VaultCardUiState(
     val createSetupTokenState: ActionState<CardSetupToken, Exception> = ActionState.Idle,
-    val vaultCardState: ActionState<CardVaultResult, Exception> = ActionState.Idle,
+    val updateSetupTokenState: ActionState<CardVaultResult, Exception> = ActionState.Idle,
+    val authChallengeState: ActionState<CardVaultResult, Exception> = ActionState.Idle,
     val createPaymentTokenState: ActionState<CardPaymentToken, Exception> = ActionState.Idle,
+    val refreshSetupTokenState: ActionState<CardSetupToken, Exception> = ActionState.Idle,
     val cardNumber: String = "",
     val cardExpirationDate: String = "",
     val cardSecurityCode: String = "",
@@ -19,8 +21,10 @@ data class VaultCardUiState(
         get() = createSetupTokenState is ActionState.Success
 
     val isVaultCardSuccessful: Boolean
-        get() = vaultCardState is ActionState.Success
+        get() = updateSetupTokenState is ActionState.Success
 
     val authChallenge: CardAuthChallenge? =
-        (vaultCardState as? ActionState.Success)?.value?.authChallenge
+        (updateSetupTokenState as? ActionState.Success)?.value?.authChallenge
+    val isVaultWith3DSSuccessful: Boolean
+        get() = authChallengeState is ActionState.Success
 }

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.paypal.android.cardpayments.CardVaultResult
 import com.paypal.android.uishared.components.ActionButtonColumn
+import com.paypal.android.uishared.components.BooleanOptionList
 import com.paypal.android.uishared.components.CardForm
 import com.paypal.android.uishared.components.CardPaymentTokenView
 import com.paypal.android.uishared.components.CardSetupTokenView
@@ -79,6 +80,11 @@ private fun Step1_CreateSetupToken(uiState: VaultCardUiState, viewModel: VaultCa
         verticalArrangement = UIConstants.spacingMedium,
     ) {
         StepHeader(stepNumber = 1, title = "Create Setup Token")
+        BooleanOptionList(
+            title = "SCA WHEN REQUIRED",
+            selectedOption = uiState.shouldRequest3DS,
+            onSelectedOptionChange = { value -> viewModel.shouldRequest3DS = value },
+        )
         ActionButtonColumn(
             defaultTitle = "CREATE SETUP TOKEN",
             successTitle = "SETUP TOKEN CREATED",

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
@@ -27,6 +27,7 @@ import com.paypal.android.uishared.components.CardSetupTokenView
 import com.paypal.android.uishared.components.ErrorView
 import com.paypal.android.uishared.components.PropertyView
 import com.paypal.android.uishared.components.StepHeader
+import com.paypal.android.uishared.state.ActionState
 import com.paypal.android.uishared.state.CompletedActionState
 import com.paypal.android.utils.UIConstants
 import com.paypal.android.utils.getActivity
@@ -44,6 +45,16 @@ fun VaultCardView(
         // continuously scroll to bottom of the list when event state is updated
         scrollState.animateScrollTo(scrollState.maxValue)
     }
+
+    val context = LocalContext.current
+    LaunchedEffect(uiState.authChallenge) {
+        context.getActivity()?.let { activity ->
+            uiState.authChallenge?.let { authChallenge ->
+                viewModel.presentAuthChallenge(activity, authChallenge)
+            }
+        }
+    }
+
     val contentPadding = UIConstants.paddingMedium
     Column(
         verticalArrangement = UIConstants.spacingLarge,

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
@@ -18,15 +18,19 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.paypal.android.cardpayments.CardAuthChallenge
 import com.paypal.android.cardpayments.CardVaultResult
 import com.paypal.android.uishared.components.ActionButtonColumn
 import com.paypal.android.uishared.components.BooleanOptionList
 import com.paypal.android.uishared.components.CardForm
 import com.paypal.android.uishared.components.CardPaymentTokenView
 import com.paypal.android.uishared.components.CardSetupTokenView
+import com.paypal.android.uishared.components.CardVaultResultView
 import com.paypal.android.uishared.components.ErrorView
+import com.paypal.android.uishared.components.InfoColumn
 import com.paypal.android.uishared.components.PropertyView
 import com.paypal.android.uishared.components.StepHeader
+import com.paypal.android.uishared.state.ActionState
 import com.paypal.android.uishared.state.CompletedActionState
 import com.paypal.android.utils.UIConstants
 import com.paypal.android.utils.getActivity
@@ -45,15 +49,6 @@ fun VaultCardView(
         scrollState.animateScrollTo(scrollState.maxValue)
     }
 
-    val context = LocalContext.current
-    LaunchedEffect(uiState.authChallenge) {
-        context.getActivity()?.let { activity ->
-            uiState.authChallenge?.let { authChallenge ->
-                viewModel.presentAuthChallenge(activity, authChallenge)
-            }
-        }
-    }
-
     val contentPadding = UIConstants.paddingMedium
     Column(
         verticalArrangement = UIConstants.spacingLarge,
@@ -62,13 +57,27 @@ fun VaultCardView(
             .padding(horizontal = contentPadding)
             .verticalScroll(scrollState)
     ) {
-        Step1_CreateSetupToken(uiState, viewModel)
+        Step_CreateSetupToken(stepNumber = 1, uiState, viewModel)
         if (uiState.isCreateSetupTokenSuccessful) {
-            Step2_VaultCard(uiState, viewModel, onUseTestCardClick)
+            Step_VaultCard(stepNumber = 2, uiState, viewModel, onUseTestCardClick)
         }
-        if (uiState.isVaultCardSuccessful) {
-            Step3_CreatePaymentToken(uiState, viewModel)
+
+        val authChallenge = uiState.authChallenge
+        if (authChallenge != null) {
+            Step_PresentAuthChallenge(stepNumber = 3, authChallenge, uiState, viewModel)
+        } else if (uiState.isVaultCardSuccessful) {
+            Step_CreatePaymentToken(stepNumber = 3, uiState, viewModel)
         }
+
+        if (uiState.isVaultWith3DSSuccessful) {
+            (uiState.refreshSetupTokenState as? ActionState.Success)?.value?.let { setupToken ->
+                InfoColumn(title = "UPDATED SETUP TOKEN") {
+                    CardSetupTokenView(setupToken = setupToken)
+                }
+            }
+            Step_CreatePaymentToken(stepNumber = 4, uiState, viewModel)
+        }
+
         Spacer(modifier = Modifier.size(contentPadding))
     }
 }
@@ -85,11 +94,15 @@ fun VaultSuccessView(cardVaultResult: CardVaultResult) {
 }
 
 @Composable
-private fun Step1_CreateSetupToken(uiState: VaultCardUiState, viewModel: VaultCardViewModel) {
+private fun Step_CreateSetupToken(
+    stepNumber: Int,
+    uiState: VaultCardUiState,
+    viewModel: VaultCardViewModel
+) {
     Column(
         verticalArrangement = UIConstants.spacingMedium,
     ) {
-        StepHeader(stepNumber = 1, title = "Create Setup Token")
+        StepHeader(stepNumber = stepNumber, title = "Create Setup Token")
         BooleanOptionList(
             title = "SCA WHEN REQUIRED",
             selectedOption = uiState.shouldRequest3DS,
@@ -111,7 +124,8 @@ private fun Step1_CreateSetupToken(uiState: VaultCardUiState, viewModel: VaultCa
 
 @ExperimentalMaterial3Api
 @Composable
-private fun Step2_VaultCard(
+private fun Step_VaultCard(
+    stepNumber: Int,
     uiState: VaultCardUiState,
     viewModel: VaultCardViewModel,
     onUseTestCardClick: () -> Unit
@@ -120,7 +134,7 @@ private fun Step2_VaultCard(
     Column(
         verticalArrangement = UIConstants.spacingMedium,
     ) {
-        StepHeader(stepNumber = 2, title = "Vault Card")
+        StepHeader(stepNumber = stepNumber, title = "Vault Card")
         CardForm(
             cardNumber = uiState.cardNumber,
             expirationDate = uiState.cardExpirationDate,
@@ -133,7 +147,7 @@ private fun Step2_VaultCard(
         ActionButtonColumn(
             defaultTitle = "VAULT CARD",
             successTitle = "CARD VAULTED",
-            state = uiState.vaultCardState,
+            state = uiState.updateSetupTokenState,
             onClick = {
                 context.getActivity()?.let { viewModel.updateSetupToken(it) }
             }
@@ -148,14 +162,44 @@ private fun Step2_VaultCard(
 
 @ExperimentalMaterial3Api
 @Composable
-private fun Step3_CreatePaymentToken(
+private fun Step_PresentAuthChallenge(
+    stepNumber: Int,
+    authChallenge: CardAuthChallenge,
+    uiState: VaultCardUiState,
+    viewModel: VaultCardViewModel
+) {
+    val context = LocalContext.current
+    Column(
+        verticalArrangement = UIConstants.spacingMedium,
+    ) {
+        StepHeader(stepNumber = stepNumber, title = "Complete Auth Challenge")
+        ActionButtonColumn(
+            defaultTitle = "PRESENT AUTH CHALLENGE",
+            successTitle = "AUTH CHALLENGE COMPLETE",
+            state = uiState.authChallengeState,
+            onClick = {
+                context.getActivity()?.let { viewModel.presentAuthChallenge(it, authChallenge) }
+            }
+        ) { state ->
+            when (state) {
+                is CompletedActionState.Failure -> ErrorView(error = state.value)
+                is CompletedActionState.Success -> CardVaultResultView(result = state.value)
+            }
+        }
+    }
+}
+
+@ExperimentalMaterial3Api
+@Composable
+private fun Step_CreatePaymentToken(
+    stepNumber: Int,
     uiState: VaultCardUiState,
     viewModel: VaultCardViewModel
 ) {
     Column(
         verticalArrangement = UIConstants.spacingMedium,
     ) {
-        StepHeader(stepNumber = 3, title = "Create Payment Token")
+        StepHeader(stepNumber = stepNumber, title = "Create Payment Token")
         ActionButtonColumn(
             defaultTitle = "CREATE PAYMENT TOKEN",
             successTitle = "PAYMENT TOKEN CREATED",

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
@@ -27,7 +27,6 @@ import com.paypal.android.uishared.components.CardSetupTokenView
 import com.paypal.android.uishared.components.ErrorView
 import com.paypal.android.uishared.components.PropertyView
 import com.paypal.android.uishared.components.StepHeader
-import com.paypal.android.uishared.state.ActionState
 import com.paypal.android.uishared.state.CompletedActionState
 import com.paypal.android.utils.UIConstants
 import com.paypal.android.utils.getActivity

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
@@ -15,17 +15,19 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.paypal.android.R
 import com.paypal.android.cardpayments.CardAuthChallenge
 import com.paypal.android.cardpayments.CardVaultResult
 import com.paypal.android.uishared.components.ActionButtonColumn
-import com.paypal.android.uishared.components.BooleanOptionList
 import com.paypal.android.uishared.components.CardForm
 import com.paypal.android.uishared.components.CardPaymentTokenView
 import com.paypal.android.uishared.components.CardSetupTokenView
 import com.paypal.android.uishared.components.CardVaultResultView
+import com.paypal.android.uishared.components.EnumOptionList
 import com.paypal.android.uishared.components.ErrorView
 import com.paypal.android.uishared.components.InfoColumn
 import com.paypal.android.uishared.components.PropertyView
@@ -103,10 +105,11 @@ private fun Step_CreateSetupToken(
         verticalArrangement = UIConstants.spacingMedium,
     ) {
         StepHeader(stepNumber = stepNumber, title = "Create Setup Token")
-        BooleanOptionList(
-            title = "SCA WHEN REQUIRED",
-            selectedOption = uiState.shouldRequest3DS,
-            onSelectedOptionChange = { value -> viewModel.shouldRequest3DS = value },
+        EnumOptionList(
+            title = stringResource(id = R.string.sca_title),
+            stringArrayResId = R.array.sca_options,
+            onSelectedOptionChange = { value -> viewModel.scaOption = value },
+            selectedOption = uiState.scaOption
         )
         ActionButtonColumn(
             defaultTitle = "CREATE SETUP TOKEN",

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
@@ -76,6 +76,12 @@ class VaultCardViewModel @Inject constructor(
             _uiState.update { it.copy(cardSecurityCode = value) }
         }
 
+    var shouldRequest3DS: Boolean
+        get() = _uiState.value.shouldRequest3DS
+        set(value) {
+            _uiState.update { it.copy(shouldRequest3DS = value) }
+        }
+
     fun prefillCard(testCard: TestCard) {
         val card = testCard.card
         _uiState.update { currentState ->

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
@@ -96,7 +96,8 @@ class VaultCardViewModel @Inject constructor(
     fun createSetupToken() {
         viewModelScope.launch {
             createSetupTokenState = ActionState.Loading
-            createSetupTokenState = createSetupTokenUseCase().mapToActionState()
+            val perform3DS = _uiState.value.shouldRequest3DS
+            createSetupTokenState = createSetupTokenUseCase(perform3DS).mapToActionState()
         }
     }
 

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
@@ -1,6 +1,7 @@
 package com.paypal.android.ui.vaultcard
 
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.paypal.android.api.model.CardSetupToken
@@ -18,6 +19,7 @@ import com.paypal.android.usecase.CreateCardPaymentTokenUseCase
 import com.paypal.android.usecase.CreateCardSetupTokenUseCase
 import com.paypal.android.usecase.GetClientIdUseCase
 import com.paypal.android.api.services.SDKSampleServerResult
+import com.paypal.android.cardpayments.CardAuthChallenge
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -162,5 +164,9 @@ class VaultCardViewModel @Inject constructor(
             expirationYear = dateString.formattedYear,
             securityCode = uiState.cardSecurityCode
         )
+    }
+
+    fun presentAuthChallenge(activity: FragmentActivity, authChallenge: CardAuthChallenge) {
+        cardClient.presentAuthChallenge(activity, authChallenge)
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
@@ -135,7 +135,8 @@ class VaultCardViewModel @Inject constructor(
                 }
 
                 val card = parseCard(_uiState.value)
-                val cardVaultRequest = CardVaultRequest(setupTokenId, card)
+                val returnUrl = "com.paypal.android.demo://example.com/returnUrl"
+                val cardVaultRequest = CardVaultRequest(setupTokenId, card, returnUrl)
                 cardClient.vault(activity, cardVaultRequest)
             }
         }

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
@@ -12,6 +12,7 @@ import com.paypal.android.cardpayments.CardClient
 import com.paypal.android.cardpayments.CardVaultListener
 import com.paypal.android.cardpayments.CardVaultRequest
 import com.paypal.android.cardpayments.CardVaultResult
+import com.paypal.android.cardpayments.threedsecure.SCA
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.models.TestCard
@@ -92,10 +93,10 @@ class VaultCardViewModel @Inject constructor(
             _uiState.update { it.copy(cardSecurityCode = value) }
         }
 
-    var shouldRequest3DS: Boolean
-        get() = _uiState.value.shouldRequest3DS
+    var scaOption: SCA
+        get() = _uiState.value.scaOption
         set(value) {
-            _uiState.update { it.copy(shouldRequest3DS = value) }
+            _uiState.update { it.copy(scaOption = value) }
         }
 
     fun prefillCard(testCard: TestCard) {
@@ -112,8 +113,8 @@ class VaultCardViewModel @Inject constructor(
     fun createSetupToken() {
         viewModelScope.launch {
             createSetupTokenState = ActionState.Loading
-            val perform3DS = _uiState.value.shouldRequest3DS
-            createSetupTokenState = createSetupTokenUseCase(perform3DS).mapToActionState()
+            val sca = _uiState.value.scaOption
+            createSetupTokenState = createSetupTokenUseCase(sca).mapToActionState()
         }
     }
 

--- a/Demo/src/main/java/com/paypal/android/uishared/components/BooleanOptionList.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/BooleanOptionList.kt
@@ -1,0 +1,42 @@
+package com.paypal.android.uishared.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.paypal.android.utils.UIConstants
+
+@Composable
+fun BooleanOptionList(
+    title: String,
+    selectedOption: Boolean,
+    onSelectedOptionChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val options = listOf("YES", "NO")
+    val selectedOptionString = if (selectedOption) "YES" else "NO"
+    OptionList(
+        title = title,
+        options = options,
+        selectedOption = selectedOptionString,
+        onSelectedOptionChange = { value -> onSelectedOptionChange(value == "YES") },
+        modifier = modifier
+    )
+}
+
+@Preview
+@Composable
+fun BooleanOptionListPreview() {
+    MaterialTheme {
+        Surface {
+            BooleanOptionList(
+                title = "Fake Title",
+                onSelectedOptionChange = {},
+                selectedOption = true,
+                modifier = Modifier.padding(UIConstants.paddingSmall)
+            )
+        }
+    }
+}

--- a/Demo/src/main/java/com/paypal/android/uishared/components/BooleanOptionList.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/BooleanOptionList.kt
@@ -15,7 +15,7 @@ fun BooleanOptionList(
     onSelectedOptionChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val options = listOf("YES", "NO")
+    val options = listOf("NO", "YES")
     val selectedOptionString = if (selectedOption) "YES" else "NO"
     OptionList(
         title = title,

--- a/Demo/src/main/java/com/paypal/android/uishared/components/CardSetupTokenView.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/CardSetupTokenView.kt
@@ -16,5 +16,8 @@ fun CardSetupTokenView(setupToken: CardSetupToken) {
         PropertyView(name = "ID", value = setupToken.id)
         PropertyView(name = "Customer ID", value = setupToken.customerId)
         PropertyView(name = "Status", value = setupToken.status)
+        setupToken.verificationStatus?.let { verificationStatus ->
+            PropertyView(name = "Verification Status", value = verificationStatus)
+        }
     }
 }

--- a/Demo/src/main/java/com/paypal/android/uishared/components/CardVaultResultView.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/CardVaultResultView.kt
@@ -1,0 +1,19 @@
+package com.paypal.android.uishared.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.paypal.android.cardpayments.CardVaultResult
+import com.paypal.android.utils.UIConstants
+
+@Composable
+fun CardVaultResultView(result: CardVaultResult) {
+    Column(
+        verticalArrangement = UIConstants.spacingMedium,
+        modifier = Modifier.padding(UIConstants.paddingMedium)
+    ) {
+        PropertyView(name = "Setup Token ID", value = result.setupTokenId)
+        PropertyView(name = "Status", value = result.status)
+    }
+}

--- a/Demo/src/main/java/com/paypal/android/uishared/components/EnumOptionList.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/EnumOptionList.kt
@@ -95,7 +95,7 @@ inline fun <reified T : Enum<T>> EnumOptionList(
 
 @Preview
 @Composable
-fun OptionListPreview() {
+fun EnumOptionListPreview() {
     MaterialTheme {
         Surface {
             EnumOptionList(

--- a/Demo/src/main/java/com/paypal/android/uishared/components/InfoColumn.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/InfoColumn.kt
@@ -1,23 +1,18 @@
 package com.paypal.android.uishared.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.paypal.android.utils.UIConstants
-import org.intellij.lang.annotations.JdkConstants.HorizontalAlignment
 
 @Composable
 fun InfoColumn(

--- a/Demo/src/main/java/com/paypal/android/uishared/components/InfoColumn.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/InfoColumn.kt
@@ -1,0 +1,66 @@
+package com.paypal.android.uishared.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import com.paypal.android.utils.UIConstants
+import org.intellij.lang.annotations.JdkConstants.HorizontalAlignment
+
+@Composable
+fun InfoColumn(
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit = {},
+) {
+    Card(
+        modifier = modifier
+    ) {
+        Row(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.inverseSurface),
+        ) {
+            Text(
+                text = title,
+                color = MaterialTheme.colorScheme.inverseOnSurface,
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(UIConstants.paddingMedium)
+                    .fillMaxWidth()
+            )
+        }
+        Column {
+            content()
+        }
+    }
+}
+
+@Preview
+@Composable
+fun InfoColumnPreview() {
+    MaterialTheme {
+        Column {
+            InfoColumn(
+                title = "Sample Title"
+            ) {
+                Text(
+                    text = "Sample Text",
+                    modifier = Modifier.padding(UIConstants.paddingLarge)
+                )
+            }
+        }
+    }
+}

--- a/Demo/src/main/java/com/paypal/android/uishared/components/OptionList.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/OptionList.kt
@@ -1,4 +1,4 @@
-package com.paypal.android.ui
+package com.paypal.android.uishared.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column

--- a/Demo/src/main/java/com/paypal/android/uishared/components/OrderView.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/OrderView.kt
@@ -1,10 +1,8 @@
 package com.paypal.android.uishared.components
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text

--- a/Demo/src/main/java/com/paypal/android/uishared/components/OrderView.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/OrderView.kt
@@ -22,11 +22,10 @@ fun OrderView(order: Order, title: String? = null) {
             .padding(UIConstants.paddingMedium)
     ) {
         title?.let { text ->
-            Spacer(modifier = Modifier.size(UIConstants.paddingMedium))
             Text(
                 text = text,
                 style = MaterialTheme.typography.titleLarge,
-                modifier = Modifier.padding(horizontal = UIConstants.paddingMedium)
+                modifier = Modifier.padding(vertical = UIConstants.paddingMedium)
             )
         }
         Column(

--- a/Demo/src/main/java/com/paypal/android/uishared/state/ActionState.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/state/ActionState.kt
@@ -5,4 +5,7 @@ sealed class ActionState<out S, out E> {
     object Loading : ActionState<Nothing, Nothing>()
     data class Success<S>(val value: S) : ActionState<S, Nothing>()
     data class Failure<E>(val value: E) : ActionState<Nothing, E>()
+
+    val isComplete: Boolean
+        get() = (this is Success) || (this is Failure)
 }

--- a/Demo/src/main/java/com/paypal/android/usecase/CreateCardSetupTokenUseCase.kt
+++ b/Demo/src/main/java/com/paypal/android/usecase/CreateCardSetupTokenUseCase.kt
@@ -13,6 +13,7 @@ class CreateCardSetupTokenUseCase @Inject constructor(
     private val sdkSampleServerAPI: SDKSampleServerAPI
 ) {
 
+    // TODO: pass SCA enum as parameter instead of perform3DS
     suspend operator fun invoke(perform3DS: Boolean): SDKSampleServerResult<CardSetupToken, Exception> =
         withContext(Dispatchers.IO) {
             // create a payment token with an empty card attribute; the merchant app will

--- a/Demo/src/main/java/com/paypal/android/usecase/CreateCardSetupTokenUseCase.kt
+++ b/Demo/src/main/java/com/paypal/android/usecase/CreateCardSetupTokenUseCase.kt
@@ -7,7 +7,6 @@ import com.paypal.android.api.services.SDKSampleServerAPI
 import com.paypal.android.api.services.SDKSampleServerResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.json.JSONObject
 import javax.inject.Inject
 
 class CreateCardSetupTokenUseCase @Inject constructor(

--- a/Demo/src/main/java/com/paypal/android/usecase/CreateCardSetupTokenUseCase.kt
+++ b/Demo/src/main/java/com/paypal/android/usecase/CreateCardSetupTokenUseCase.kt
@@ -5,6 +5,7 @@ import com.google.gson.JsonParser
 import com.paypal.android.api.model.CardSetupToken
 import com.paypal.android.api.services.SDKSampleServerAPI
 import com.paypal.android.api.services.SDKSampleServerResult
+import com.paypal.android.cardpayments.threedsecure.SCA
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -13,36 +14,24 @@ class CreateCardSetupTokenUseCase @Inject constructor(
     private val sdkSampleServerAPI: SDKSampleServerAPI
 ) {
 
-    // TODO: pass SCA enum as parameter instead of perform3DS
-    suspend operator fun invoke(perform3DS: Boolean): SDKSampleServerResult<CardSetupToken, Exception> =
+    suspend operator fun invoke(sca: SCA): SDKSampleServerResult<CardSetupToken, Exception> =
         withContext(Dispatchers.IO) {
             // create a payment token with an empty card attribute; the merchant app will
             // provide the card's details through the SDK
-            val request = if (perform3DS) {
-                // language=JSON
-                """
-                {
-                    "payment_source": {
-                        "card": {
-                            "verification_method": "SCA_ALWAYS",
-                            "experience_context": {
-                                "return_url": "com.paypal.android.demo://vault/success",
-                                "cancel_url": "com.paypal.android.demo://vault/cancel"
-                            }
+            // language=JSON
+            val request = """
+            {
+                "payment_source": {
+                    "card": {
+                        "verification_method": "${sca.name}",
+                        "experience_context": {
+                            "return_url": "com.paypal.android.demo://vault/success",
+                            "cancel_url": "com.paypal.android.demo://vault/cancel"
                         }
                     }
                 }
-                """
-            } else {
-                // language=JSON
-                """
-                {
-                    "payment_source": {
-                        "card": {}
-                    }
-                }
-                """
             }
+            """
             val jsonOrder = JsonParser.parseString(request) as JsonObject
             sdkSampleServerAPI.createSetupToken(jsonOrder)
         }

--- a/Demo/src/main/java/com/paypal/android/usecase/GetSetupTokenUseCase.kt
+++ b/Demo/src/main/java/com/paypal/android/usecase/GetSetupTokenUseCase.kt
@@ -11,7 +11,6 @@ class GetSetupTokenUseCase @Inject constructor(
     private val sdkSampleServerAPI: SDKSampleServerAPI
 ) {
 
-    // TODO: pass SCA enum as parameter instead of perform3DS
     suspend operator fun invoke(setupTokenId: String): SDKSampleServerResult<CardSetupToken, Exception> =
         withContext(Dispatchers.IO) {
             sdkSampleServerAPI.getSetupToken(setupTokenId)

--- a/Demo/src/main/java/com/paypal/android/usecase/GetSetupTokenUseCase.kt
+++ b/Demo/src/main/java/com/paypal/android/usecase/GetSetupTokenUseCase.kt
@@ -1,0 +1,19 @@
+package com.paypal.android.usecase
+
+import com.paypal.android.api.model.CardSetupToken
+import com.paypal.android.api.services.SDKSampleServerAPI
+import com.paypal.android.api.services.SDKSampleServerResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class GetSetupTokenUseCase @Inject constructor(
+    private val sdkSampleServerAPI: SDKSampleServerAPI
+) {
+
+    // TODO: pass SCA enum as parameter instead of perform3DS
+    suspend operator fun invoke(setupTokenId: String): SDKSampleServerResult<CardSetupToken, Exception> =
+        withContext(Dispatchers.IO) {
+            sdkSampleServerAPI.getSetupToken(setupTokenId)
+        }
+}

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
@@ -13,6 +13,8 @@ import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.paypalwebpayments.errors.PayPalWebCheckoutError
 import org.json.JSONObject
 
+// TODO: consider renaming PayPalWebLauncher to PayPalAuthChallengeLauncher
+
 internal class PayPalWebLauncher(
     private val urlScheme: String,
     private val coreConfig: CoreConfig,

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/errors/PayPalWebCheckoutError.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/errors/PayPalWebCheckoutError.kt
@@ -17,6 +17,7 @@ internal object PayPalWebCheckoutError {
         errorDescription = "Result did not contain the expected data. Payer ID or Order ID is null."
     )
 
+    // 2. An error occurred while browser switching
     fun browserSwitchError(cause: BrowserSwitchException) = PayPalSDKError(
         code = PayPalWebCheckoutErrorCode.BROWSER_SWITCH.ordinal,
         errorDescription = cause.message ?: "Unable to Browser Switch"

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -23,6 +23,9 @@ class PayPalWebCheckoutClientUnitTest {
 
     private val analyticsService = mockk<AnalyticsService>(relaxed = true)
 
+    private val checkoutListener = mockk<PayPalWebCheckoutListener>(relaxed = true)
+    private val vaultListener = mockk<PayPalWebVaultListener>(relaxed = true)
+
     private lateinit var payPalWebLauncher: PayPalWebLauncher
     private lateinit var sut: PayPalWebCheckoutClient
 
@@ -34,19 +37,19 @@ class PayPalWebCheckoutClientUnitTest {
 
     @Test
     fun `start() launches PayPal web checkout`() {
-        sut.listener = mockk(relaxed = true)
+        sut.listener = checkoutListener
 
         every { payPalWebLauncher.launchPayPalWebCheckout(any(), any()) } returns null
 
         val request = PayPalWebCheckoutRequest("fake-order-id")
         sut.start(request)
         verify(exactly = 1) { payPalWebLauncher.launchPayPalWebCheckout(activity, request) }
-        verify(exactly = 0) { sut.listener?.onPayPalWebFailure(any()) }
+        verify(exactly = 0) { checkoutListener.onPayPalWebFailure(any()) }
     }
 
     @Test
     fun `start() notifies merchant of browser switch failure`() {
-        sut.listener = mockk(relaxed = true)
+        sut.listener = checkoutListener
 
         val sdkError = PayPalSDKError(123, "fake error description")
         every { payPalWebLauncher.launchPayPalWebCheckout(any(), any()) } returns sdkError
@@ -55,14 +58,14 @@ class PayPalWebCheckoutClientUnitTest {
         sut.start(request)
 
         val slot = slot<PayPalSDKError>()
-        verify(exactly = 1) { sut.listener?.onPayPalWebFailure(capture(slot)) }
+        verify(exactly = 1) { checkoutListener.onPayPalWebFailure(capture(slot)) }
 
         assertSame(slot.captured, sdkError)
     }
 
     @Test
     fun `vault() launches PayPal web checkout`() {
-        sut.vaultListener = mockk(relaxed = true)
+        sut.vaultListener = vaultListener
 
         every { payPalWebLauncher.launchPayPalWebVault(any(), any()) } returns null
 
@@ -70,12 +73,12 @@ class PayPalWebCheckoutClientUnitTest {
             PayPalWebVaultRequest("fake-setup-token-id", "https://example.com/approval/url")
         sut.vault(request)
         verify(exactly = 1) { payPalWebLauncher.launchPayPalWebVault(activity, request) }
-        verify(exactly = 0) { sut.vaultListener?.onPayPalWebVaultFailure(any()) }
+        verify(exactly = 0) { vaultListener.onPayPalWebVaultFailure(any()) }
     }
 
     @Test
     fun `vault() notifies merchant of browser switch failure`() {
-        sut.vaultListener = mockk(relaxed = true)
+        sut.vaultListener = vaultListener
 
         val sdkError = PayPalSDKError(123, "fake error description")
         every { payPalWebLauncher.launchPayPalWebVault(any(), any()) } returns sdkError
@@ -85,14 +88,14 @@ class PayPalWebCheckoutClientUnitTest {
         sut.vault(request)
 
         val slot = slot<PayPalSDKError>()
-        verify(exactly = 1) { sut.vaultListener?.onPayPalWebVaultFailure(capture(slot)) }
+        verify(exactly = 1) { vaultListener.onPayPalWebVaultFailure(capture(slot)) }
 
         assertSame(slot.captured, sdkError)
     }
 
     @Test
     fun `handleBrowserSwitchResult notifies merchant of Checkout success`() {
-        sut.listener = mockk(relaxed = true)
+        sut.listener = checkoutListener
 
         val successResult = PayPalWebCheckoutResult("fake-order-id", "fake-payer-id")
         every {
@@ -102,13 +105,13 @@ class PayPalWebCheckoutClientUnitTest {
         sut.handleBrowserSwitchResult()
 
         val slot = slot<PayPalWebCheckoutResult>()
-        verify(exactly = 1) { sut.listener?.onPayPalWebSuccess(capture(slot)) }
+        verify(exactly = 1) { checkoutListener.onPayPalWebSuccess(capture(slot)) }
         assertSame(successResult, slot.captured)
     }
 
     @Test
     fun `handleBrowserSwitchResult notifies merchant of Checkout failure`() {
-        sut.listener = mockk(relaxed = true)
+        sut.listener = checkoutListener
 
         val error = PayPalSDKError(123, "fake-error-description")
         every {
@@ -118,13 +121,13 @@ class PayPalWebCheckoutClientUnitTest {
         sut.handleBrowserSwitchResult()
 
         val slot = slot<PayPalSDKError>()
-        verify(exactly = 1) { sut.listener?.onPayPalWebFailure(capture(slot)) }
+        verify(exactly = 1) { checkoutListener.onPayPalWebFailure(capture(slot)) }
         assertSame(error, slot.captured)
     }
 
     @Test
     fun `handleBrowserSwitchResult notifies merchant of Checkout cancelation`() {
-        sut.listener = mockk(relaxed = true)
+        sut.listener = checkoutListener
 
         val status = PayPalWebStatus.CheckoutCanceled("fake-order_id")
         every {
@@ -133,17 +136,62 @@ class PayPalWebCheckoutClientUnitTest {
 
         sut.handleBrowserSwitchResult()
 
-        verify(exactly = 1) { sut.listener?.onPayPalWebCanceled() }
+        verify(exactly = 1) { checkoutListener.onPayPalWebCanceled() }
+    }
+
+    @Test
+    fun `handleBrowserSwitchResult notifies merchant of vault success`() {
+        sut.vaultListener = vaultListener
+
+        val successResult = PayPalWebVaultResult("fake-approval-session-id")
+        every {
+            payPalWebLauncher.deliverBrowserSwitchResult(activity)
+        } returns PayPalWebStatus.VaultSuccess(successResult)
+
+        sut.handleBrowserSwitchResult()
+
+        val slot = slot<PayPalWebVaultResult>()
+        verify(exactly = 1) { vaultListener.onPayPalWebVaultSuccess(capture(slot)) }
+        assertSame(successResult, slot.captured)
+    }
+
+    @Test
+    fun `handleBrowserSwitchResult notifies merchant of vault failure`() {
+        sut.vaultListener = vaultListener
+
+        val error = PayPalSDKError(123, "fake-error-description")
+        every {
+            payPalWebLauncher.deliverBrowserSwitchResult(activity)
+        } returns PayPalWebStatus.VaultError(error)
+
+        sut.handleBrowserSwitchResult()
+
+        val slot = slot<PayPalSDKError>()
+        verify(exactly = 1) { vaultListener.onPayPalWebVaultFailure(capture(slot)) }
+        assertSame(error, slot.captured)
+    }
+
+    @Test
+    fun `handleBrowserSwitchResult notifies merchant of vault cancelation`() {
+        sut.vaultListener = vaultListener
+
+        every {
+            payPalWebLauncher.deliverBrowserSwitchResult(activity)
+        } returns PayPalWebStatus.VaultCanceled
+
+        sut.handleBrowserSwitchResult()
+        verify(exactly = 1) { vaultListener.onPayPalWebVaultCanceled() }
     }
 
     @Test
     fun `handleBrowserSwitchResult doesn't deliver result when browserSwitchResult is null`() {
-        sut.listener = mockk(relaxed = true)
+        sut.listener = checkoutListener
+        sut.vaultListener = vaultListener
         every { payPalWebLauncher.deliverBrowserSwitchResult(activity) } returns null
 
         sut.handleBrowserSwitchResult()
-        verify { sut.listener?.wasNot(Called) }
-        verify { sut.vaultListener?.wasNot(Called) }
+        verify { checkoutListener.wasNot(Called) }
+        verify { vaultListener.wasNot(Called) }
     }
 
     @Test

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -143,6 +143,7 @@ class PayPalWebCheckoutClientUnitTest {
 
         sut.handleBrowserSwitchResult()
         verify { sut.listener?.wasNot(Called) }
+        verify { sut.vaultListener?.wasNot(Called) }
     }
 
     @Test


### PR DESCRIPTION
### What

This PR adds Card Vault without Purchase 3DS authentication to the Demo app.

### Summary of changes

  * Add `CardClient#presentAuthChallenge()`
  * Add `returnUrl` property to `CardVaultRequest`
  * Add `authChallenge` property to `CardVaultResult`
  * Add `CardAuthChallenge` type

 ### Checklist

 - [x] Added a changelog entry

### Screenshot


https://github.com/paypal/paypal-android/assets/58225613/5aa4df70-02c6-4848-a5e3-484f083a159c



### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
