### PR TITLE
Update demo app Clients from lateinit vars to nullable vars

### DIFF
--- a/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
@@ -47,7 +47,7 @@ class ApproveOrderViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(ApproveOrderUiState())
     val uiState = _uiState.asStateFlow()
 
-    private lateinit var cardClient: CardClient
+    private var cardClient: CardClient? = null
     private lateinit var payPalDataCollector: PayPalDataCollector
 
     fun createOrder() {
@@ -85,7 +85,7 @@ class ApproveOrderViewModel @Inject constructor(
                 payPalDataCollector = PayPalDataCollector(coreConfig)
 
                 cardClient = CardClient(activity, coreConfig)
-                cardClient.approveOrderListener = object : ApproveOrderListener {
+                cardClient?.approveOrderListener = object : ApproveOrderListener {
                     override fun onApproveOrderSuccess(result: CardResult) {
                         approveOrderState = ActionState.Success(result)
                     }
@@ -108,7 +108,7 @@ class ApproveOrderViewModel @Inject constructor(
                 }
 
                 val cardRequest = mapUIStateToCardRequestWithOrderId(orderId)
-                cardClient.approveOrder(activity, cardRequest)
+                cardClient?.approveOrder(activity, cardRequest)
             }
         }
     }
@@ -210,7 +210,6 @@ class ApproveOrderViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-
-        cardClient.removeObservers()
+        cardClient?.removeObservers()
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalWebViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalWebViewModel.kt
@@ -41,7 +41,7 @@ class PayPalWebViewModel @Inject constructor(
         private val TAG = PayPalWebViewModel::class.qualifiedName
     }
 
-    private lateinit var paypalClient: PayPalWebCheckoutClient
+    private var paypalClient: PayPalWebCheckoutClient? = null
     private lateinit var payPalDataCollector: PayPalDataCollector
 
     private val _uiState = MutableStateFlow(PayPalWebUiState())
@@ -115,9 +115,9 @@ class PayPalWebViewModel @Inject constructor(
 
                 paypalClient =
                     PayPalWebCheckoutClient(activity, coreConfig, "com.paypal.android.demo")
-                paypalClient.listener = this@PayPalWebViewModel
+                paypalClient?.listener = this@PayPalWebViewModel
 
-                paypalClient.start(PayPalWebCheckoutRequest(orderId, fundingSource))
+                paypalClient?.start(PayPalWebCheckoutRequest(orderId, fundingSource))
             }
         }
     }
@@ -157,7 +157,6 @@ class PayPalWebViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-
-        paypalClient.removeObservers()
+        paypalClient?.removeObservers()
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
@@ -37,7 +37,7 @@ class VaultCardViewModel @Inject constructor(
     val createPaymentTokenUseCase: CreateCardPaymentTokenUseCase
 ) : ViewModel() {
 
-    private lateinit var cardClient: CardClient
+    private var cardClient: CardClient? = null
 
     private val _uiState = MutableStateFlow(VaultCardUiState())
     val uiState = _uiState.asStateFlow()
@@ -142,7 +142,7 @@ class VaultCardViewModel @Inject constructor(
                 val clientId = clientIdResult.value
                 val configuration = CoreConfig(clientId = clientId)
                 cardClient = CardClient(activity, configuration)
-                cardClient.cardVaultListener = object : CardVaultListener {
+                cardClient?.cardVaultListener = object : CardVaultListener {
 
                     override fun onVaultSuccess(result: CardVaultResult) {
                         updateSetupTokenState = ActionState.Success(result)
@@ -156,7 +156,7 @@ class VaultCardViewModel @Inject constructor(
                 val card = parseCard(_uiState.value)
                 val returnUrl = "com.paypal.android.demo://example.com/returnUrl"
                 val cardVaultRequest = CardVaultRequest(setupTokenId, card, returnUrl)
-                cardClient.vault(activity, cardVaultRequest)
+                cardClient?.vault(activity, cardVaultRequest)
             }
         }
     }
@@ -189,7 +189,7 @@ class VaultCardViewModel @Inject constructor(
         authChallengeState = ActionState.Loading
 
         // change listener behavior to handle auth result
-        cardClient.cardVaultListener = object : CardVaultListener {
+        cardClient?.cardVaultListener = object : CardVaultListener {
             override fun onVaultSuccess(result: CardVaultResult) {
                 viewModelScope.launch {
                     refreshSetupTokenState =
@@ -202,11 +202,11 @@ class VaultCardViewModel @Inject constructor(
                 authChallengeState = ActionState.Failure(error)
             }
         }
-        cardClient.presentAuthChallenge(activity, authChallenge)
+        cardClient?.presentAuthChallenge(activity, authChallenge)
     }
 
     override fun onCleared() {
         super.onCleared()
-        cardClient.removeObservers()
+        cardClient?.removeObservers()
     }
 }


### PR DESCRIPTION
### Summary of changes

- Convert Clients from a lateinit var to a nullable var in the demo app for card and PayPal web flows

There were crashes in the demo app where lateinit Clients were not getting set either due to a network error or if the activity was cleared without setting the client. These crashes were introduced when the removeObservers() function was added to the clients.

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
