### PR TITLE
Provide ways to define PayLaterButton color from xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # PayPal Android SDK Release Notes
 
-## 1.4.0 (2024-04-29)
+## unreleased
 * PaymentButtons
-  * Undeprecate `PayPalCreditButtonColor.BLACK` and `.DARK_BLUE`
-  * Undeprecate `PayPalButtonColor.BLUE`, `.BLACK`, and `.SILVER`
-  * Added analytics events
-    * `payment-button:initialized` and `payment-button:tapped`
+  * Add `paylater_color` to `PayLaterButton` to control the color of the pay later button from XML.
+
+## 1.4.0 (2024-04-29)
 * CardPayments
   * Add `liabilityShift` property to `CardResult`
   * Callback `PayPalSDKError` when `CardClient#approveOrder()` 3DS verification fails
@@ -20,12 +19,16 @@
     * Create `PayPalDataCollectorRequest`
     * Add `PayPalDataCollector#collectDeviceData(context, request)`
     * Deprecate `PayPalDataCollector#collectDeviceData(context, clientMetadataId, additionalData)`
+* PaymentButtons
+  * Undeprecate `PayPalCreditButtonColor.BLACK` and `.DARK_BLUE`
+  * Undeprecate `PayPalButtonColor.BLUE`, `.BLACK`, and `.SILVER`
+  * Added analytics events
+    * `payment-button:initialized` and `payment-button:tapped`
+  * Update font typeface to "PayPalOpen" to meet brand guidelines
 * PayPalNativePayments
   * Fixes Google Play Store Rejection
     * Bump Native Checkout version to 1.3.2
     * Add `hasUserLocationConsent` to `PayPalNativeCheckoutRequest`
-* PaymentButtons
-  * Update font typeface to "PayPalOpen" to meet brand guidelines
 * PayPalWebPayments
   * Add `PayPalWebCheckoutClient.removeObservers()` method
 

--- a/Demo/src/main/java/com/paypal/android/ui/DemoApp.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/DemoApp.kt
@@ -27,6 +27,7 @@ import com.paypal.android.ui.approveorder.ApproveOrderViewModel
 import com.paypal.android.ui.features.FeaturesView
 import com.paypal.android.ui.paypalbuttons.PayPalButtonsView
 import com.paypal.android.ui.paypalnative.PayPalNativeView
+import com.paypal.android.ui.paypalstaticbuttons.PayPalStaticButtonsView
 import com.paypal.android.ui.paypalweb.PayPalWebView
 import com.paypal.android.ui.paypalwebvault.PayPalWebVaultView
 import com.paypal.android.ui.selectcard.SelectCardView
@@ -114,6 +115,9 @@ fun DemoApp() {
                 }
                 composable(DemoAppDestinations.PAYPAL_BUTTONS) {
                     PayPalButtonsView()
+                }
+                composable(DemoAppDestinations.PAYPAL_STATIC_BUTTONS) {
+                    PayPalStaticButtonsView()
                 }
                 composable(DemoAppDestinations.PAYPAL_NATIVE) {
                     PayPalNativeView()

--- a/Demo/src/main/java/com/paypal/android/ui/DemoAppDestinations.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/DemoAppDestinations.kt
@@ -7,6 +7,7 @@ object DemoAppDestinations {
     const val PAYPAL_WEB = "paypal_web"
     const val PAYPAL_WEB_VAULT = "paypal_web_vault"
     const val PAYPAL_BUTTONS = "paypal_buttons"
+    const val PAYPAL_STATIC_BUTTONS = "paypal_static_buttons"
     const val PAYPAL_NATIVE = "paypal_native"
     const val SELECT_TEST_CARD = "select_test_card"
 
@@ -16,6 +17,7 @@ object DemoAppDestinations {
         CARD_VAULT -> "Vault Card"
         PAYPAL_WEB -> "PayPal Web"
         PAYPAL_BUTTONS -> "PayPal Buttons"
+        PAYPAL_STATIC_BUTTONS -> "PayPal Static Buttons"
         PAYPAL_NATIVE -> "PayPal Native"
         SELECT_TEST_CARD -> "Select a Test Card"
         PAYPAL_WEB_VAULT -> "PayPal Web Vault"

--- a/Demo/src/main/java/com/paypal/android/ui/features/Feature.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/features/Feature.kt
@@ -10,5 +10,9 @@ enum class Feature(@StringRes val stringRes: Int, val routeName: String) {
     PAYPAL_WEB(R.string.feature_paypal_web, DemoAppDestinations.PAYPAL_WEB),
     PAYPAL_WEB_VAULT(R.string.feature_paypal_web_vault, DemoAppDestinations.PAYPAL_WEB_VAULT),
     PAYPAL_BUTTONS(R.string.feature_paypal_buttons, DemoAppDestinations.PAYPAL_BUTTONS),
+    PAYPAL_STATIC_BUTTONS(
+        R.string.feature_paypal_static_buttons,
+        DemoAppDestinations.PAYPAL_STATIC_BUTTONS
+    ),
     PAYPAL_NATIVE(R.string.feature_paypal_native, DemoAppDestinations.PAYPAL_NATIVE)
 }

--- a/Demo/src/main/java/com/paypal/android/ui/features/FeaturesView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/features/FeaturesView.kt
@@ -37,6 +37,7 @@ private val cardFeatures = listOf(
 private val payPalWebFeatures = listOf(
     Feature.PAYPAL_WEB,
     Feature.PAYPAL_BUTTONS,
+    Feature.PAYPAL_STATIC_BUTTONS,
     Feature.PAYPAL_WEB_VAULT
 )
 

--- a/Demo/src/main/java/com/paypal/android/ui/paypalstaticbuttons/PayPalStaticButtonsView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalstaticbuttons/PayPalStaticButtonsView.kt
@@ -1,10 +1,12 @@
 package com.paypal.android.ui.paypalstaticbuttons
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.viewinterop.AndroidView
 import com.paypal.android.R
 
+@SuppressLint("InflateParams")
 @Composable
 fun PayPalStaticButtonsView() {
     AndroidView(

--- a/Demo/src/main/java/com/paypal/android/ui/paypalstaticbuttons/PayPalStaticButtonsView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalstaticbuttons/PayPalStaticButtonsView.kt
@@ -2,7 +2,9 @@ package com.paypal.android.ui.paypalstaticbuttons
 
 import android.annotation.SuppressLint
 import android.view.LayoutInflater
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import com.paypal.android.R
 
@@ -15,6 +17,7 @@ fun PayPalStaticButtonsView() {
                 .inflate(R.layout.pay_later_button_test_layout, null, false)
 
             view
-        }
+        },
+        modifier = Modifier.fillMaxSize()
     )
 }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalstaticbuttons/PayPalStaticButtonsView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalstaticbuttons/PayPalStaticButtonsView.kt
@@ -1,0 +1,18 @@
+package com.paypal.android.ui.paypalstaticbuttons
+
+import android.view.LayoutInflater
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.viewinterop.AndroidView
+import com.paypal.android.R
+
+@Composable
+fun PayPalStaticButtonsView() {
+    AndroidView(
+        factory = { context ->
+            val view = LayoutInflater.from(context)
+                .inflate(R.layout.pay_later_button_test_layout, null, false)
+
+            view
+        }
+    )
+}

--- a/Demo/src/main/res/layout/pay_later_button_test_layout.xml
+++ b/Demo/src/main/res/layout/pay_later_button_test_layout.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- XML view for testing only. These aren't used anywhere else in the demo application. -->
-
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"

--- a/Demo/src/main/res/layout/pay_later_button_test_layout.xml
+++ b/Demo/src/main/res/layout/pay_later_button_test_layout.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.paypal.android.paymentbuttons.PayLaterButton
+        android:id="@+id/button1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:padding="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:paylater_color="white"
+        />
+
+    <com.paypal.android.paymentbuttons.PayLaterButton
+        android:id="@+id/button2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button1"
+        android:layout_margin="8dp"
+        android:padding="8dp"
+        app:paylater_color="gold"
+        />
+
+    <com.paypal.android.paymentbuttons.PayLaterButton
+        android:id="@+id/button3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button2"
+        android:layout_margin="8dp"
+        android:padding="8dp"
+        app:paylater_color="blue"
+        />
+
+    <com.paypal.android.paymentbuttons.PayLaterButton
+        android:id="@+id/button4"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button3"
+        android:layout_margin="8dp"
+        android:padding="8dp"
+        app:paylater_color="silver"
+        />
+
+    <com.paypal.android.paymentbuttons.PayLaterButton
+        android:id="@+id/button5"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button4"
+        android:layout_margin="8dp"
+        android:padding="8dp"
+        app:paylater_color="black"
+        />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Demo/src/main/res/layout/pay_later_button_test_layout.xml
+++ b/Demo/src/main/res/layout/pay_later_button_test_layout.xml
@@ -3,8 +3,10 @@
 <!-- XML view for testing only. These aren't used anywhere else in the demo application. -->
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    tools:ignore="UnusedResources"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <com.paypal.android.paymentbuttons.PayLaterButton

--- a/Demo/src/main/res/layout/pay_later_button_test_layout.xml
+++ b/Demo/src/main/res/layout/pay_later_button_test_layout.xml
@@ -1,59 +1,107 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:ignore="UnusedResources">
 
-    <com.paypal.android.paymentbuttons.PayLaterButton
-        android:id="@+id/button1"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
-        android:padding="8dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:paylater_color="white" />
+        android:orientation="vertical">
 
-    <com.paypal.android.paymentbuttons.PayLaterButton
-        android:id="@+id/button2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:padding="8dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button1"
-        app:paylater_color="gold" />
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="PayPal Button"
+            tools:ignore="HardcodedText" />
 
-    <com.paypal.android.paymentbuttons.PayLaterButton
-        android:id="@+id/button3"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:padding="8dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button2"
-        app:paylater_color="blue" />
+        <com.paypal.android.paymentbuttons.PayPalButton
+            android:id="@+id/button7"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:paypal_color="white" />
 
-    <com.paypal.android.paymentbuttons.PayLaterButton
-        android:id="@+id/button4"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:padding="8dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button3"
-        app:paylater_color="silver" />
+        <com.paypal.android.paymentbuttons.PayPalButton
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:paypal_color="black" />
 
-    <com.paypal.android.paymentbuttons.PayLaterButton
-        android:id="@+id/button5"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:padding="8dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button4"
-        app:paylater_color="black" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.paypal.android.paymentbuttons.PayPalButton
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:paypal_color="blue" />
+
+        <com.paypal.android.paymentbuttons.PayPalButton
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:paypal_color="gold" />
+
+        <com.paypal.android.paymentbuttons.PayPalButton
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:paypal_color="silver" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Pay Later"
+            tools:ignore="HardcodedText" />
+
+        <com.paypal.android.paymentbuttons.PayLaterButton
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:paylater_color="white" />
+
+        <com.paypal.android.paymentbuttons.PayLaterButton
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:paylater_color="gold" />
+
+        <com.paypal.android.paymentbuttons.PayLaterButton
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:paylater_color="blue" />
+
+        <com.paypal.android.paymentbuttons.PayLaterButton
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:paylater_color="silver" />
+
+        <com.paypal.android.paymentbuttons.PayLaterButton
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:paylater_color="black" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="PayPal Credit"
+            tools:ignore="HardcodedText" />
+
+        <com.paypal.android.paymentbuttons.PayPalCreditButton
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:paypal_credit_color="black" />
+
+        <com.paypal.android.paymentbuttons.PayPalCreditButton
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:paypal_credit_color="dark_blue" />
+
+    </LinearLayout>
+</ScrollView>

--- a/Demo/src/main/res/layout/pay_later_button_test_layout.xml
+++ b/Demo/src/main/res/layout/pay_later_button_test_layout.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!-- XML view for testing only. These aren't used anywhere else in the demo application. -->
+
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/Demo/src/main/res/layout/pay_later_button_test_layout.xml
+++ b/Demo/src/main/res/layout/pay_later_button_test_layout.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:ignore="UnusedResources"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    tools:ignore="UnusedResources">
 
     <com.paypal.android.paymentbuttons.PayLaterButton
         android:id="@+id/button1"
@@ -15,50 +15,45 @@
         android:padding="8dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:paylater_color="white"
-        />
+        app:paylater_color="white" />
 
     <com.paypal.android.paymentbuttons.PayLaterButton
         android:id="@+id/button2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button1"
         android:layout_margin="8dp"
         android:padding="8dp"
-        app:paylater_color="gold"
-        />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button1"
+        app:paylater_color="gold" />
 
     <com.paypal.android.paymentbuttons.PayLaterButton
         android:id="@+id/button3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button2"
         android:layout_margin="8dp"
         android:padding="8dp"
-        app:paylater_color="blue"
-        />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button2"
+        app:paylater_color="blue" />
 
     <com.paypal.android.paymentbuttons.PayLaterButton
         android:id="@+id/button4"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button3"
         android:layout_margin="8dp"
         android:padding="8dp"
-        app:paylater_color="silver"
-        />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button3"
+        app:paylater_color="silver" />
 
     <com.paypal.android.paymentbuttons.PayLaterButton
         android:id="@+id/button5"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button4"
         android:layout_margin="8dp"
         android:padding="8dp"
-        app:paylater_color="black"
-        />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button4"
+        app:paylater_color="black" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="feature_paypal_web_vault">PayPal Web Vault</string>
     <string name="feature_paypal_native">PayPal Native</string>
     <string name="feature_paypal_buttons">PayPal Buttons</string>
+    <string name="feature_paypal_static_buttons">PayPal Buttons - XML</string>
 
     <!-- Card Fields -->
     <string name="card_field_card_number">CARD NUMBER</string>

--- a/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PayLaterButton.kt
+++ b/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PayLaterButton.kt
@@ -64,12 +64,23 @@ class PayLaterButton @JvmOverloads constructor(
     override val fundingType: PaymentButtonFundingType = PaymentButtonFundingType.PAY_LATER
 
     init {
+        context.obtainStyledAttributes(attributeSet, R.styleable.PayLaterButton).use { typedArray ->
+            updateColorFrom(typedArray)
+        }
         updateLabel(PayPalButtonLabel.PAY_LATER)
         analyticsService.sendAnalyticsEvent(
             "payment-button:initialized",
             orderId = null,
             buttonType = PaymentButtonFundingType.PAY_LATER.buttonType
         )
+    }
+
+    private fun updateColorFrom(typedArray: TypedArray) {
+        val paypalColorAttributeIndex = typedArray.getInt(
+            R.styleable.PayLaterButton_paylater_color,
+            PayPalButtonColor.GOLD.value
+        )
+        color = PayPalButtonColor(paypalColorAttributeIndex)
     }
 
     private fun updateLabel(updatedLabel: PayPalButtonLabel) {

--- a/PaymentButtons/src/main/res/values/attrs.xml
+++ b/PaymentButtons/src/main/res/values/attrs.xml
@@ -39,4 +39,14 @@
             <enum name="white" value="3" />
         </attr>
     </declare-styleable>
+
+    <declare-styleable name="PayLaterButton">
+    <attr name="paylater_color" format="enum">
+        <enum name="gold" value="0" />
+        <enum name="blue" value="1" />
+        <enum name="white" value="2" />
+        <enum name="black" value="3" />
+        <enum name="silver" value="4" />
+    </attr>
+    </declare-styleable>
 </resources>


### PR DESCRIPTION
### Summary of changes

Addresses a Live Issue reported by a merchant.
 - Fix issue with `PayLaterButton` not honoring `paypal_color` attribute in xml.
 - `PayLaterButton` used to extend from `PayPalButton`, but now it extends from `PaymentButton`. I'm providing a new attribute `paylater_color` to change the button color in xml.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @saperi22 

### Screenshots

<img width="409" alt="Screenshot 2024-05-23 at 9 36 08 AM" src="https://github.com/paypal/paypal-android/assets/104481964/047abb60-2e49-4abd-8b6f-90ddb720994e">
<img width="401" alt="Screenshot 2024-05-23 at 9 36 14 AM" src="https://github.com/paypal/paypal-android/assets/104481964/9a848eb1-daa7-4811-8a3f-329eae82a2ed">

