### PR TITLE
Revert 3DS URL Parsing for CardResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # PayPal Android SDK Release Notes
 
+## unreleased
+
+* CardPayments
+  * Deprecate `CardResult.liabilityShift` property
+  * Add `CardResult.status` property
+  * Add `CardResult.didAttemptThreeDSecureAuthentication` property
+
 ## 1.5.0 (2024-07-10)
 * PayPalWebPayments
   * Deprecate `PayPalWebVaultRequest(setupTokenId, approveVaultHref)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * CardPayments
   * Deprecate `CardResult.liabilityShift` property
+  * Deprecate `CardResult.deepLinkUrl` property
   * Add `CardResult.status` property
   * Add `CardResult.didAttemptThreeDSecureAuthentication` property
 

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthLauncher.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthLauncher.kt
@@ -145,7 +145,11 @@ internal class CardAuthLauncher(
                 CardStatus.ApproveOrderError(CardError.malformedDeepLinkError, orderId)
             } else {
                 val liabilityShift = deepLinkUrl.getQueryParameter("liability_shift")
-                val result = CardResult(orderId, deepLinkUrl, liabilityShift)
+                val result = CardResult(
+                    orderId = orderId,
+                    liabilityShift = liabilityShift,
+                    didAttemptThreeDSecureAuthentication = true
+                )
                 CardStatus.ApproveOrderSuccess(result)
             }
         }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -92,7 +92,11 @@ class CardClient internal constructor(
                 )
 
                 if (response.payerActionHref == null) {
-                    val result = CardResult(response.orderId)
+                    val result = CardResult(
+                        orderId = response.orderId,
+                        status = response.status?.name,
+                        didAttemptThreeDSecureAuthentication = false
+                    )
                     notifyApproveOrderSuccess(result)
                 } else {
                     analyticsService.sendAnalyticsEvent(

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResult.kt
@@ -1,7 +1,5 @@
 package com.paypal.android.cardpayments
 
-import android.net.Uri
-
 /**
  * A result returned by [CardClient] when an order was successfully approved with a [Card].
  *
@@ -14,14 +12,10 @@ import android.net.Uri
 data class CardResult(
     val orderId: String,
 
-    /**
-     * @suppress
-     */
-    val deepLinkUrl: Uri? = null,
-
     @Deprecated("Use didAttemptThreeDSecureAuthentication instead.")
     val liabilityShift: String? = null,
 
     var status: String? = null,
+
     val didAttemptThreeDSecureAuthentication: Boolean = false
 )

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResult.kt
@@ -23,7 +23,7 @@ data class CardResult(
     @Deprecated("Use didAttemptThreeDSecureAuthentication instead.")
     val liabilityShift: String? = null,
 
-    var status: String? = null,
+    val status: String? = null,
 
     val didAttemptThreeDSecureAuthentication: Boolean = false
 )

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResult.kt
@@ -7,6 +7,9 @@ import android.net.Uri
  *
  * @property [orderId] associated order ID.
  * @property [liabilityShift] Liability shift value returned from 3DS verification
+ * @property [status] status of the order
+ * @property [didAttemptThreeDSecureAuthentication] 3DS verification was attempted.
+ * Use v2/checkout/orders/{orderId} in your server to get verification results.
  */
 data class CardResult(
     val orderId: String,
@@ -15,5 +18,10 @@ data class CardResult(
      * @suppress
      */
     val deepLinkUrl: Uri? = null,
-    val liabilityShift: String? = null
+
+    @Deprecated("Use didAttemptThreeDSecureAuthentication instead.")
+    val liabilityShift: String? = null,
+
+    var status: String? = null,
+    val didAttemptThreeDSecureAuthentication: Boolean = false
 )

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResult.kt
@@ -1,5 +1,7 @@
 package com.paypal.android.cardpayments
 
+import android.net.Uri
+
 /**
  * A result returned by [CardClient] when an order was successfully approved with a [Card].
  *
@@ -11,6 +13,12 @@ package com.paypal.android.cardpayments
  */
 data class CardResult(
     val orderId: String,
+
+    /**
+     * @suppress
+     */
+    @Deprecated("Use status instead.")
+    val deepLinkUrl: Uri? = null,
 
     @Deprecated("Use didAttemptThreeDSecureAuthentication instead.")
     val liabilityShift: String? = null,

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
@@ -15,6 +15,7 @@ import io.mockk.slot
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -124,6 +125,8 @@ class CardAuthLauncherUnitTest {
         val cardResult = status.result
         assertEquals("fake-order-id", cardResult.orderId)
         assertEquals("NO", cardResult.liabilityShift)
+        assertTrue(cardResult.didAttemptThreeDSecureAuthentication)
+        assertNull(cardResult.status)
     }
 
     @Test

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Before
@@ -98,6 +99,8 @@ class CardClientUnitTest {
 
         val actual = resultSlot.captured
         assertEquals("sample-order-id", actual.orderId)
+        assertEquals(OrderStatus.APPROVED.name, actual.status)
+        assertFalse(actual.didAttemptThreeDSecureAuthentication)
     }
 
     @Test
@@ -183,7 +186,11 @@ class CardClientUnitTest {
         val sut = createCardClient(testScheduler)
         sut.approveOrderListener = approveOrderListener
 
-        val successResult = CardResult("fake-order-id")
+        val successResult = CardResult(
+            orderId = "fake-order-id",
+            status = OrderStatus.APPROVED.name,
+            didAttemptThreeDSecureAuthentication = false
+        )
         every {
             cardAuthLauncher.deliverBrowserSwitchResult(activity)
         } returns CardStatus.ApproveOrderSuccess(successResult)

--- a/Demo/src/main/java/com/paypal/android/uishared/components/CardResultView.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/CardResultView.kt
@@ -31,9 +31,12 @@ fun CardResultView(result: CardResult) {
 fun CardResultViewWith3DSAuth() {
     MaterialTheme {
         Surface(modifier = Modifier.fillMaxWidth()) {
-            CardResultView(
-                CardResult("fake-order-id", "fake-status", true)
+            val result = CardResult(
+                orderId = "fake-order-id",
+                status = "fake-status",
+                didAttemptThreeDSecureAuthentication = true
             )
+            CardResultView(result)
         }
     }
 }
@@ -43,9 +46,12 @@ fun CardResultViewWith3DSAuth() {
 fun CardResultViewWithout3DSAuth() {
     MaterialTheme {
         Surface(modifier = Modifier.fillMaxWidth()) {
-            CardResultView(
-                CardResult("fake-order-id", "fake-status", false)
+            val result = CardResult(
+                orderId = "fake-order-id",
+                status = "fake-status",
+                didAttemptThreeDSecureAuthentication = false
             )
+            CardResultView(result)
         }
     }
 }

--- a/Demo/src/main/java/com/paypal/android/uishared/components/CardResultView.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/CardResultView.kt
@@ -17,7 +17,7 @@ fun CardResultView(result: CardResult) {
         verticalArrangement = UIConstants.spacingMedium,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = UIConstants.paddingMedium)
+            .padding(UIConstants.paddingMedium)
     ) {
         PropertyView(name = "Order ID", value = result.orderId)
         PropertyView(name = "Order Status", value = result.status)

--- a/Demo/src/main/java/com/paypal/android/uishared/components/CardResultView.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/components/CardResultView.kt
@@ -1,14 +1,10 @@
 package com.paypal.android.uishared.components
 
-import android.net.Uri
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -18,51 +14,25 @@ import com.paypal.android.utils.UIConstants
 @Composable
 fun CardResultView(result: CardResult) {
     Column(
+        verticalArrangement = UIConstants.spacingMedium,
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = UIConstants.paddingMedium)
     ) {
-        Text(
-            text = "Order ID",
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier
-                .padding(top = UIConstants.paddingMedium)
-        )
-        Text(
-            text = result.orderId,
-            modifier = Modifier
-                .padding(top = UIConstants.paddingExtraSmall)
-        )
-        Text(
-            text = "Deep Link URL",
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier
-                .padding(top = UIConstants.paddingMedium)
-        )
-        val deepLinkUrl = result.deepLinkUrl
-        if (deepLinkUrl == null) {
-            Text(
-                text = "NOT SET",
-                modifier = Modifier
-                    .padding(top = UIConstants.paddingExtraSmall)
-            )
-        } else {
-            UriView(uri = deepLinkUrl)
-        }
-        Spacer(modifier = Modifier.size(UIConstants.paddingLarge))
+        PropertyView(name = "Order ID", value = result.orderId)
+        PropertyView(name = "Order Status", value = result.status)
+        val didAttemptText = if (result.didAttemptThreeDSecureAuthentication) "YES" else "NO"
+        PropertyView(name = "Did Attempt 3DS Authentication", value = didAttemptText)
     }
 }
 
 @Preview
 @Composable
-fun CardResultViewWithDeepLinkPreview() {
+fun CardResultViewWith3DSAuth() {
     MaterialTheme {
         Surface(modifier = Modifier.fillMaxWidth()) {
             CardResultView(
-                CardResult(
-                    "fake-order-id",
-                    Uri.parse("fake-scheme://fake-host/fake-path?fakeParam1=value1&fakeParam2=value2")
-                )
+                CardResult("fake-order-id", "fake-status", true)
             )
         }
     }
@@ -70,11 +40,11 @@ fun CardResultViewWithDeepLinkPreview() {
 
 @Preview
 @Composable
-fun CardResultViewWithoutDeepLinkPreview() {
+fun CardResultViewWithout3DSAuth() {
     MaterialTheme {
         Surface(modifier = Modifier.fillMaxWidth()) {
             CardResultView(
-                CardResult("fake-order-id")
+                CardResult("fake-order-id", "fake-status", false)
             )
         }
     }


### PR DESCRIPTION
### Summary of changes

* Reference iOS PR: https://github.com/paypal/paypal-ios/pull/254
* CardPayments
  * Add `status` property to `CardResult`
  * Add `didAttemptThreeDSecureAuthentication` property to `CardResult`
* Breaking Changes
  * CardPayments
    * Remove `liabilityShift` property from `CardResult`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
