### PR TITLE
Support Beta Releases in GitHub Actions Script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,9 +83,9 @@ task incrementSnapshotVersion {
         def (major, minor, patch) = versionString.tokenize('.')
 
         // check if patch version ends with beta and a single/multi-digit number
-        def isBetaVersion = patch.matches(/-beta\d+$/)
+        def isBetaVersion = patch.matches(/[0-9]+-beta\d+$/)
         if (isBetaVersion) {
-            def betaMatcher = patch =~ /[0-9.]+-beta(\d+)$/
+            def betaMatcher = patch =~ /[0-9]+-beta(\d+)$/
             def betaVersion = betaMatcher[0][1].toInteger()
             // capture beginning of beta patch string and increment beta version
             def newBeta = patch.replaceFirst(/([0-9.]+-beta)\d+$/, '$1' + (betaVersion + 1))

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,6 @@ task incrementSnapshotVersion {
 
         } else {
             def patchInteger = (patch.endsWith('-SNAPSHOT') ? patch - '-SNAPSHOT' : patch).toInteger()
-
             def newVersion = "$major.$minor.${patchInteger + 1}-SNAPSHOT"
             def updatedScript =
                     topLevelGradleFileText.replaceFirst(/("sdkVersionName"\s*: )".*",/, '$1"' + newVersion + '",')

--- a/build.gradle
+++ b/build.gradle
@@ -81,12 +81,27 @@ task incrementSnapshotVersion {
         def versionString = matcher[0][1]
 
         def (major, minor, patch) = versionString.tokenize('.')
-        def patchInteger = (patch.endsWith('-SNAPSHOT') ? patch - '-SNAPSHOT' : patch).toInteger()
 
-        def newVersion = "$major.$minor.${patchInteger + 1}-SNAPSHOT"
-        def updatedScript =
-                topLevelGradleFileText.replaceFirst(/("sdkVersionName"\s*: )".*",/, '$1"' + newVersion + '",')
-        topLevelGradleFile.write(updatedScript, 'UTF-8')
+        // check if patch version ends with beta and a single/multi-digit number
+        def isBetaVersion = patch.matches(/-beta\d+$/)
+        if (isBetaVersion) {
+            def betaMatcher = patch =~ /[0-9.]+-beta(\d+)$/
+            def betaVersion = betaMatcher[0][1].toInteger()
+            // capture beginning of beta patch string and increment beta version
+            def newBeta = patch.replaceFirst(/([0-9.]+-beta)\d+$/, '$1' + (betaVersion + 1))
+            def newVersion = "$major.$minor.${newBeta}-SNAPSHOT"
+            def updatedScript =
+                    topLevelGradleFileText.replaceFirst(/("sdkVersionName"\s*: )".*",/, '$1"' + newVersion + '",')
+            topLevelGradleFile.write(updatedScript, 'UTF-8')
+
+        } else {
+            def patchInteger = (patch.endsWith('-SNAPSHOT') ? patch - '-SNAPSHOT' : patch).toInteger()
+
+            def newVersion = "$major.$minor.${patchInteger + 1}-SNAPSHOT"
+            def updatedScript =
+                    topLevelGradleFileText.replaceFirst(/("sdkVersionName"\s*: )".*",/, '$1"' + newVersion + '",')
+            topLevelGradleFile.write(updatedScript, 'UTF-8')
+        }
     }
 }
 


### PR DESCRIPTION
### Summary of changes

 - This PR modifies versioning logic to support `beta1`, `beta2`, etc. style version strings 

 ### Checklist

 - [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
