### PR TITLE
Migrate CardClient Analytics Logic Into CardAnalytics Class 

### DIFF
--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
@@ -11,27 +11,44 @@ class CardAnalytics(
         analyticsService.sendAnalyticsEvent(eventName, orderId)
     }
 
-    fun notifyConfirmPaymentSourceAuthChallengeReceived(orderId: String) {
-        val eventName = "card-payments:approve-order:confirm-payment-auth-challenge-received"
+    fun notifyApproveOrderSucceeded(orderId: String) {
+        val eventName = "card-payments:approve-order:succeeded"
         analyticsService.sendAnalyticsEvent(eventName, orderId)
     }
 
-    fun notifyConfirmPaymentSourceFailed(orderId: String) {
-        val eventName = "card-payments:approve-order:confirm-payment-source-failed"
+    fun notifyApproveOrderFailed(orderId: String) {
+        val eventName = "card-payments:approve-order:failed"
         analyticsService.sendAnalyticsEvent(eventName, orderId)
     }
 
-    fun notifyApproveOrder3DSCanceled(orderId: String?) {
-        analyticsService.sendAnalyticsEvent("card-payments:3ds:challenge:user-canceled", orderId)
-    }
-
-    fun notifyApproveOrderSucceededWithout3DS(orderId: String) {
-        val eventName = "card-payments:approve-order:succeeded-without-3ds"
+    fun notifyApproveOrderAuthChallengeReceived(orderId: String) {
+        val eventName = "card-payments:approve-order:auth-challenge-received"
         analyticsService.sendAnalyticsEvent(eventName, orderId)
     }
 
-    fun notifyApproveOrder3DSFailed(orderId: String?) {
-        analyticsService.sendAnalyticsEvent("card-payments:3ds:failed", orderId)
+    fun notifyApproveOrderAuthChallengeStarted(orderId: String?) {
+        val eventName = "card-payments:approve-order:auth-challenge-started"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
+    }
+
+    fun notifyApproveOrderAuthChallengeSucceeded(orderId: String) {
+        val eventName = "card-payments:approve-order:auth-challenge-succeeded"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
+    }
+
+    fun notifyApproveOrderAuthChallengeCanceled(orderId: String?) {
+        val eventName = "card-payments:approve-order:auth-challenge-canceled"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
+    }
+
+    fun notifyApproveOrderAuthChallengeFailed(orderId: String?) {
+        val eventName = "card-payments:approve-order:auth-challenge-failed"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
+    }
+
+    fun notifyApproveOrderUnknownError(orderId: String?) {
+        val eventName = "card-payments:approve-order:unknown-error"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
     }
 
     fun notifyVaultStarted(setupTokenId: String) {
@@ -41,6 +58,16 @@ class CardAnalytics(
 
     fun notifyVaultAuthChallengeReceived(setupTokenId: String) {
         val eventName = "card-payments:vault:auth-challenge-received"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+
+    fun notifyVaultAuthChallengeStarted(setupTokenId: String?) {
+        val eventName = "card-payments:vault:auth-challenge-started"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+
+    fun notifyVaultAuthChallengeFailed(setupTokenId: String?) {
+        val eventName = "card-payments:vault:auth-challenge-failed"
         analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
     }
 

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
@@ -11,11 +11,6 @@ class CardAnalytics(
         analyticsService.sendAnalyticsEvent(eventName, orderId)
     }
 
-    fun notifyConfirmPaymentSourceSucceeded(orderId: String) {
-        val eventName = "card-payments:approve-order:confirm-payment-source-succeeded"
-        analyticsService.sendAnalyticsEvent(eventName, orderId)
-    }
-
     fun notifyConfirmPaymentSourceAuthChallengeReceived(orderId: String) {
         val eventName = "card-payments:approve-order:confirm-payment-auth-challenge-received"
         analyticsService.sendAnalyticsEvent(eventName, orderId)
@@ -30,8 +25,9 @@ class CardAnalytics(
         analyticsService.sendAnalyticsEvent("card-payments:3ds:challenge:user-canceled", orderId)
     }
 
-    fun notifyApproveOrder3DSSuccess(orderId: String) {
-        analyticsService.sendAnalyticsEvent("card-payments:3ds:succeeded", orderId)
+    fun notifyApproveOrderSucceededWithout3DS(orderId: String) {
+        val eventName = "card-payments:approve-order:succeeded-without-3ds"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
     }
 
     fun notifyApproveOrder3DSFailed(orderId: String?) {

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
@@ -2,6 +2,7 @@ package com.paypal.android.cardpayments
 
 import com.paypal.android.corepayments.analytics.AnalyticsService
 
+@Suppress("TooManyFunctions")
 class CardAnalytics(
     private val analyticsService: AnalyticsService
 ) {

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
@@ -6,6 +6,7 @@ class CardAnalytics(
     private val analyticsService: AnalyticsService
 ) {
 
+    // region Approve Order
     fun notifyApproveOrderStarted(orderId: String) {
         val eventName = "card-payments:approve-order:started"
         analyticsService.sendAnalyticsEvent(eventName, orderId)
@@ -50,9 +51,21 @@ class CardAnalytics(
         val eventName = "card-payments:approve-order:unknown-error"
         analyticsService.sendAnalyticsEvent(eventName, orderId)
     }
+    // endregion
 
+    // region Vault
     fun notifyVaultStarted(setupTokenId: String) {
         val eventName = "card-payments:vault:started"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+
+    fun notifyVaultSucceeded(setupTokenId: String) {
+        val eventName = "card-payments:vault:succeeded"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+
+    fun notifyVaultFailed(setupTokenId: String?) {
+        val eventName = "card-payments:vault:failed"
         analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
     }
 
@@ -66,21 +79,24 @@ class CardAnalytics(
         analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
     }
 
+    fun notifyVaultAuthChallengeSucceeded(setupTokenId: String) {
+        val eventName = "card-payments:vault:auth-challenge-succeeded"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+
+    fun notifyVaultAuthChallengeCanceled(setupTokenId: String?) {
+        val eventName = "card-payments:vault:auth-challenge-canceled"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+
     fun notifyVaultAuthChallengeFailed(setupTokenId: String?) {
         val eventName = "card-payments:vault:auth-challenge-failed"
         analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
     }
 
-    fun notifyVaultSuccess(setupTokenId: String) {
-        analyticsService.sendAnalyticsEvent("card:browser-login:canceled", setupTokenId)
-    }
-
-    fun notifyVaultFailure(setupTokenId: String?) {
-        analyticsService.sendAnalyticsEvent("card:failed", setupTokenId)
-    }
-
-    fun notifyVaultCancellation(setupTokenId: String?) {
-        val eventName = "paypal-web-payments:browser-login:canceled"
+    fun notifyVaultUnknownError(setupTokenId: String?) {
+        val eventName = "card-payments:vault:unknown-error"
         analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
     }
+    // endregion
 }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
@@ -6,29 +6,24 @@ class CardAnalytics(
     private val analyticsService: AnalyticsService
 ) {
 
-    fun notify3DSStarted(orderId: String) {
-        analyticsService.sendAnalyticsEvent("card-payments:3ds:started", orderId)
+    fun notifyApproveOrderStarted(orderId: String) {
+        val eventName = "card-payments:approve-order:started"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
     }
 
     fun notifyConfirmPaymentSourceSucceeded(orderId: String) {
-        analyticsService.sendAnalyticsEvent(
-            "card-payments:3ds:confirm-payment-source:succeeded",
-            orderId
-        )
+        val eventName = "card-payments:approve-order:confirm-payment-source-succeeded"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
     }
 
-    fun notifyConfirmPaymentSourceChallengeRequired(orderId: String) {
-        analyticsService.sendAnalyticsEvent(
-            "card-payments:3ds:confirm-payment-source:challenge-required",
-            orderId
-        )
+    fun notifyConfirmPaymentSourceAuthChallengeReceived(orderId: String) {
+        val eventName = "card-payments:approve-order:confirm-payment-auth-challenge-received"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
     }
 
     fun notifyConfirmPaymentSourceFailed(orderId: String) {
-        analyticsService.sendAnalyticsEvent(
-            "card-payments:3ds:confirm-payment-source:failed",
-            orderId
-        )
+        val eventName = "card-payments:approve-order:confirm-payment-source-failed"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
     }
 
     fun notifyApproveOrder3DSCanceled(orderId: String?) {
@@ -52,6 +47,9 @@ class CardAnalytics(
     }
 
     fun notifyVaultCancellation(setupTokenId: String?) {
-        analyticsService.sendAnalyticsEvent("paypal-web-payments:browser-login:canceled", setupTokenId)
+        analyticsService.sendAnalyticsEvent(
+            "paypal-web-payments:browser-login:canceled",
+            setupTokenId
+        )
     }
 }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
@@ -38,6 +38,16 @@ class CardAnalytics(
         analyticsService.sendAnalyticsEvent("card-payments:3ds:failed", orderId)
     }
 
+    fun notifyVaultStarted(setupTokenId: String) {
+        val eventName = "card-payments:vault:started"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+
+    fun notifyVaultAuthChallengeReceived(setupTokenId: String) {
+        val eventName = "card-payments:vault:auth-challenge-received"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+
     fun notifyVaultSuccess(setupTokenId: String) {
         analyticsService.sendAnalyticsEvent("card:browser-login:canceled", setupTokenId)
     }
@@ -47,9 +57,7 @@ class CardAnalytics(
     }
 
     fun notifyVaultCancellation(setupTokenId: String?) {
-        analyticsService.sendAnalyticsEvent(
-            "paypal-web-payments:browser-login:canceled",
-            setupTokenId
-        )
+        val eventName = "paypal-web-payments:browser-login:canceled"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
     }
 }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
@@ -1,0 +1,57 @@
+package com.paypal.android.cardpayments
+
+import com.paypal.android.corepayments.analytics.AnalyticsService
+
+class CardAnalytics(
+    private val analyticsService: AnalyticsService
+) {
+
+    fun notify3DSStarted(orderId: String) {
+        analyticsService.sendAnalyticsEvent("card-payments:3ds:started", orderId)
+    }
+
+    fun notifyConfirmPaymentSourceSucceeded(orderId: String) {
+        analyticsService.sendAnalyticsEvent(
+            "card-payments:3ds:confirm-payment-source:succeeded",
+            orderId
+        )
+    }
+
+    fun notifyConfirmPaymentSourceChallengeRequired(orderId: String) {
+        analyticsService.sendAnalyticsEvent(
+            "card-payments:3ds:confirm-payment-source:challenge-required",
+            orderId
+        )
+    }
+
+    fun notifyConfirmPaymentSourceFailed(orderId: String) {
+        analyticsService.sendAnalyticsEvent(
+            "card-payments:3ds:confirm-payment-source:failed",
+            orderId
+        )
+    }
+
+    fun notifyApproveOrder3DSCanceled(orderId: String?) {
+        analyticsService.sendAnalyticsEvent("card-payments:3ds:challenge:user-canceled", orderId)
+    }
+
+    fun notifyApproveOrder3DSSuccess(orderId: String) {
+        analyticsService.sendAnalyticsEvent("card-payments:3ds:succeeded", orderId)
+    }
+
+    fun notifyApproveOrder3DSFailed(orderId: String?) {
+        analyticsService.sendAnalyticsEvent("card-payments:3ds:failed", orderId)
+    }
+
+    fun notifyVaultSuccess(setupTokenId: String) {
+        analyticsService.sendAnalyticsEvent("card:browser-login:canceled", setupTokenId)
+    }
+
+    fun notifyVaultFailure(setupTokenId: String?) {
+        analyticsService.sendAnalyticsEvent("card:failed", setupTokenId)
+    }
+
+    fun notifyVaultCancellation(setupTokenId: String?) {
+        analyticsService.sendAnalyticsEvent("paypal-web-payments:browser-login:canceled", setupTokenId)
+    }
+}

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -132,7 +132,6 @@ class CardClient internal constructor(
                         CardAuthChallenge.Vault(url = url, request = cardVaultRequest)
                     cardVaultListener?.onVaultAuthorizationRequired(authChallenge)
                 }
-
             } catch (error: PayPalSDKError) {
                 analytics.notifyVaultFailed(cardVaultRequest.setupTokenId)
                 throw error

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -70,7 +70,7 @@ class CardClient internal constructor(
     fun approveOrder(cardRequest: CardRequest) {
         // TODO: deprecate this method and offer auth challenge integration pattern (similar to vault)
         approveOrderId = cardRequest.orderId
-        analytics.notify3DSStarted(cardRequest.orderId)
+        analytics.notifyApproveOrderStarted(cardRequest.orderId)
 
         CoroutineScope(dispatcher).launch(approveOrderExceptionHandler) {
             // TODO: migrate away from throwing exceptions to result objects
@@ -83,7 +83,7 @@ class CardClient internal constructor(
                         response.run { CardResult(orderId = orderId, status = status?.name) }
                     notifyApproveOrderSuccess(result)
                 } else {
-                    analytics.notifyConfirmPaymentSourceChallengeRequired(cardRequest.orderId)
+                    analytics.notifyConfirmPaymentSourceAuthChallengeReceived(cardRequest.orderId)
                     approveOrderListener?.onApproveOrderThreeDSecureWillLaunch()
 
                     val url = Uri.parse(response.payerActionHref)

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -76,12 +76,11 @@ class CardClient internal constructor(
             // TODO: migrate away from throwing exceptions to result objects
             try {
                 val response = checkoutOrdersAPI.confirmPaymentSource(cardRequest)
-                analytics.notifyConfirmPaymentSourceSucceeded(cardRequest.orderId)
-
                 if (response.payerActionHref == null) {
+                    analytics.notifyApproveOrderSucceededWithout3DS(response.orderId)
                     val result =
                         response.run { CardResult(orderId = orderId, status = status?.name) }
-                    notifyApproveOrderSuccess(result)
+                    approveOrderListener?.onApproveOrderSuccess(result)
                 } else {
                     analytics.notifyConfirmPaymentSourceAuthChallengeReceived(cardRequest.orderId)
                     approveOrderListener?.onApproveOrderThreeDSecureWillLaunch()

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
@@ -10,7 +10,6 @@ import com.paypal.android.cardpayments.api.CheckoutOrdersAPI
 import com.paypal.android.cardpayments.api.ConfirmPaymentSourceResponse
 import com.paypal.android.corepayments.OrderStatus
 import com.paypal.android.corepayments.PayPalSDKError
-import com.paypal.android.corepayments.analytics.AnalyticsService
 import io.mockk.Called
 import io.mockk.coEvery
 import io.mockk.every
@@ -58,7 +57,7 @@ class CardClientUnitTest {
     private val checkoutOrdersAPI = mockk<CheckoutOrdersAPI>(relaxed = true)
     private val paymentMethodTokensAPI = mockk<DataVaultPaymentMethodTokensAPI>(relaxed = true)
 
-    private val analyticsService = mockk<AnalyticsService>(relaxed = true)
+    private val cardAnalytics = mockk<CardAnalytics>(relaxed = true)
     private val confirmPaymentSourceResponse =
         ConfirmPaymentSourceResponse(orderId, OrderStatus.APPROVED)
 
@@ -405,7 +404,7 @@ class CardClientUnitTest {
         val sut = CardClient(
             checkoutOrdersAPI,
             paymentMethodTokensAPI,
-            analyticsService,
+            cardAnalytics,
             cardAuthLauncher,
             dispatcher
         )


### PR DESCRIPTION
### Summary of changes

 - This PR creates a `CardAnalytics` class to encapsulate analytics notification logic
 - Externalizing Analytics code should make Analytics Events easier to audit in one place
 - Externalizing Analytics will also make future refactoring to migrate away from the listener pattern more clear

 ### Checklist

 - [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
