### PR TITLE
Update to Version Catalog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
       SIGNING_KEY_FILE_PATH: /home/runner/secretKey.gpg
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -39,9 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -55,9 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -70,9 +70,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -85,9 +85,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -100,9 +100,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -126,9 +126,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set github user
         uses: ./.github/actions/set_github_user
       - name: Update Version

--- a/.github/workflows/release_demo.yml
+++ b/.github/workflows/release_demo.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set github user
         uses: ./.github/actions/set_github_user
       - name: Update Version

--- a/.github/workflows/release_snapshot.yml
+++ b/.github/workflows/release_snapshot.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -58,9 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -73,9 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -88,9 +88,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -103,9 +103,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -129,9 +129,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Assemble Release AAR on Main Branch
         run: ./gradlew clean assembleRelease -x :Demo:assembleRelease # we exclude Demo module in assemble
       - name: Upload Main Branch Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: main-aar
           path: |
@@ -68,7 +68,7 @@ jobs:
       - name: Assemble Release AAR on Current Branch
         run: ./gradlew clean assembleRelease -x :Demo:assembleRelease # we exclude Demo module in assemble
       - name: Upload Current Branch Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: current-aar
           path: |
@@ -83,7 +83,7 @@ jobs:
       - name: Install Diffuse
         run: brew install JakeWharton/repo/diffuse
       - name: Download Workflow Artifacts 
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
       - name: Set up Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
@@ -37,15 +37,15 @@ jobs:
     runs-on: macOS-13
     steps:
       # Set up environment to assemble SDK
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'
 
       # Assemble artifacts from main branch
       - name: Checkout Main Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: main
       - name: Assemble Release AAR on Main Branch
@@ -64,7 +64,7 @@ jobs:
 
       # Assemble artifacts from current branch
       - name: Checkout Current Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Assemble Release AAR on Current Branch
         run: ./gradlew clean assembleRelease -x :Demo:assembleRelease # we exclude Demo module in assemble
       - name: Upload Current Branch Artifacts
@@ -84,8 +84,8 @@ jobs:
         run: brew install JakeWharton/repo/diffuse
       - name: Download Workflow Artifacts 
         uses: actions/download-artifact@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
           java-version: '11'

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'microsoft'

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
@@ -39,7 +40,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/CardPayments/build.gradle
+++ b/CardPayments/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     alias libs.plugins.android.library
-    alias libs.plugins.jetbrains.kotlin.android
-    alias libs.plugins.jacoco.android
-    alias libs.plugins.kotlin.parcelize
+    alias libs.plugins.kotlinAndroid
+    alias libs.plugins.jacocoAndroid
+    alias libs.plugins.kotlinParcelize
 }
 
 android {

--- a/CardPayments/build.gradle
+++ b/CardPayments/build.gradle
@@ -48,17 +48,17 @@ dependencies {
 
     implementation libs.browser.switch
 
-    testImplementation deps.junit
-    testImplementation deps.mockk
-    testImplementation deps.jsonAssert
-    testImplementation deps.robolectric
-    testImplementation deps.kotlinxAndroidCoroutinesTest
-    testImplementation deps.androidxTestCore
-    testImplementation deps.striktCore
-    testImplementation deps.striktMockk
+    testImplementation libs.junit
+    testImplementation libs.mockk
+    testImplementation libs.json.assert
+    testImplementation libs.robolectric
+    testImplementation libs.kotlinx.android.coroutines.test
+    testImplementation libs.androidx.test.core
+    testImplementation libs.strikt.core
+    testImplementation libs.strikt.mockk
 
-    androidTestImplementation deps.androidxJUnit
-    androidTestImplementation deps.androidxEspressoCore
+    androidTestImplementation libs.androidx.junit
+    androidTestImplementation libs.androidx.espresso.core
 
     implementation libs.androidx.lifecycle.common.java8
     implementation libs.androidx.lifecycle.runtime.ktx

--- a/CardPayments/build.gradle
+++ b/CardPayments/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
+    alias libs.plugins.android.library
+    alias libs.plugins.jetbrains.kotlin.android
     alias libs.plugins.jacoco.android
-    id 'kotlin-parcelize'
+    alias libs.plugins.kotlin.parcelize
 }
 
 android {

--- a/CardPayments/build.gradle
+++ b/CardPayments/build.gradle
@@ -42,7 +42,7 @@ android {
 dependencies {
     api project(':CorePayments')
     implementation libs.kotlin.std.lib
-    implementation deps.androidxCoreKtx
+    implementation libs.androidx.core.ktx
     implementation deps.androidxAppcompat
     implementation deps.kotlinxAndroidCoroutines
 

--- a/CardPayments/build.gradle
+++ b/CardPayments/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation libs.androidx.appcompat
     implementation libs.kotlinx.coroutines.android
 
-    implementation deps.browserSwitch
+    implementation libs.browser.switch
 
     testImplementation deps.junit
     testImplementation deps.mockk

--- a/CardPayments/build.gradle
+++ b/CardPayments/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.dicedmelon.gradle.jacoco-android'
+    alias libs.plugins.jacoco.android
     id 'kotlin-parcelize'
 }
 

--- a/CardPayments/build.gradle
+++ b/CardPayments/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     api project(':CorePayments')
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx
-    implementation deps.androidxAppcompat
+    implementation libs.androidx.appcompat
     implementation deps.kotlinxAndroidCoroutines
 
     implementation deps.browserSwitch

--- a/CardPayments/build.gradle
+++ b/CardPayments/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx
     implementation libs.androidx.appcompat
-    implementation deps.kotlinxAndroidCoroutines
+    implementation libs.kotlinx.coroutines.android
 
     implementation deps.browserSwitch
 
@@ -60,9 +60,8 @@ dependencies {
     androidTestImplementation deps.androidxJUnit
     androidTestImplementation deps.androidxEspressoCore
 
-    implementation deps.androidxLifecycleCommonJava
-    implementation deps.androidxLifecycleRuntimeKtx
-
+    implementation libs.androidx.lifecycle.common.java8
+    implementation libs.androidx.lifecycle.runtime.ktx
 }
 
 project.ext.name = "card-payments"

--- a/CardPayments/build.gradle
+++ b/CardPayments/build.gradle
@@ -41,27 +41,25 @@ android {
 
 dependencies {
     api project(':CorePayments')
-    implementation libs.kotlin.std.lib
-    implementation libs.androidx.core.ktx
+    implementation libs.kotlin.stdLib
+    implementation libs.androidx.coreKtx
     implementation libs.androidx.appcompat
-    implementation libs.kotlinx.coroutines.android
-
-    implementation libs.browser.switch
+    implementation libs.kotlinx.coroutinesAndroid
+    implementation libs.braintree.browserSwitch
+    implementation libs.lifecycle.commonJava8
+    implementation libs.lifecycle.runtimeKtx
 
     testImplementation libs.junit
     testImplementation libs.mockk
     testImplementation libs.json.assert
     testImplementation libs.robolectric
-    testImplementation libs.kotlinx.android.coroutines.test
+    testImplementation libs.kotlinx.coroutinesTest
     testImplementation libs.androidx.test.core
     testImplementation libs.strikt.core
     testImplementation libs.strikt.mockk
 
-    androidTestImplementation libs.androidx.junit
-    androidTestImplementation libs.androidx.espresso.core
-
-    implementation libs.androidx.lifecycle.common.java8
-    implementation libs.androidx.lifecycle.runtime.ktx
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.androidx.test.espresso
 }
 
 project.ext.name = "card-payments"

--- a/CardPayments/build.gradle
+++ b/CardPayments/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 
     testImplementation libs.junit
     testImplementation libs.mockk
-    testImplementation libs.json.assert
+    testImplementation libs.jsonAssert
     testImplementation libs.robolectric
     testImplementation libs.kotlinx.coroutinesTest
     testImplementation libs.androidx.test.core

--- a/CardPayments/build.gradle
+++ b/CardPayments/build.gradle
@@ -41,7 +41,7 @@ android {
 
 dependencies {
     api project(':CorePayments')
-    implementation deps.kotlinStdLib
+    implementation libs.kotlin.std.lib
     implementation deps.androidxCoreKtx
     implementation deps.androidxAppcompat
     implementation deps.kotlinxAndroidCoroutines

--- a/CorePayments/build.gradle
+++ b/CorePayments/build.gradle
@@ -58,7 +58,7 @@ android {
 
 dependencies {
     implementation libs.kotlin.std.lib
-    implementation deps.androidxCoreKtx
+    implementation libs.androidx.core.ktx
     implementation deps.androidxAppcompat
     implementation deps.kotlinxAndroidCoroutines
 

--- a/CorePayments/build.gradle
+++ b/CorePayments/build.gradle
@@ -1,8 +1,7 @@
 plugins {
     alias libs.plugins.android.library
     alias libs.plugins.jetbrains.kotlin.android
-
-    id 'com.dicedmelon.gradle.jacoco-android'
+    alias libs.plugins.jacoco.android
     id 'kotlin-parcelize'
 }
 

--- a/CorePayments/build.gradle
+++ b/CorePayments/build.gradle
@@ -57,7 +57,7 @@ android {
 }
 
 dependencies {
-    implementation deps.kotlinStdLib
+    implementation libs.kotlin.std.lib
     implementation deps.androidxCoreKtx
     implementation deps.androidxAppcompat
     implementation deps.kotlinxAndroidCoroutines

--- a/CorePayments/build.gradle
+++ b/CorePayments/build.gradle
@@ -57,22 +57,22 @@ android {
 }
 
 dependencies {
-    implementation libs.kotlin.std.lib
-    implementation libs.androidx.core.ktx
+    implementation libs.androidx.coreKtx
     implementation libs.androidx.appcompat
-    implementation libs.kotlinx.coroutines.android
+    implementation libs.kotlin.stdLib
+    implementation libs.kotlinx.coroutinesAndroid
 
+    testImplementation libs.json
     testImplementation libs.json.assert
     testImplementation libs.junit
     testImplementation libs.mockk
     testImplementation libs.robolectric
-    testImplementation libs.json
-    testImplementation libs.kotlinx.android.coroutines.test
+    testImplementation libs.kotlinx.coroutinesTest
     testImplementation libs.androidx.test.core
 
-    androidTestImplementation libs.androidx.junit
-    androidTestImplementation libs.androidx.espresso.core
-    androidTestImplementation libs.kotlinx.android.coroutines.test
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.androidx.test.espresso
+    androidTestImplementation libs.kotlinx.coroutinesTest
 }
 
 project.ext.name = "core-payments"

--- a/CorePayments/build.gradle
+++ b/CorePayments/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation libs.kotlinx.coroutinesAndroid
 
     testImplementation libs.json
-    testImplementation libs.json.assert
+    testImplementation libs.jsonAssert
     testImplementation libs.junit
     testImplementation libs.mockk
     testImplementation libs.robolectric

--- a/CorePayments/build.gradle
+++ b/CorePayments/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx
     implementation libs.androidx.appcompat
-    implementation deps.kotlinxAndroidCoroutines
+    implementation libs.kotlinx.coroutines.android
 
     testImplementation deps.jsonAssert
     testImplementation deps.junit

--- a/CorePayments/build.gradle
+++ b/CorePayments/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     alias libs.plugins.android.library
-    alias libs.plugins.jetbrains.kotlin.android
-    alias libs.plugins.jacoco.android
-    alias libs.plugins.kotlin.parcelize
+    alias libs.plugins.kotlinAndroid
+    alias libs.plugins.jacocoAndroid
+    alias libs.plugins.kotlinParcelize
 }
 
 android {

--- a/CorePayments/build.gradle
+++ b/CorePayments/build.gradle
@@ -2,7 +2,7 @@ plugins {
     alias libs.plugins.android.library
     alias libs.plugins.jetbrains.kotlin.android
     alias libs.plugins.jacoco.android
-    id 'kotlin-parcelize'
+    alias libs.plugins.kotlin.parcelize
 }
 
 android {

--- a/CorePayments/build.gradle
+++ b/CorePayments/build.gradle
@@ -62,17 +62,17 @@ dependencies {
     implementation libs.androidx.appcompat
     implementation libs.kotlinx.coroutines.android
 
-    testImplementation deps.jsonAssert
-    testImplementation deps.junit
-    testImplementation deps.mockk
-    testImplementation deps.robolectric
-    testImplementation deps.json
-    testImplementation deps.kotlinxAndroidCoroutinesTest
-    testImplementation deps.androidxTestCore
+    testImplementation libs.json.assert
+    testImplementation libs.junit
+    testImplementation libs.mockk
+    testImplementation libs.robolectric
+    testImplementation libs.json
+    testImplementation libs.kotlinx.android.coroutines.test
+    testImplementation libs.androidx.test.core
 
-    androidTestImplementation deps.androidxJUnit
-    androidTestImplementation deps.androidxEspressoCore
-    androidTestImplementation deps.kotlinxAndroidCoroutinesTest
+    androidTestImplementation libs.androidx.junit
+    androidTestImplementation libs.androidx.espresso.core
+    androidTestImplementation libs.kotlinx.android.coroutines.test
 }
 
 project.ext.name = "core-payments"

--- a/CorePayments/build.gradle
+++ b/CorePayments/build.gradle
@@ -1,6 +1,7 @@
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
+    alias libs.plugins.android.library
+    alias libs.plugins.jetbrains.kotlin.android
+
     id 'com.dicedmelon.gradle.jacoco-android'
     id 'kotlin-parcelize'
 }

--- a/CorePayments/build.gradle
+++ b/CorePayments/build.gradle
@@ -59,7 +59,7 @@ android {
 dependencies {
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx
-    implementation deps.androidxAppcompat
+    implementation libs.androidx.appcompat
     implementation deps.kotlinxAndroidCoroutines
 
     testImplementation deps.jsonAssert

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -107,7 +107,7 @@ dependencies {
     releaseImplementation deps.fraudProtection
 
     implementation libs.kotlin.std.lib
-    implementation deps.androidxCoreKtx
+    implementation libs.androidx.core.ktx
     implementation deps.androidxAppcompat
     implementation deps.material
     implementation deps.constraintLayout

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -142,8 +142,8 @@ dependencies {
     implementation libs.square.converter.gson
     implementation libs.square.logging.interceptor
 
-    implementation deps.hilt
-    kapt deps.hiltKapt
+    implementation libs.google.dagger.hilt.android
+    kapt libs.google.dagger.hilt.compiler
 
     implementation libs.androidx.navigation.compose
     implementation libs.hilt.navigation.compose

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     releaseImplementation deps.paypalNativePayments
     releaseImplementation deps.fraudProtection
 
-    implementation deps.kotlinStdLib
+    implementation libs.kotlin.std.lib
     implementation deps.androidxCoreKtx
     implementation deps.androidxAppcompat
     implementation deps.material

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -148,13 +148,13 @@ dependencies {
     implementation libs.androidx.navigation.compose
     implementation libs.hilt.navigation.compose
 
-    testImplementation deps.junit
+    testImplementation libs.junit
 
-    androidTestImplementation deps.androidxJUnit
-    androidTestImplementation deps.androidxEspressoCore
-    androidTestImplementation deps.androidxTestRunner
-    androidTestImplementation deps.androidxTestRules
-    androidTestImplementation deps.androidxTestUiAutomator
+    androidTestImplementation libs.androidx.junit
+    androidTestImplementation libs.androidx.espresso.core
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.ui.automator
 
     // compose ui-test
     androidTestImplementation libs.androidx.compose.ui.test.junit4

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -138,9 +138,9 @@ dependencies {
 
     implementation libs.androidx.preference.ktx
 
-    implementation deps.retrofit
-    implementation deps.gson
-    implementation deps.loggingInterceptor
+    implementation libs.square.retrofit2
+    implementation libs.square.converter.gson
+    implementation libs.square.logging.interceptor
 
     implementation deps.hilt
     kapt deps.hiltKapt

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -108,7 +108,7 @@ dependencies {
 
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx
-    implementation deps.androidxAppcompat
+    implementation libs.androidx.appcompat
     implementation deps.material
     implementation deps.constraintLayout
     implementation deps.androidxLifecycleRuntimeKtx

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     implementation libs.androidx.fragment.ktx
 
     // TODO: remove dependency when we don't relay on nxo models anymore
-    implementation(deps.nativeCheckout) {
+    implementation(libs.native.checkout) {
         exclude module: 'data-collector'
     }
 

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -1,10 +1,10 @@
 plugins {
     alias libs.plugins.android.application
-    alias libs.plugins.jetbrains.kotlin.android
     alias libs.plugins.dagger.hilt
-    alias libs.plugins.kotlin.parcelize
-    alias libs.plugins.gradle.play.publisher
-    alias libs.plugins.kotlin.kapt
+    alias libs.plugins.gradlePlayPublisher
+    alias libs.plugins.kotlinAndroid
+    alias libs.plugins.kotlinKapt
+    alias libs.plugins.kotlinParcelize
 }
 
 def paypalProperties = loadPropertiesFromFile("paypal.properties")

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -30,7 +30,7 @@ android {
 
     composeOptions {
         // Ref: https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility
-        kotlinCompilerExtensionVersion "${versions.compose}"
+        kotlinCompilerExtensionVersion "1.4.7"
     }
 
     buildTypes {

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -93,18 +93,12 @@ kapt {
 }
 
 dependencies {
-    debugImplementation project(':CardPayments')
-    debugImplementation project(':FraudProtection')
-    debugImplementation project(':PayPalNativePayments')
-    debugImplementation project(':PayPalWebPayments')
-    debugImplementation project(':PaymentButtons')
-    debugImplementation project(':Venmo')
-
-    releaseImplementation deps.cardPayments
-    releaseImplementation deps.paymentButtons
-    releaseImplementation deps.paypalWebPayments
-    releaseImplementation deps.paypalNativePayments
-    releaseImplementation deps.fraudProtection
+    implementation project(':CardPayments')
+    implementation project(':FraudProtection')
+    implementation project(':PayPalNativePayments')
+    implementation project(':PayPalWebPayments')
+    implementation project(':PaymentButtons')
+    implementation project(':Venmo')
 
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -100,16 +100,16 @@ dependencies {
     implementation project(':PaymentButtons')
     implementation project(':Venmo')
 
-    implementation libs.kotlin.std.lib
-    implementation libs.androidx.core.ktx
+    implementation libs.kotlin.stdLib
+    implementation libs.androidx.coreKtx
     implementation libs.androidx.appcompat
-    implementation libs.google.android.material
-    implementation libs.androidx.constraint.layout
-    implementation libs.androidx.lifecycle.runtime.ktx
-    implementation libs.androidx.fragment.ktx
+    implementation libs.android.material
+    implementation libs.androidx.constraintLayout
+    implementation libs.lifecycle.runtimeKtx
+    implementation libs.androidx.fragmentKtx
 
     // TODO: remove dependency when we don't relay on nxo models anymore
-    implementation(libs.native.checkout) {
+    implementation(libs.paypal.nativeCheckout) {
         exclude module: 'data-collector'
     }
 
@@ -120,39 +120,38 @@ dependencies {
     // and are known to be compatible by the Jetpack Team
     // More info: https://developer.android.com/jetpack/compose/bom
     // Another ref: https://developer.android.com/jetpack/compose/setup#setup-compose
-    implementation platform(libs.androidx.compose.bom)
-    androidTestImplementation platform(libs.androidx.compose.bom)
+    implementation platform(libs.compose.bom)
+    androidTestImplementation platform(libs.compose.bom)
 
-    implementation libs.androidx.compose.material3
-    implementation libs.androidx.compose.ui.tooling.preview
-    debugImplementation libs.androidx.compose.ui.tooling
+    implementation libs.compose.material3
+    implementation libs.compose.uiToolingPreview
+    debugImplementation libs.compose.uiTooling
 
-    implementation libs.androidx.lifecycle.view.model.compose
-    implementation libs.androidx.lifecycle.runtime.compose
-
-    implementation libs.androidx.preference.ktx
+    implementation libs.lifecycle.viewModelCompose
+    implementation libs.lifecycle.runtimeCompose
+    implementation libs.androidx.preferenceKtx
 
     implementation libs.square.retrofit2
-    implementation libs.square.converter.gson
-    implementation libs.square.logging.interceptor
+    implementation libs.square.converterGson
+    implementation libs.square.loggingInterceptor
 
-    implementation libs.google.dagger.hilt.android
-    kapt libs.google.dagger.hilt.compiler
+    implementation libs.dagger.hiltAndroid
+    kapt libs.dagger.hiltCompiler
 
-    implementation libs.androidx.navigation.compose
-    implementation libs.hilt.navigation.compose
+    implementation libs.navigation.compose
+    implementation libs.hilt.navigationCompose
 
     testImplementation libs.junit
 
-    androidTestImplementation libs.androidx.junit
-    androidTestImplementation libs.androidx.espresso.core
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.androidx.test.espresso
     androidTestImplementation libs.androidx.test.runner
     androidTestImplementation libs.androidx.test.rules
-    androidTestImplementation libs.androidx.test.ui.automator
+    androidTestImplementation libs.androidx.test.uiAutomator
 
     // compose ui-test
-    androidTestImplementation libs.androidx.compose.ui.test.junit4
-    debugImplementation libs.androidx.compose.ui.test.manifest
+    androidTestImplementation libs.compose.uiTestJunit4
+    debugImplementation libs.compose.uiTestManifest
 }
 
 /**

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -109,10 +109,10 @@ dependencies {
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx
     implementation libs.androidx.appcompat
-    implementation deps.material
-    implementation deps.constraintLayout
-    implementation deps.androidxLifecycleRuntimeKtx
-    implementation deps.fragmentKtx
+    implementation libs.google.android.material
+    implementation libs.androidx.constraint.layout
+    implementation libs.androidx.lifecycle.runtime.ktx
+    implementation libs.androidx.fragment.ktx
 
     // TODO: remove dependency when we don't relay on nxo models anymore
     implementation(deps.nativeCheckout) {
@@ -125,13 +125,12 @@ dependencies {
     // to be compatible with one another. The set of dependencies output by the bom have been tested
     // and are known to be compatible by the Jetpack Team
     // More info: https://developer.android.com/jetpack/compose/bom
-    def composeBom = platform('androidx.compose:compose-bom:2023.05.01')
-    implementation composeBom
-    androidTestImplementation composeBom
+    implementation platform(libs.androidx.compose.bom)
+    androidTestImplementation platform(libs.androidx.compose.bom)
 
-    implementation deps.composeMaterial3
-    implementation deps.composeUiToolingPreview
-    debugImplementation deps.composeUiTooling
+    implementation libs.androidx.compose.material3
+    implementation libs.androidx.compose.ui.tooling.preview
+    debugImplementation libs.androidx.compose.ui.tooling
 
     implementation deps.lifecycleViewModelCompose
     implementation deps.lifecycleRuntimeCompose
@@ -157,8 +156,8 @@ dependencies {
     androidTestImplementation deps.androidxTestUiAutomator
 
     // compose ui-test
-    androidTestImplementation deps.composeUiTestJUnit4
-    debugImplementation deps.composeUiTestManifest
+    androidTestImplementation libs.androidx.compose.ui.test.junit4
+    debugImplementation libs.androidx.compose.ui.test.manifest
 }
 
 /**

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     implementation libs.androidx.lifecycle.view.model.compose
     implementation libs.androidx.lifecycle.runtime.compose
 
-    implementation deps.preference
+    implementation libs.androidx.preference.ktx
 
     implementation deps.retrofit
     implementation deps.gson

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id 'com.android.application'
-    id 'kotlin-android'
-    id 'kotlin-kapt'
-    id 'dagger.hilt.android.plugin'
-    id 'kotlin-parcelize'
-    id 'com.github.triplet.play' version '3.8.4'
+    alias libs.plugins.android.application
+    alias libs.plugins.jetbrains.kotlin.android
+    alias libs.plugins.dagger.hilt
+    alias libs.plugins.kotlin.parcelize
+    alias libs.plugins.gradle.play.publisher
+    alias libs.plugins.kotlin.kapt
 }
 
 def paypalProperties = loadPropertiesFromFile("paypal.properties")

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -125,6 +125,7 @@ dependencies {
     // to be compatible with one another. The set of dependencies output by the bom have been tested
     // and are known to be compatible by the Jetpack Team
     // More info: https://developer.android.com/jetpack/compose/bom
+    // Another ref: https://developer.android.com/jetpack/compose/setup#setup-compose
     implementation platform(libs.androidx.compose.bom)
     androidTestImplementation platform(libs.androidx.compose.bom)
 
@@ -132,8 +133,8 @@ dependencies {
     implementation libs.androidx.compose.ui.tooling.preview
     debugImplementation libs.androidx.compose.ui.tooling
 
-    implementation deps.lifecycleViewModelCompose
-    implementation deps.lifecycleRuntimeCompose
+    implementation libs.androidx.lifecycle.view.model.compose
+    implementation libs.androidx.lifecycle.runtime.compose
 
     implementation deps.preference
 
@@ -144,8 +145,8 @@ dependencies {
     implementation deps.hilt
     kapt deps.hiltKapt
 
-    implementation deps.navigationCompose
-    implementation deps.hiltNavigationCompose
+    implementation libs.androidx.navigation.compose
+    implementation libs.hilt.navigation.compose
 
     testImplementation deps.junit
 

--- a/FraudProtection/build.gradle
+++ b/FraudProtection/build.gradle
@@ -42,13 +42,13 @@ dependencies {
     implementation libs.androidx.appcompat
     implementation libs.androidx.preference.ktx
 
-    testImplementation deps.junit
-    testImplementation deps.mockk
-    testImplementation deps.jsonAssert
-    testImplementation deps.robolectric
+    testImplementation libs.junit
+    testImplementation libs.mockk
+    testImplementation libs.json.assert
+    testImplementation libs.robolectric
 
-    androidTestImplementation deps.androidxJUnit
-    androidTestImplementation deps.androidxEspressoCore
+    androidTestImplementation libs.androidx.junit
+    androidTestImplementation libs.androidx.espresso.core
 }
 
 

--- a/FraudProtection/build.gradle
+++ b/FraudProtection/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     alias libs.plugins.android.library
-    alias libs.plugins.jetbrains.kotlin.android
+    alias libs.plugins.kotlinAndroid
 }
 
 android {

--- a/FraudProtection/build.gradle
+++ b/FraudProtection/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation files('libs/android-magnessdk-5.5.1.jar')
 
     api project(':CorePayments')
-    implementation deps.kotlinStdLib
+    implementation libs.kotlin.std.lib
     implementation deps.androidxCoreKtx
     implementation deps.androidxAppcompat
     implementation deps.preference

--- a/FraudProtection/build.gradle
+++ b/FraudProtection/build.gradle
@@ -37,18 +37,18 @@ dependencies {
     implementation files('libs/android-magnessdk-5.5.1.jar')
 
     api project(':CorePayments')
-    implementation libs.kotlin.std.lib
-    implementation libs.androidx.core.ktx
+    implementation libs.kotlin.stdLib
+    implementation libs.androidx.coreKtx
     implementation libs.androidx.appcompat
-    implementation libs.androidx.preference.ktx
+    implementation libs.androidx.preferenceKtx
 
     testImplementation libs.junit
     testImplementation libs.mockk
     testImplementation libs.json.assert
     testImplementation libs.robolectric
 
-    androidTestImplementation libs.androidx.junit
-    androidTestImplementation libs.androidx.espresso.core
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.androidx.test.espresso
 }
 
 

--- a/FraudProtection/build.gradle
+++ b/FraudProtection/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx
     implementation libs.androidx.appcompat
-    implementation deps.preference
+    implementation libs.androidx.preference.ktx
 
     testImplementation deps.junit
     testImplementation deps.mockk

--- a/FraudProtection/build.gradle
+++ b/FraudProtection/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
     api project(':CorePayments')
     implementation libs.kotlin.std.lib
-    implementation deps.androidxCoreKtx
+    implementation libs.androidx.core.ktx
     implementation deps.androidxAppcompat
     implementation deps.preference
 

--- a/FraudProtection/build.gradle
+++ b/FraudProtection/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     api project(':CorePayments')
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx
-    implementation deps.androidxAppcompat
+    implementation libs.androidx.appcompat
     implementation deps.preference
 
     testImplementation deps.junit

--- a/FraudProtection/build.gradle
+++ b/FraudProtection/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
+    alias libs.plugins.android.library
+    alias libs.plugins.jetbrains.kotlin.android
 }
 
 android {

--- a/FraudProtection/build.gradle
+++ b/FraudProtection/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 
     testImplementation libs.junit
     testImplementation libs.mockk
-    testImplementation libs.json.assert
+    testImplementation libs.jsonAssert
     testImplementation libs.robolectric
 
     androidTestImplementation libs.androidx.test.junit

--- a/PayPalNativePayments/build.gradle
+++ b/PayPalNativePayments/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     }
 
     implementation libs.kotlin.std.lib
-    implementation deps.androidxCoreKtx
+    implementation libs.androidx.core.ktx
     implementation deps.androidxAppcompat
     implementation deps.kotlinxAndroidCoroutines
     implementation deps.material

--- a/PayPalNativePayments/build.gradle
+++ b/PayPalNativePayments/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     alias libs.plugins.android.library
-    alias libs.plugins.jetbrains.kotlin.android
+    alias libs.plugins.kotlinAndroid
 }
 
 android {

--- a/PayPalNativePayments/build.gradle
+++ b/PayPalNativePayments/build.gradle
@@ -50,15 +50,15 @@ dependencies {
     implementation libs.kotlinx.coroutines.android
     implementation libs.google.android.material
 
-    testImplementation deps.junit
-    testImplementation deps.mockk
-    testImplementation deps.robolectric
-    testImplementation deps.kotlinxAndroidCoroutinesTest
-    testImplementation deps.striktCore
-    testImplementation deps.striktMockk
+    testImplementation libs.junit
+    testImplementation libs.mockk
+    testImplementation libs.robolectric
+    testImplementation libs.kotlinx.android.coroutines.test
+    testImplementation libs.strikt.core
+    testImplementation libs.strikt.mockk
 
-    androidTestImplementation deps.androidxJUnit
-    androidTestImplementation deps.androidxEspressoCore
+    androidTestImplementation libs.androidx.junit
+    androidTestImplementation libs.androidx.espresso.core
 }
 
 project.ext.name = "paypal-native-payments"

--- a/PayPalNativePayments/build.gradle
+++ b/PayPalNativePayments/build.gradle
@@ -44,7 +44,7 @@ dependencies {
         exclude module: 'data-collector'
     }
 
-    implementation deps.kotlinStdLib
+    implementation libs.kotlin.std.lib
     implementation deps.androidxCoreKtx
     implementation deps.androidxAppcompat
     implementation deps.kotlinxAndroidCoroutines

--- a/PayPalNativePayments/build.gradle
+++ b/PayPalNativePayments/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     api project(':CorePayments')
     implementation project(':FraudProtection')
 
-    implementation (deps.nativeCheckout) {
+    implementation (libs.native.checkout) {
         exclude module: 'data-collector'
     }
 

--- a/PayPalNativePayments/build.gradle
+++ b/PayPalNativePayments/build.gradle
@@ -40,25 +40,25 @@ dependencies {
     api project(':CorePayments')
     implementation project(':FraudProtection')
 
-    implementation (libs.native.checkout) {
+    implementation(libs.paypal.nativeCheckout) {
         exclude module: 'data-collector'
     }
 
-    implementation libs.kotlin.std.lib
-    implementation libs.androidx.core.ktx
+    implementation libs.kotlin.stdLib
+    implementation libs.androidx.coreKtx
     implementation libs.androidx.appcompat
-    implementation libs.kotlinx.coroutines.android
-    implementation libs.google.android.material
+    implementation libs.kotlinx.coroutinesAndroid
+    implementation libs.android.material
 
     testImplementation libs.junit
     testImplementation libs.mockk
     testImplementation libs.robolectric
-    testImplementation libs.kotlinx.android.coroutines.test
+    testImplementation libs.kotlinx.coroutinesTest
     testImplementation libs.strikt.core
     testImplementation libs.strikt.mockk
 
-    androidTestImplementation libs.androidx.junit
-    androidTestImplementation libs.androidx.espresso.core
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.androidx.test.espresso
 }
 
 project.ext.name = "paypal-native-payments"

--- a/PayPalNativePayments/build.gradle
+++ b/PayPalNativePayments/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx
-    implementation deps.androidxAppcompat
+    implementation libs.androidx.appcompat
     implementation deps.kotlinxAndroidCoroutines
     implementation deps.material
 

--- a/PayPalNativePayments/build.gradle
+++ b/PayPalNativePayments/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
+    alias libs.plugins.android.library
+    alias libs.plugins.jetbrains.kotlin.android
 }
 
 android {

--- a/PayPalNativePayments/build.gradle
+++ b/PayPalNativePayments/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx
     implementation libs.androidx.appcompat
-    implementation deps.kotlinxAndroidCoroutines
-    implementation deps.material
+    implementation libs.kotlinx.coroutines.android
+    implementation libs.google.android.material
 
     testImplementation deps.junit
     testImplementation deps.mockk

--- a/PayPalWebPayments/build.gradle
+++ b/PayPalWebPayments/build.gradle
@@ -31,23 +31,23 @@ android {
 
 dependencies {
     api project(':CorePayments')
-    implementation libs.browser.switch
+    implementation libs.braintree.browserSwitch
 
-    implementation libs.kotlin.std.lib
-    implementation libs.androidx.core.ktx
+    implementation libs.kotlin.stdLib
+    implementation libs.androidx.coreKtx
     implementation libs.androidx.appcompat
-    implementation libs.kotlinx.coroutines.android
-    implementation libs.google.android.material
+    implementation libs.kotlinx.coroutinesAndroid
+    implementation libs.android.material
 
     testImplementation libs.junit
     testImplementation libs.mockk
     testImplementation libs.robolectric
-    testImplementation libs.kotlinx.android.coroutines.test
+    testImplementation libs.kotlinx.coroutinesTest
     testImplementation libs.strikt.core
     testImplementation libs.strikt.mockk
 
-    androidTestImplementation libs.androidx.junit
-    androidTestImplementation libs.androidx.espresso.core
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.androidx.test.espresso
 }
 
 project.ext.name = "paypal-web-payments"

--- a/PayPalWebPayments/build.gradle
+++ b/PayPalWebPayments/build.gradle
@@ -36,8 +36,8 @@ dependencies {
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx
     implementation libs.androidx.appcompat
-    implementation deps.kotlinxAndroidCoroutines
-    implementation deps.material
+    implementation libs.kotlinx.coroutines.android
+    implementation libs.google.android.material
 
     testImplementation deps.junit
     testImplementation deps.mockk

--- a/PayPalWebPayments/build.gradle
+++ b/PayPalWebPayments/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx
-    implementation deps.androidxAppcompat
+    implementation libs.androidx.appcompat
     implementation deps.kotlinxAndroidCoroutines
     implementation deps.material
 

--- a/PayPalWebPayments/build.gradle
+++ b/PayPalWebPayments/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     alias libs.plugins.android.library
-    alias libs.plugins.jetbrains.kotlin.android
+    alias libs.plugins.kotlinAndroid
 }
 
 android {

--- a/PayPalWebPayments/build.gradle
+++ b/PayPalWebPayments/build.gradle
@@ -39,15 +39,15 @@ dependencies {
     implementation libs.kotlinx.coroutines.android
     implementation libs.google.android.material
 
-    testImplementation deps.junit
-    testImplementation deps.mockk
-    testImplementation deps.robolectric
-    testImplementation deps.kotlinxAndroidCoroutinesTest
-    testImplementation deps.striktCore
-    testImplementation deps.striktMockk
+    testImplementation libs.junit
+    testImplementation libs.mockk
+    testImplementation libs.robolectric
+    testImplementation libs.kotlinx.android.coroutines.test
+    testImplementation libs.strikt.core
+    testImplementation libs.strikt.mockk
 
-    androidTestImplementation deps.androidxJUnit
-    androidTestImplementation deps.androidxEspressoCore
+    androidTestImplementation libs.androidx.junit
+    androidTestImplementation libs.androidx.espresso.core
 }
 
 project.ext.name = "paypal-web-payments"

--- a/PayPalWebPayments/build.gradle
+++ b/PayPalWebPayments/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation deps.browserSwitch
 
     implementation libs.kotlin.std.lib
-    implementation deps.androidxCoreKtx
+    implementation libs.androidx.core.ktx
     implementation deps.androidxAppcompat
     implementation deps.kotlinxAndroidCoroutines
     implementation deps.material

--- a/PayPalWebPayments/build.gradle
+++ b/PayPalWebPayments/build.gradle
@@ -31,7 +31,7 @@ android {
 
 dependencies {
     api project(':CorePayments')
-    implementation deps.browserSwitch
+    implementation libs.browser.switch
 
     implementation libs.kotlin.std.lib
     implementation libs.androidx.core.ktx

--- a/PayPalWebPayments/build.gradle
+++ b/PayPalWebPayments/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
+    alias libs.plugins.android.library
+    alias libs.plugins.jetbrains.kotlin.android
 }
 
 android {

--- a/PayPalWebPayments/build.gradle
+++ b/PayPalWebPayments/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     api project(':CorePayments')
     implementation deps.browserSwitch
 
-    implementation deps.kotlinStdLib
+    implementation libs.kotlin.std.lib
     implementation deps.androidxCoreKtx
     implementation deps.androidxAppcompat
     implementation deps.kotlinxAndroidCoroutines

--- a/PaymentButtons/build.gradle
+++ b/PaymentButtons/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 dependencies {
-    implementation deps.androidxCoreKtx
+    implementation libs.androidx.core.ktx
     implementation deps.material
 
     implementation project(':CorePayments')

--- a/PaymentButtons/build.gradle
+++ b/PaymentButtons/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     alias libs.plugins.android.library
-    alias libs.plugins.jetbrains.kotlin.android
+    alias libs.plugins.kotlinAndroid
 }
 
 android {

--- a/PaymentButtons/build.gradle
+++ b/PaymentButtons/build.gradle
@@ -31,7 +31,7 @@ android {
 
 dependencies {
     implementation libs.androidx.core.ktx
-    implementation deps.material
+    implementation libs.google.android.material
 
     implementation project(':CorePayments')
 }

--- a/PaymentButtons/build.gradle
+++ b/PaymentButtons/build.gradle
@@ -30,8 +30,8 @@ android {
 }
 
 dependencies {
-    implementation libs.androidx.core.ktx
-    implementation libs.google.android.material
+    implementation libs.androidx.coreKtx
+    implementation libs.android.material
 
     implementation project(':CorePayments')
 }

--- a/PaymentButtons/build.gradle
+++ b/PaymentButtons/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
+    alias libs.plugins.android.library
+    alias libs.plugins.jetbrains.kotlin.android
 }
 
 android {

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -32,7 +32,7 @@ android {
 
 dependencies {
 
-    implementation deps.androidxCoreKtx
+    implementation libs.androidx.core.ktx
     implementation deps.androidxAppcompat
     implementation deps.material
     testImplementation deps.junit

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     alias libs.plugins.android.library
-    alias libs.plugins.jetbrains.kotlin.android
+    alias libs.plugins.kotlinAndroid
 }
 
 android {

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -31,10 +31,9 @@ android {
 }
 
 dependencies {
-
     implementation libs.androidx.core.ktx
     implementation libs.androidx.appcompat
-    implementation deps.material
+    implementation libs.google.android.material
     testImplementation deps.junit
     androidTestImplementation deps.androidxJUnit
     androidTestImplementation deps.androidxEspressoCore

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation libs.androidx.core.ktx
     implementation libs.androidx.appcompat
     implementation libs.google.android.material
-    testImplementation deps.junit
-    androidTestImplementation deps.androidxJUnit
-    androidTestImplementation deps.androidxEspressoCore
+    testImplementation libs.junit
+    androidTestImplementation libs.androidx.junit
+    androidTestImplementation libs.androidx.espresso.core
 }

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
+    alias libs.plugins.android.library
+    alias libs.plugins.jetbrains.kotlin.android
 }
 
 android {

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -31,10 +31,12 @@ android {
 }
 
 dependencies {
-    implementation libs.androidx.core.ktx
+    implementation libs.androidx.coreKtx
     implementation libs.androidx.appcompat
-    implementation libs.google.android.material
+    implementation libs.android.material
+
     testImplementation libs.junit
-    androidTestImplementation libs.androidx.junit
-    androidTestImplementation libs.androidx.espresso.core
+
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.androidx.test.espresso
 }

--- a/Venmo/build.gradle
+++ b/Venmo/build.gradle
@@ -33,7 +33,7 @@ android {
 dependencies {
 
     implementation libs.androidx.core.ktx
-    implementation deps.androidxAppcompat
+    implementation libs.androidx.appcompat
     implementation deps.material
     testImplementation deps.junit
     androidTestImplementation deps.androidxJUnit

--- a/build.gradle
+++ b/build.gradle
@@ -15,26 +15,7 @@ buildscript {
 
     ext.deps = [
 
-            // Android
-            "material"                    : "com.google.android.material:material:1.4.0",
-            "constraintLayout"            : "androidx.constraintlayout:constraintlayout:2.1.0",
-            "kotlinxAndroidCoroutines"    : "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1",
-            "androidxLifecycleRuntimeKtx" : "androidx.lifecycle:lifecycle-runtime-ktx:2.4.1",
-            "androidxLifecycleCommonJava" : "androidx.lifecycle:lifecycle-common-java8:2.4.1",
-            "fragmentKtx"                 : "androidx.fragment:fragment-ktx:1.6.0",
-
             // Jetpack Compose
-            // Ref: https://developer.android.com/jetpack/compose/setup#setup-compose
-            "composeMaterial3"            : "androidx.compose.material3:material3",
-            "composeUi"                   : "androidx.compose.ui:ui",
-            "composeUiTestJUnit4"         : "androidx.compose.ui:ui-test-junit4",
-            "composeUiTestManifest"       : "androidx.compose.ui:ui-test-manifest",
-            "composeUiTooling"            : "androidx.compose.ui:ui-tooling",
-            "composeUiToolingPreview"     : "androidx.compose.ui:ui-tooling-preview",
-            "composeRuntimeLivedata"      : "androidx.compose.runtime:runtime-livedata",
-            "composeFoundation"           : "androidx.compose.foundation:foundation",
-            "composeMaterial"             : "androidx.compose.material:material",
-            "composeConstraintLayout"     : "androidx.constraintlayout:constraintlayout-compose",
             "lifecycleViewModelCompose"   : "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1",
             "lifecycleRuntimeCompose"     : "androidx.lifecycle:lifecycle-runtime-compose:2.6.1",
             "navigationCompose"           : "androidx.navigation:navigation-compose:2.7.5",

--- a/build.gradle
+++ b/build.gradle
@@ -15,22 +15,6 @@ buildscript {
 
     ext.deps = [
 
-            // Testing
-            "junit"                       : "junit:junit:4.13.2",
-            "androidxJUnit"               : "androidx.test.ext:junit:1.1.5",
-            "androidxEspressoCore"        : "androidx.test.espresso:espresso-core:3.4.0",
-            "androidxTestCore"            : "androidx.test:core:1.5.0",
-            "androidxTestRunner"          : "androidx.test:runner:1.5.2",
-            "androidxTestRules"           : "androidx.test:rules:1.5.0",
-            "androidxTestUiAutomator"     : "androidx.test.uiautomator:uiautomator:2.2.0",
-            "mockk"                       : "io.mockk:mockk:1.13.5",
-            "kotlinxAndroidCoroutinesTest": "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.1",
-            "robolectric"                 : "org.robolectric:robolectric:4.13",
-            "jsonAssert"                  : "org.skyscreamer:jsonassert:1.4.0",
-            "striktMockk"                 : "io.strikt:strikt-mockk:0.30.1",
-            "striktCore"                  : "io.strikt:strikt-core:0.30.1",
-            "json"                        : "org.json:json:20220320",
-
             // PayPal
             "nativeCheckout"              : "com.paypal.checkout:android-sdk:1.3.2",
 
@@ -40,7 +24,6 @@ buildscript {
             "paypalWebPayments"           : "com.paypal.android:paypal-web-payments:${modules.sdkVersionName}",
             "paypalNativePayments"        : "com.paypal.android:paypal-native-payments:${modules.sdkVersionName}",
             "fraudProtection"             : "com.paypal.android:fraud-protection:${modules.sdkVersionName}",
-
     ]
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -12,10 +12,6 @@ buildscript {
             "compose": "1.4.7",
             "hilt"   : "2.44"
     ]
-
-    dependencies {
-        classpath "com.dicedmelon.gradle:jacoco-android:0.1.5"
-    }
 }
 
 plugins {
@@ -23,8 +19,9 @@ plugins {
     alias libs.plugins.android.library apply false
     alias libs.plugins.jetbrains.kotlin.android apply false
     alias libs.plugins.dagger.hilt apply false
-    alias libs.plugins.gradle.nexus.publish.plugin
+    alias libs.plugins.jacoco.android apply false
     alias libs.plugins.detekt
+    alias libs.plugins.gradle.nexus.publish.plugin
 }
 
 version modules.sdkVersionName // we add it here so that nexus automatically chooses staging or snapshot repo

--- a/build.gradle
+++ b/build.gradle
@@ -10,14 +10,14 @@ buildscript {
 plugins {
     alias libs.plugins.android.application apply false
     alias libs.plugins.android.library apply false
-    alias libs.plugins.jetbrains.kotlin.android apply false
     alias libs.plugins.dagger.hilt apply false
-    alias libs.plugins.jacoco.android apply false
-    alias libs.plugins.kotlin.parcelize apply false
-    alias libs.plugins.gradle.play.publisher apply false
-    alias libs.plugins.kotlin.kapt apply false
     alias libs.plugins.detekt
-    alias libs.plugins.gradle.nexus.publish.plugin
+    alias libs.plugins.gradlePlayPublisher apply false
+    alias libs.plugins.jacocoAndroid apply false
+    alias libs.plugins.kotlinAndroid apply false
+    alias libs.plugins.kotlinParcelize apply false
+    alias libs.plugins.kotlinKapt apply false
+    alias libs.plugins.nexus.publishPlugin
 }
 
 version modules.sdkVersionName // we add it here so that nexus automatically chooses staging or snapshot repo

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
     alias libs.plugins.jetbrains.kotlin.android apply false
     alias libs.plugins.dagger.hilt apply false
     alias libs.plugins.jacoco.android apply false
+    alias libs.plugins.kotlin.parcelize apply false
     alias libs.plugins.detekt
     alias libs.plugins.gradle.nexus.publish.plugin
 }

--- a/build.gradle
+++ b/build.gradle
@@ -64,18 +64,6 @@ detekt {
 }
 
 subprojects {
-    configurations.all {
-        resolutionStrategy {
-            eachDependency { details ->
-                if ('org.jacoco' == details.requested.group) {
-                    details.useVersion "0.8.7"
-                }
-            }
-        }
-    }
-}
-
-subprojects {
     group = "com.paypal.android"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,9 @@
 buildscript {
-
     ext.modules = [
             "sdkVersionName"      : "1.5.1-SNAPSHOT",
             "demoAppVersionCode"  : 4,
             "androidMinSdkVersion": 21,
             "androidTargetVersion": 35
-    ]
-
-    ext.versions = [
-            "kotlin" : "1.8.21",
-            "compose": "1.4.7",
-            "hilt"   : "2.44"
     ]
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,31 +13,18 @@ buildscript {
             "hilt"   : "2.44"
     ]
 
-    ext.deps = [
-
-            // Release modules
-            "cardPayments"                : "com.paypal.android:card-payments:${modules.sdkVersionName}",
-            "paymentButtons"              : "com.paypal.android:payment-buttons:${modules.sdkVersionName}",
-            "paypalWebPayments"           : "com.paypal.android:paypal-web-payments:${modules.sdkVersionName}",
-            "paypalNativePayments"        : "com.paypal.android:paypal-native-payments:${modules.sdkVersionName}",
-            "fraudProtection"             : "com.paypal.android:fraud-protection:${modules.sdkVersionName}",
-    ]
-
-    repositories {
-        google()
-    }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.4.1"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.dicedmelon.gradle:jacoco-android:0.1.5"
         classpath "com.google.dagger:hilt-android-gradle-plugin:${versions.hilt}"
     }
 }
 
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "${detektVersion}"
-    id 'org.jetbrains.kotlin.android' version '1.5.30' apply false
-    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
+    alias libs.plugins.android.application apply false
+    alias libs.plugins.android.library apply false
+    alias libs.plugins.jetbrains.kotlin.android apply false
+    alias libs.plugins.gradle.nexus.publish.plugin
+    alias libs.plugins.detekt
 }
 
 version modules.sdkVersionName // we add it here so that nexus automatically chooses staging or snapshot repo
@@ -54,26 +41,6 @@ nexusPublishing {
     transitionCheckOptions {
         // give nexus sonatype more time to close the staging repository
         delayBetween.set(Duration.ofSeconds(20))
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        mavenLocal()
-
-        maven {
-            url 'https://oss.sonatype.org/content/repositories/snapshots/'
-        }
-
-        maven {
-            url "https://cardinalcommerceprod.jfrog.io/artifactory/android"
-            credentials {
-                username cardinalUsername
-                password cardinalPassword
-            }
-        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,6 @@ buildscript {
 
     ext.deps = [
 
-            // PayPal
-            "nativeCheckout"              : "com.paypal.checkout:android-sdk:1.3.2",
-
             // Release modules
             "cardPayments"                : "com.paypal.android:card-payments:${modules.sdkVersionName}",
             "paymentButtons"              : "com.paypal.android:payment-buttons:${modules.sdkVersionName}",

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ buildscript {
 
     dependencies {
         classpath "com.dicedmelon.gradle:jacoco-android:0.1.5"
-        classpath "com.google.dagger:hilt-android-gradle-plugin:${versions.hilt}"
     }
 }
 
@@ -23,6 +22,7 @@ plugins {
     alias libs.plugins.android.application apply false
     alias libs.plugins.android.library apply false
     alias libs.plugins.jetbrains.kotlin.android apply false
+    alias libs.plugins.dagger.hilt apply false
     alias libs.plugins.gradle.nexus.publish.plugin
     alias libs.plugins.detekt
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,6 @@ buildscript {
 
     ext.deps = [
 
-            // Dependency Injection
-            "hilt"                        : "com.google.dagger:hilt-android:${versions.hilt}",
-            "hiltKapt"                    : "com.google.dagger:hilt-compiler:${versions.hilt}",
-
             // Browser Switch
             "browserSwitch"               : "com.braintreepayments.api:browser-switch:2.3.1",
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ plugins {
     alias libs.plugins.dagger.hilt apply false
     alias libs.plugins.jacoco.android apply false
     alias libs.plugins.kotlin.parcelize apply false
+    alias libs.plugins.gradle.play.publisher apply false
+    alias libs.plugins.kotlin.kapt apply false
     alias libs.plugins.detekt
     alias libs.plugins.gradle.nexus.publish.plugin
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,6 @@ buildscript {
 
     ext.deps = [
 
-            // Jetpack
-            "preference"                  : "androidx.preference:preference-ktx:1.1.1",
-
             // Networking
             "retrofit"                    : "com.squareup.retrofit2:retrofit:2.9.0",
             "gson"                        : "com.squareup.retrofit2:converter-gson:2.3.0",

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,6 @@ buildscript {
     ext.deps = [
 
             // Android
-            "androidxCoreKtx"             : "androidx.core:core-ktx:1.6.0",
-            "androidxAppcompat"           : "androidx.appcompat:appcompat:1.3.1",
-
             "material"                    : "com.google.android.material:material:1.4.0",
             "constraintLayout"            : "androidx.constraintlayout:constraintlayout:2.1.0",
             "kotlinxAndroidCoroutines"    : "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1",

--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,6 @@ buildscript {
 
     ext.deps = [
 
-            // Networking
-            "retrofit"                    : "com.squareup.retrofit2:retrofit:2.9.0",
-            "gson"                        : "com.squareup.retrofit2:converter-gson:2.3.0",
-            "loggingInterceptor"          : "com.squareup.okhttp3:logging-interceptor:4.9.2",
-
             // Dependency Injection
             "hilt"                        : "com.google.dagger:hilt-android:${versions.hilt}",
             "hiltKapt"                    : "com.google.dagger:hilt-compiler:${versions.hilt}",

--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,6 @@ buildscript {
 
     ext.deps = [
 
-            // Jetpack Compose
-            "lifecycleViewModelCompose"   : "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1",
-            "lifecycleRuntimeCompose"     : "androidx.lifecycle:lifecycle-runtime-compose:2.6.1",
-            "navigationCompose"           : "androidx.navigation:navigation-compose:2.7.5",
-            "hiltNavigationCompose"       : "androidx.hilt:hilt-navigation-compose:1.1.0",
-
             // Jetpack
             "preference"                  : "androidx.preference:preference-ktx:1.1.1",
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,6 @@ buildscript {
 
     ext.deps = [
 
-            // Browser Switch
-            "browserSwitch"               : "com.braintreepayments.api:browser-switch:2.3.1",
-
             // Testing
             "junit"                       : "junit:junit:4.13.2",
             "androidxJUnit"               : "androidx.test.ext:junit:1.1.5",

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,6 @@ buildscript {
     ]
 
     ext.deps = [
-            // Kotlin
-            "kotlinStdLib"                : "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
 
             // Android
             "androidxCoreKtx"             : "androidx.core:core-ktx:1.6.0",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,101 +1,97 @@
 [versions]
+androidGradlePlugin = "7.4.1"
 androidxAppcompat = "1.3.1"
 androidxComposeBom = "2023.05.01"
 androidxCoreKtx = "1.6.0"
+androidxEspressoCore = "3.4.0"
 androidxFragmentKtx = "1.6.0"
-androidxLifecycleRuntimeKtx = "2.4.1"
+androidxJUnit = "1.1.5"
 androidxLifecycleCommonJava = "2.4.1"
-constraintLayout = "2.1.0"
-googleMaterial = "1.4.0"
-kotlinVersion = "1.8.21"
-kotlinxCoroutinesAndroid = "1.6.1"
-lifecycleViewModelCompose = "2.5.1"
-lifecycleRuntimeCompose = "2.6.1"
-navigationCompose = "2.7.5"
-hiltNavigationCompose = "1.1.0"
+androidxLifecycleRuntimeKtx = "2.4.1"
 androidxPreferenceKtx = "1.1.1"
-squareRetrofit2 = "2.9.0"
+androidxTestCore = "1.5.0"
+androidxTestRules = "1.5.0"
+androidxTestRunner = "1.5.2"
+androidxTestUiAutomator = "2.2.0"
+browserSwitch = "2.3.1"
+constraintLayout = "2.1.0"
+daggerHilt = "2.44"
+detektVersion = "1.22.0"
+googleMaterial = "1.4.0"
+gradleNexusPublishPlugin = "1.1.0"
+gradlePlayPublisher = "3.8.4"
+hiltNavigationCompose = "1.1.0"
+hiltVersion = "2.44"
+jacocoAndroid = "0.1.5"
+json = "20220320"
+jsonAssert = "1.4.0"
+junit = "4.13.2"
+kotlinVersion = "1.8.21"
+kotlinxAndroidCoroutinesTest = "1.6.1"
+kotlinxCoroutinesAndroid = "1.6.1"
+lifecycleRuntimeCompose = "2.6.1"
+lifecycleViewModelCompose = "2.5.1"
+mockk = "1.13.5"
+nativeCheckout = "1.3.2"
+navigationCompose = "2.7.5"
+robolectric = "4.13"
 squareConverterGson = "2.3.0"
 squareLoggingInterceptor = "4.9.2"
-hiltVersion = "2.44"
-browserSwitch = "2.3.1"
-junit = "4.13.2"
-androidxJUnit = "1.1.5"
-androidxEspressoCore = "3.4.0"
-androidxTestCore = "1.5.0"
-androidxTestRunner = "1.5.2"
-androidxTestRules = "1.5.0"
-androidxTestUiAutomator = "2.2.0"
-mockk = "1.13.5"
-kotlinxAndroidCoroutinesTest = "1.6.1"
-robolectric = "4.13"
-jsonAssert = "1.4.0"
-striktMockk = "0.30.1"
+squareRetrofit2 = "2.9.0"
 striktCore = "0.30.1"
-json = "20220320"
-nativeCheckout = "1.3.2"
-detektVersion = "1.22.0"
-gradleNexusPublishPlugin = "1.1.0"
-androidGradlePlugin = "7.4.1"
-daggerHilt = "2.44"
-jacocoAndroid = "0.1.5"
-gradlePlayPublisher = "3.8.4"
+striktMockk = "0.30.1"
 
 [libraries]
-kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCoreKtx" }
-androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppcompat" }
-androidx-constraint-layout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintLayout" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycleRuntimeKtx" }
-androidx-lifecycle-common-java8 = { group = "androidx.lifecycle", name = "lifecycle-common-java8", version.ref = "androidxLifecycleCommonJava" }
-androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidxFragmentKtx" }
-kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
-google-android-material = { group = "com.google.android.material", name = "material", version.ref = "googleMaterial" }
-
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
-
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-
-androidx-lifecycle-view-model-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewModelCompose" }
+androidx-constraint-layout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintLayout" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCoreKtx" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspressoCore" }
+androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidxFragmentKtx" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJUnit" }
+androidx-lifecycle-common-java8 = { group = "androidx.lifecycle", name = "lifecycle-common-java8", version.ref = "androidxLifecycleCommonJava" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
-
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycleRuntimeKtx" }
+androidx-lifecycle-view-model-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewModelCompose" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidxPreferenceKtx" }
-square-retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "squareRetrofit2" }
-square-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "squareConverterGson" }
-square-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "squareLoggingInterceptor" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
+androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTestRules" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
+androidx-test-ui-automator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidxTestUiAutomator" }
+browser-switch = { group = "com.braintreepayments.api", name = "browser-switch", version.ref = "browserSwitch" }
+google-android-material = { group = "com.google.android.material", name = "material", version.ref = "googleMaterial" }
 google-dagger-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltVersion" }
 google-dagger-hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hiltVersion" }
-browser-switch = { group = "com.braintreepayments.api", name = "browser-switch", version.ref = "browserSwitch" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJUnit" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspressoCore" }
-androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
-androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
-androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTestRules" }
-androidx-test-ui-automator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidxTestUiAutomator" }
-mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
-kotlinx-android-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxAndroidCoroutinesTest" }
-robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
-json-assert = { group = "org.skyscreamer", name = "jsonassert", version.ref = "jsonAssert" }
-strikt-mockk = { group = "io.strikt", name = "strikt-mockk", version.ref = "striktMockk" }
-strikt-core = { group = "io.strikt", name = "strikt-core", version.ref = "striktCore" }
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 json = { group = "org.json", name = "json", version.ref = "json" }
+json-assert = { group = "org.skyscreamer", name = "jsonassert", version.ref = "jsonAssert" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
+kotlinx-android-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxAndroidCoroutinesTest" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 native-checkout = { group = "com.paypal.checkout", name = "android-sdk", version.ref = "nativeCheckout" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+square-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "squareConverterGson" }
+square-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "squareLoggingInterceptor" }
+square-retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "squareRetrofit2" }
+strikt-core = { group = "io.strikt", name = "strikt-core", version.ref = "striktCore" }
+strikt-mockk = { group = "io.strikt", name = "strikt-mockk", version.ref = "striktMockk" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
+dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "daggerHilt" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektVersion" }
 gradle-nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradleNexusPublishPlugin" }
-dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "daggerHilt" }
-jacoco-android = { id = "com.dicedmelon.gradle.jacoco-android", version.ref = "jacocoAndroid" }
-kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlinVersion" }
 gradle-play-publisher = { id = "com.github.triplet.play", version.ref = "gradlePlayPublisher" }
+jacoco-android = { id = "com.dicedmelon.gradle.jacoco-android", version.ref = "jacocoAndroid" }
+jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlinVersion" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlinVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ lifecycleViewModelCompose = "2.5.1"
 lifecycleRuntimeCompose = "2.6.1"
 navigationCompose = "2.7.5"
 hiltNavigationCompose = "1.1.0"
+androidxPreferenceKtx = "1.1.1"
 
 [libraries]
 kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
@@ -42,5 +43,7 @@ androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lif
 
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+
+androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidxPreferenceKtx" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,9 +89,9 @@ android-application = { id = "com.android.application", version.ref = "androidGr
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "daggerHilt" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektVersion" }
-gradle-nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradleNexusPublishPlugin" }
-gradle-play-publisher = { id = "com.github.triplet.play", version.ref = "gradlePlayPublisher" }
-jacoco-android = { id = "com.dicedmelon.gradle.jacoco-android", version.ref = "jacocoAndroid" }
-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlinVersion" }
-kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlinVersion" }
+nexus-publishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradleNexusPublishPlugin" }
+gradlePlayPublisher = { id = "com.github.triplet.play", version.ref = "gradlePlayPublisher" }
+jacocoAndroid = { id = "com.dicedmelon.gradle.jacoco-android", version.ref = "jacocoAndroid" }
+kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
+kotlinKapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlinVersion" }
+kotlinParcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlinVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ jsonAssert = "1.4.0"
 striktMockk = "0.30.1"
 striktCore = "0.30.1"
 json = "20220320"
+nativeCheckout = "1.3.2"
 
 [libraries]
 kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
@@ -83,5 +84,6 @@ json-assert = { group = "org.skyscreamer", name = "jsonassert", version.ref = "j
 strikt-mockk = { group = "io.strikt", name = "strikt-mockk", version.ref = "striktMockk" }
 strikt-core = { group = "io.strikt", name = "strikt-core", version.ref = "striktCore" }
 json = { group = "org.json", name = "json", version.ref = "json" }
+native-checkout = { group = "com.paypal.checkout", name = "android-sdk", version.ref = "nativeCheckout" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+kotlin = "1.8.21"
+
+[libraries]
+kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+
+[plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,7 +65,7 @@ dagger-hiltAndroid = { group = "com.google.dagger", name = "hilt-android", versi
 dagger-hiltCompiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hiltVersion" }
 hilt-navigationCompose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 json = { group = "org.json", name = "json", version.ref = "json" }
-json-assert = { group = "org.skyscreamer", name = "jsonassert", version.ref = "jsonAssert" }
+jsonAssert = { group = "org.skyscreamer", name = "jsonassert", version.ref = "jsonAssert" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-stdLib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
 kotlinx-coroutinesAndroid = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,11 @@
 [versions]
 kotlin = "1.8.21"
+androidxCoreKtx = "1.6.0"
+androidxAppcompat = "1.3.1"
 
 [libraries]
 kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+androidx-core-ktx = { group = "androidx.core", name ="core-ktx", version.ref = "androidxCoreKtx" }
+androidx-appcompat = { group = "androidx.appcompat", name ="appcompat", version.ref = "androidxAppcompat" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ androidxLifecycleRuntimeKtx = "2.4.1"
 androidxLifecycleCommonJava = "2.4.1"
 constraintLayout = "2.1.0"
 googleMaterial = "1.4.0"
-kotlin = "1.8.21"
+kotlinVersion = "1.8.21"
 kotlinxCoroutinesAndroid = "1.6.1"
 lifecycleViewModelCompose = "2.5.1"
 lifecycleRuntimeCompose = "2.6.1"
@@ -17,9 +17,10 @@ androidxPreferenceKtx = "1.1.1"
 squareRetrofit2 = "2.9.0"
 squareConverterGson = "2.3.0"
 squareLoggingInterceptor = "4.9.2"
+hiltVersion = "2.44"
 
 [libraries]
-kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCoreKtx" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppcompat" }
@@ -53,5 +54,7 @@ square-retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", versio
 square-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "squareConverterGson" }
 square-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "squareLoggingInterceptor" }
 
+google-dagger-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltVersion" }
+google-dagger-hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hiltVersion" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,3 +99,4 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektVersion" }
 gradle-nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradleNexusPublishPlugin" }
 dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "daggerHilt" }
 jacoco-android = { id = "com.dicedmelon.gradle.jacoco-android", version.ref = "jacocoAndroid" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlinVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ squareRetrofit2 = "2.9.0"
 squareConverterGson = "2.3.0"
 squareLoggingInterceptor = "4.9.2"
 hiltVersion = "2.44"
+browserSwitch = "2.3.1"
 
 [libraries]
 kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
@@ -56,5 +57,7 @@ square-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-i
 
 google-dagger-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltVersion" }
 google-dagger-hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hiltVersion" }
+
+browser-switch = { group = "com.braintreepayments.api", name = "browser-switch", version.ref = "browserSwitch" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,10 @@ constraintLayout = "2.1.0"
 googleMaterial = "1.4.0"
 kotlin = "1.8.21"
 kotlinxCoroutinesAndroid = "1.6.1"
+lifecycleViewModelCompose = "2.5.1"
+lifecycleRuntimeCompose = "2.6.1"
+navigationCompose = "2.7.5"
+hiltNavigationCompose = "1.1.0"
 
 [libraries]
 kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
@@ -24,7 +28,6 @@ google-android-material = { group = "com.google.android.material", name = "mater
 
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 
-# Ref: https://developer.android.com/jetpack/compose/setup#setup-compose
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
@@ -33,5 +36,11 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-material = { group = "androidx.compose.material", name = "material" }
+
+androidx-lifecycle-view-model-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewModelCompose" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
+
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ squareLoggingInterceptor = "4.9.2"
 hiltVersion = "2.44"
 browserSwitch = "2.3.1"
 junit = "4.13.2"
-androidxJUnit= "1.1.5"
+androidxJUnit = "1.1.5"
 androidxEspressoCore = "3.4.0"
 androidxTestCore = "1.5.0"
 androidxTestRunner = "1.5.2"
@@ -34,6 +34,9 @@ striktMockk = "0.30.1"
 striktCore = "0.30.1"
 json = "20220320"
 nativeCheckout = "1.3.2"
+detektVersion = "1.22.0"
+gradleNexusPublishPlugin = "1.1.0"
+androidGradlePlugin = "7.4.1"
 
 [libraries]
 kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
@@ -87,3 +90,8 @@ json = { group = "org.json", name = "json", version.ref = "json" }
 native-checkout = { group = "com.paypal.checkout", name = "android-sdk", version.ref = "nativeCheckout" }
 
 [plugins]
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektVersion" }
+gradle-nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradleNexusPublishPlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,9 @@ lifecycleRuntimeCompose = "2.6.1"
 navigationCompose = "2.7.5"
 hiltNavigationCompose = "1.1.0"
 androidxPreferenceKtx = "1.1.1"
+squareRetrofit2 = "2.9.0"
+squareConverterGson = "2.3.0"
+squareLoggingInterceptor = "4.9.2"
 
 [libraries]
 kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
@@ -45,5 +48,10 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidxPreferenceKtx" }
+
+square-retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "squareRetrofit2" }
+square-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "squareConverterGson" }
+square-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "squareLoggingInterceptor" }
+
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ gradleNexusPublishPlugin = "1.1.0"
 androidGradlePlugin = "7.4.1"
 daggerHilt = "2.44"
 jacocoAndroid = "0.1.5"
+gradlePlayPublisher = "3.8.4"
 
 [libraries]
 kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
@@ -100,3 +101,5 @@ gradle-nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", ve
 dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "daggerHilt" }
 jacoco-android = { id = "com.dicedmelon.gradle.jacoco-android", version.ref = "jacocoAndroid" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlinVersion" }
+gradle-play-publisher = { id = "com.github.triplet.play", version.ref = "gradlePlayPublisher" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlinVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,14 +55,10 @@ google-android-material = { group = "com.google.android.material", name = "mater
 
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 
-androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }
-androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
-androidx-compose-material = { group = "androidx.compose.material", name = "material" }
 
 androidx-lifecycle-view-model-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewModelCompose" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ detektVersion = "1.22.0"
 gradleNexusPublishPlugin = "1.1.0"
 androidGradlePlugin = "7.4.1"
 daggerHilt = "2.44"
+jacocoAndroid = "0.1.5"
 
 [libraries]
 kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
@@ -97,3 +98,4 @@ jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = 
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektVersion" }
 gradle-nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradleNexusPublishPlugin" }
 dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "daggerHilt" }
+jacoco-android = { id = "com.dicedmelon.gradle.jacoco-android", version.ref = "jacocoAndroid" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,44 +42,44 @@ striktCore = "0.30.1"
 striktMockk = "0.30.1"
 
 [libraries]
+android-material = { group = "com.google.android.material", name = "material", version.ref = "googleMaterial" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppcompat" }
-androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
-androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-constraint-layout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintLayout" }
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCoreKtx" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspressoCore" }
-androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidxFragmentKtx" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJUnit" }
-androidx-lifecycle-common-java8 = { group = "androidx.lifecycle", name = "lifecycle-common-java8", version.ref = "androidxLifecycleCommonJava" }
-androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycleRuntimeKtx" }
-androidx-lifecycle-view-model-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewModelCompose" }
-androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
-androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidxPreferenceKtx" }
+androidx-constraintLayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintLayout" }
+androidx-coreKtx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCoreKtx" }
+androidx-fragmentKtx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidxFragmentKtx" }
+androidx-preferenceKtx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidxPreferenceKtx" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
+androidx-test-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspressoCore" }
+androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJUnit" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTestRules" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
-androidx-test-ui-automator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidxTestUiAutomator" }
-browser-switch = { group = "com.braintreepayments.api", name = "browser-switch", version.ref = "browserSwitch" }
-google-android-material = { group = "com.google.android.material", name = "material", version.ref = "googleMaterial" }
-google-dagger-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltVersion" }
-google-dagger-hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hiltVersion" }
-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+androidx-test-uiAutomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidxTestUiAutomator" }
+braintree-browserSwitch = { group = "com.braintreepayments.api", name = "browser-switch", version.ref = "browserSwitch" }
+compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
+compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+compose-uiTestJunit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+compose-uiTestManifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+compose-uiTooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+compose-uiToolingPreview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+dagger-hiltAndroid = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltVersion" }
+dagger-hiltCompiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hiltVersion" }
+hilt-navigationCompose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 json = { group = "org.json", name = "json", version.ref = "json" }
 json-assert = { group = "org.skyscreamer", name = "jsonassert", version.ref = "jsonAssert" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
-kotlinx-android-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxAndroidCoroutinesTest" }
-kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
+kotlin-stdLib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
+kotlinx-coroutinesAndroid = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
+kotlinx-coroutinesTest = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxAndroidCoroutinesTest" }
+lifecycle-commonJava8 = { group = "androidx.lifecycle", name = "lifecycle-common-java8", version.ref = "androidxLifecycleCommonJava" }
+lifecycle-runtimeCompose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
+lifecycle-runtimeKtx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycleRuntimeKtx" }
+lifecycle-viewModelCompose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewModelCompose" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
-native-checkout = { group = "com.paypal.checkout", name = "android-sdk", version.ref = "nativeCheckout" }
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+paypal-nativeCheckout = { group = "com.paypal.checkout", name = "android-sdk", version.ref = "nativeCheckout" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
-square-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "squareConverterGson" }
-square-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "squareLoggingInterceptor" }
+square-converterGson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "squareConverterGson" }
+square-loggingInterceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "squareLoggingInterceptor" }
 square-retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "squareRetrofit2" }
 strikt-core = { group = "io.strikt", name = "strikt-core", version.ref = "striktCore" }
 strikt-mockk = { group = "io.strikt", name = "strikt-mockk", version.ref = "striktMockk" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,37 @@
 [versions]
-kotlin = "1.8.21"
-androidxCoreKtx = "1.6.0"
 androidxAppcompat = "1.3.1"
+androidxComposeBom = "2023.05.01"
+androidxCoreKtx = "1.6.0"
+androidxFragmentKtx = "1.6.0"
+androidxLifecycleRuntimeKtx = "2.4.1"
+androidxLifecycleCommonJava = "2.4.1"
+constraintLayout = "2.1.0"
+googleMaterial = "1.4.0"
+kotlin = "1.8.21"
+kotlinxCoroutinesAndroid = "1.6.1"
 
 [libraries]
 kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
-androidx-core-ktx = { group = "androidx.core", name ="core-ktx", version.ref = "androidxCoreKtx" }
-androidx-appcompat = { group = "androidx.appcompat", name ="appcompat", version.ref = "androidxAppcompat" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCoreKtx" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppcompat" }
+androidx-constraint-layout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintLayout" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycleRuntimeKtx" }
+androidx-lifecycle-common-java8 = { group = "androidx.lifecycle", name = "lifecycle-common-java8", version.ref = "androidxLifecycleCommonJava" }
+androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidxFragmentKtx" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
+google-android-material = { group = "com.google.android.material", name = "material", version.ref = "googleMaterial" }
+
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+
+# Ref: https://developer.android.com/jetpack/compose/setup#setup-compose
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
+androidx-compose-material = { group = "androidx.compose.material", name = "material" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,20 @@ squareConverterGson = "2.3.0"
 squareLoggingInterceptor = "4.9.2"
 hiltVersion = "2.44"
 browserSwitch = "2.3.1"
+junit = "4.13.2"
+androidxJUnit= "1.1.5"
+androidxEspressoCore = "3.4.0"
+androidxTestCore = "1.5.0"
+androidxTestRunner = "1.5.2"
+androidxTestRules = "1.5.0"
+androidxTestUiAutomator = "2.2.0"
+mockk = "1.13.5"
+kotlinxAndroidCoroutinesTest = "1.6.1"
+robolectric = "4.13"
+jsonAssert = "1.4.0"
+striktMockk = "0.30.1"
+striktCore = "0.30.1"
+json = "20220320"
 
 [libraries]
 kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
@@ -48,16 +62,26 @@ androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lif
 
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
-
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidxPreferenceKtx" }
-
 square-retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "squareRetrofit2" }
 square-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "squareConverterGson" }
 square-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "squareLoggingInterceptor" }
-
 google-dagger-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltVersion" }
 google-dagger-hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hiltVersion" }
-
 browser-switch = { group = "com.braintreepayments.api", name = "browser-switch", version.ref = "browserSwitch" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJUnit" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspressoCore" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
+androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTestRules" }
+androidx-test-ui-automator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidxTestUiAutomator" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+kotlinx-android-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxAndroidCoroutinesTest" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+json-assert = { group = "org.skyscreamer", name = "jsonassert", version.ref = "jsonAssert" }
+strikt-mockk = { group = "io.strikt", name = "strikt-mockk", version.ref = "striktMockk" }
+strikt-core = { group = "io.strikt", name = "strikt-core", version.ref = "striktCore" }
+json = { group = "org.json", name = "json", version.ref = "json" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ nativeCheckout = "1.3.2"
 detektVersion = "1.22.0"
 gradleNexusPublishPlugin = "1.1.0"
 androidGradlePlugin = "7.4.1"
+daggerHilt = "2.44"
 
 [libraries]
 kotlin-std-lib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
@@ -95,3 +96,4 @@ android-library = { id = "com.android.library", version.ref = "androidGradlePlug
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektVersion" }
 gradle-nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradleNexusPublishPlugin" }
+dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "daggerHilt" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,41 @@
+pluginManagement {
+    repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
+
+        maven {
+            url "https://cardinalcommerceprod.jfrog.io/artifactory/android"
+            credentials {
+                username cardinalUsername
+                password cardinalPassword
+            }
+        }
+    }
+}
+
+rootProject.name = "AndroidSDK"
 include ':CardPayments'
 include ':CorePayments'
 include ':Demo'
-rootProject.name = "AndroidSDK"
 include ':FraudProtection'
 include ':PayPalNativePayments'
 include ':PayPalWebPayments'


### PR DESCRIPTION
### Summary of changes

 - This PR is to modernize our Gradle configuration by migrating to Version Catalogs as recommended [by Google](https://developer.android.com/build/migrate-to-catalogs)
 - The naming convention for naming dependencies in the version catalog is loosely based on this set of [best practices](https://blog.gradle.org/best-practices-naming-version-catalog-entries), though it's worth revisiting

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
