### PR TITLE
Convert PayPalWebCheckoutClient from lateinit to nullable

### DIFF
--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
@@ -37,7 +37,7 @@ class PayPalWebVaultViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(PayPalWebVaultUiState())
     val uiState = _uiState.asStateFlow()
 
-    private lateinit var paypalClient: PayPalWebCheckoutClient
+    private var paypalClient: PayPalWebCheckoutClient? = null
     private lateinit var payPalDataCollector: PayPalDataCollector
     private var createSetupTokenState
         get() = _uiState.value.createSetupTokenState
@@ -95,9 +95,9 @@ class PayPalWebVaultViewModel @Inject constructor(
                 payPalDataCollector = PayPalDataCollector(coreConfig)
 
                 paypalClient = PayPalWebCheckoutClient(activity, coreConfig, URL_SCHEME)
-                paypalClient.vaultListener = this@PayPalWebVaultViewModel
+                paypalClient?.vaultListener = this@PayPalWebVaultViewModel
 
-                paypalClient.vault(request)
+                paypalClient?.vault(request)
             }
         }
     }
@@ -129,6 +129,6 @@ class PayPalWebVaultViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        paypalClient.removeObservers()
+        paypalClient?.removeObservers()
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Convert `PayPalWebCheckoutClient` from a lateinit var to a nullable var in the demo app

There was a crash in the demo app when `PayPalWebCheckoutClient` was not getting set either due to a network error or if the PayPal activity was cleared without setting the client. This crash was introduced when the `removeObservers()` function was added to the PayPalClient.

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
