### PR TITLE
Migrate PayPalWebClient Analytics Logic Into PayPalWebAnalytics Class

### DIFF
--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
@@ -3,9 +3,7 @@ package com.paypal.android.cardpayments
 import com.paypal.android.corepayments.analytics.AnalyticsService
 
 @Suppress("TooManyFunctions")
-class CardAnalytics(
-    private val analyticsService: AnalyticsService
-) {
+class CardAnalytics(private val analyticsService: AnalyticsService) {
 
     // region Approve Order
     fun notifyApproveOrderStarted(orderId: String) {

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAnalytics.kt
@@ -3,7 +3,7 @@ package com.paypal.android.cardpayments
 import com.paypal.android.corepayments.analytics.AnalyticsService
 
 @Suppress("TooManyFunctions")
-class CardAnalytics(private val analyticsService: AnalyticsService) {
+internal class CardAnalytics(private val analyticsService: AnalyticsService) {
 
     // region Approve Order
     fun notifyApproveOrderStarted(orderId: String) {

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebAnalytics.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebAnalytics.kt
@@ -3,7 +3,7 @@ package com.paypal.android.paypalwebpayments
 import com.paypal.android.corepayments.analytics.AnalyticsService
 
 @Suppress("TooManyFunctions")
-class PayPalWebAnalytics(private val analyticsService: AnalyticsService) {
+internal class PayPalWebAnalytics(private val analyticsService: AnalyticsService) {
 
     fun notifyCheckoutStarted(orderId: String) {
         val eventName = "paypal-web-payments:checkout:started"

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebAnalytics.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebAnalytics.kt
@@ -51,7 +51,7 @@ internal class PayPalWebAnalytics(private val analyticsService: AnalyticsService
     }
 
     fun notifyVaultAuthChallengeCanceled(setupTokenId: String?) {
-        val eventName = "paypal-web-payments:checkout:auth-challenge-canceled"
+        val eventName = "paypal-web-payments:vault:auth-challenge-canceled"
         analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
     }
 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebAnalytics.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebAnalytics.kt
@@ -1,0 +1,57 @@
+package com.paypal.android.paypalwebpayments
+
+import com.paypal.android.corepayments.analytics.AnalyticsService
+
+@Suppress("TooManyFunctions")
+class PayPalWebAnalytics(private val analyticsService: AnalyticsService) {
+
+    fun notifyCheckoutStarted(orderId: String) {
+        val eventName = "paypal-web-payments:checkout:started"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
+    }
+
+    fun notifyCheckoutAuthChallengeStarted(orderId: String) {
+        val eventName = "paypal-web-payments:checkout:auth-challenge-started"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
+    }
+
+    fun notifyCheckoutAuthChallengeSucceeded(orderId: String?) {
+        val eventName = "paypal-web-payments:checkout:auth-challenge-succeeded"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
+    }
+
+    fun notifyCheckoutAuthChallengeFailed(orderId: String?) {
+        val eventName = "paypal-web-payments:checkout:auth-challenge-failed"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
+    }
+
+    fun notifyCheckoutAuthChallengeCanceled(orderId: String?) {
+        val eventName = "paypal-web-payments:checkout:auth-challenge-canceled"
+        analyticsService.sendAnalyticsEvent(eventName, orderId)
+    }
+
+    fun notifyVaultStarted(setupTokenId: String) {
+        val eventName = "paypal-web-payments:vault:started"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+
+    fun notifyVaultAuthChallengeStarted(setupTokenId: String) {
+        val eventName = "paypal-web-payments:vault:auth-challenge-started"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+
+    fun notifyVaultAuthChallengeSucceeded(setupTokenId: String?) {
+        val eventName = "paypal-web-payments:vault:auth-challenge-succeeded"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+
+    fun notifyVaultAuthChallengeFailed(setupTokenId: String?) {
+        val eventName = "paypal-web-payments:vault:auth-challenge-failed"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+
+    fun notifyVaultAuthChallengeCanceled(setupTokenId: String?) {
+        val eventName = "paypal-web-payments:checkout:auth-challenge-canceled"
+        analyticsService.sendAnalyticsEvent(eventName, setupTokenId)
+    }
+}

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -15,7 +15,6 @@ import com.paypal.android.corepayments.analytics.AnalyticsService
  * Use this client to approve an order with a [PayPalWebCheckoutRequest].
  */
 class PayPalWebCheckoutClient internal constructor(
-    private val analyticsService: AnalyticsService,
     private val analytics: PayPalWebAnalytics,
     private val payPalWebLauncher: PayPalWebLauncher
 ) {
@@ -28,7 +27,6 @@ class PayPalWebCheckoutClient internal constructor(
      * @param urlScheme the custom URl scheme used to return to your app from a browser switch flow
      */
     constructor(context: Context, configuration: CoreConfig, urlScheme: String) : this(
-        AnalyticsService(context.applicationContext, configuration),
         PayPalWebAnalytics(AnalyticsService(context.applicationContext, configuration)),
         PayPalWebLauncher(urlScheme, configuration),
     )

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.util.Log
 import androidx.activity.ComponentActivity
 import com.paypal.android.corepayments.CoreConfig
-import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.corepayments.analytics.AnalyticsService
 
 // NEXT MAJOR VERSION: consider renaming this module to PayPalWebClient since

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -21,7 +21,7 @@ import org.robolectric.RobolectricTestRunner
 class PayPalWebCheckoutClientUnitTest {
 
     private val activity: FragmentActivity = mockk(relaxed = true)
-    private val analyticsService = mockk<AnalyticsService>(relaxed = true)
+    private val analytics = mockk<PayPalWebAnalytics>(relaxed = true)
 
     private val checkoutListener = mockk<PayPalWebCheckoutListener>(relaxed = true)
     private val vaultListener = mockk<PayPalWebVaultListener>(relaxed = true)
@@ -34,7 +34,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Before
     fun beforeEach() {
         payPalWebLauncher = mockk(relaxed = true)
-        sut = PayPalWebCheckoutClient(analyticsService, payPalWebLauncher)
+        sut = PayPalWebCheckoutClient(analytics, payPalWebLauncher)
     }
 
     @Test

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -3,7 +3,6 @@ package com.paypal.android.paypalwebpayments
 import android.content.Intent
 import androidx.fragment.app.FragmentActivity
 import com.paypal.android.corepayments.PayPalSDKError
-import com.paypal.android.corepayments.analytics.AnalyticsService
 import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk


### PR DESCRIPTION
### Summary of changes

 - This PR creates a `PayPalWebAnalytics` class to encapsulate analytics notification logic
 - Externalizing Analytics code should make Analytics Events easier to audit in one place
 - Externalizing Analytics will also make future refactoring to migrate away from the listener pattern more clear

 ### Checklist

 - [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
