### PR TITLE
Card: Remove try/catch from Approve Order Flow

### DIFF
--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardClient.kt
@@ -41,12 +41,6 @@ class CardClient internal constructor(
     private var approveOrderId: String? = null
 
     // TODO: remove once try-catch is removed
-    private val approveOrderExceptionHandler = CoreCoroutineExceptionHandler { error ->
-        analytics.notifyApproveOrderUnknownError(null)
-        approveOrderListener?.onApproveOrderFailure(error)
-    }
-
-    // TODO: remove once try-catch is removed
     private val vaultExceptionHandler = CoreCoroutineExceptionHandler { error ->
         analytics.notifyVaultUnknownError(null)
         cardVaultListener?.onVaultFailure(error)
@@ -77,7 +71,7 @@ class CardClient internal constructor(
         approveOrderId = cardRequest.orderId
         analytics.notifyApproveOrderStarted(cardRequest.orderId)
 
-        CoroutineScope(dispatcher).launch(approveOrderExceptionHandler) {
+        CoroutineScope(dispatcher).launch {
             when (val response = checkoutOrdersAPI.confirmPaymentSource(cardRequest)) {
                 is ConfirmPaymentSourceResult.Success -> {
                     if (response.payerActionHref == null) {

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResponseParser.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResponseParser.kt
@@ -1,6 +1,6 @@
 package com.paypal.android.cardpayments
 
-import com.paypal.android.cardpayments.api.ConfirmPaymentSourceResponse
+import com.paypal.android.cardpayments.api.ConfirmPaymentSourceResult
 import com.paypal.android.cardpayments.model.PaymentSource
 import com.paypal.android.cardpayments.model.PurchaseUnit
 import com.paypal.android.corepayments.APIClientError
@@ -14,7 +14,7 @@ import org.json.JSONException
 internal class CardResponseParser {
 
     @Throws(PayPalSDKError::class)
-    fun parseConfirmPaymentSourceResponse(httpResponse: HttpResponse): ConfirmPaymentSourceResponse =
+    fun parseConfirmPaymentSourceResponse(httpResponse: HttpResponse): ConfirmPaymentSourceResult =
         try {
             val bodyResponse = httpResponse.body!!
 
@@ -24,7 +24,7 @@ internal class CardResponseParser {
 
             // this section is for 3DS
             val payerActionHref = json.getLinkHref("payer-action")
-            ConfirmPaymentSourceResponse(
+            ConfirmPaymentSourceResult(
                 id,
                 OrderStatus.valueOf(status),
                 payerActionHref,

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResponseParser.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardResponseParser.kt
@@ -13,7 +13,6 @@ import org.json.JSONException
 
 internal class CardResponseParser {
 
-    @Throws(PayPalSDKError::class)
     fun parseConfirmPaymentSourceResponse(httpResponse: HttpResponse): ConfirmPaymentSourceResult =
         try {
             val bodyResponse = httpResponse.body!!
@@ -24,7 +23,7 @@ internal class CardResponseParser {
 
             // this section is for 3DS
             val payerActionHref = json.getLinkHref("payer-action")
-            ConfirmPaymentSourceResult(
+            ConfirmPaymentSourceResult.Success(
                 id,
                 OrderStatus.valueOf(status),
                 payerActionHref,
@@ -33,7 +32,8 @@ internal class CardResponseParser {
             )
         } catch (ignored: JSONException) {
             val correlationId = httpResponse.headers["Paypal-Debug-Id"]
-            throw APIClientError.dataParsingError(correlationId)
+            val error = APIClientError.dataParsingError(correlationId)
+            ConfirmPaymentSourceResult.Failure(error)
         }
 
     fun parseError(httpResponse: HttpResponse): PayPalSDKError? {

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CheckoutOrdersAPI.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CheckoutOrdersAPI.kt
@@ -13,7 +13,7 @@ internal class CheckoutOrdersAPI(
 ) {
     constructor(coreConfig: CoreConfig) : this(RestClient(coreConfig))
 
-    suspend fun confirmPaymentSource(cardRequest: CardRequest): ConfirmPaymentSourceResponse {
+    suspend fun confirmPaymentSource(cardRequest: CardRequest): ConfirmPaymentSourceResult {
         val apiRequest = requestFactory.createConfirmPaymentSourceRequest(cardRequest)
         val httpResponse = restClient.send(apiRequest)
 

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CheckoutOrdersAPI.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CheckoutOrdersAPI.kt
@@ -19,7 +19,7 @@ internal class CheckoutOrdersAPI(
 
         val error = responseParser.parseError(httpResponse)
         if (error != null) {
-            throw error
+            return ConfirmPaymentSourceResult.Failure(error)
         } else {
             return responseParser.parseConfirmPaymentSourceResponse(httpResponse)
         }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CheckoutOrdersAPI.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/CheckoutOrdersAPI.kt
@@ -18,10 +18,10 @@ internal class CheckoutOrdersAPI(
         val httpResponse = restClient.send(apiRequest)
 
         val error = responseParser.parseError(httpResponse)
-        if (error != null) {
-            return ConfirmPaymentSourceResult.Failure(error)
+        return if (error == null) {
+            responseParser.parseConfirmPaymentSourceResponse(httpResponse)
         } else {
-            return responseParser.parseConfirmPaymentSourceResponse(httpResponse)
+            ConfirmPaymentSourceResult.Failure(error)
         }
     }
 }

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/ConfirmPaymentSourceResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/ConfirmPaymentSourceResult.kt
@@ -1,13 +1,20 @@
 package com.paypal.android.cardpayments.api
 
+import com.paypal.android.cardpayments.CardPresentAuthChallengeResult
 import com.paypal.android.cardpayments.model.PaymentSource
 import com.paypal.android.cardpayments.model.PurchaseUnit
 import com.paypal.android.corepayments.OrderStatus
+import com.paypal.android.corepayments.PayPalSDKError
 
-internal data class ConfirmPaymentSourceResult(
-    val orderId: String,
-    val status: OrderStatus? = null,
-    val payerActionHref: String? = null,
-    val paymentSource: PaymentSource? = null,
-    val purchaseUnits: List<PurchaseUnit>? = null
-)
+internal sealed class ConfirmPaymentSourceResult {
+
+    data class Success(
+        val orderId: String,
+        val status: OrderStatus? = null,
+        val payerActionHref: String? = null,
+        val paymentSource: PaymentSource? = null,
+        val purchaseUnits: List<PurchaseUnit>? = null
+    ) : ConfirmPaymentSourceResult()
+
+    data class Failure(val error: PayPalSDKError) : ConfirmPaymentSourceResult()
+}

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/ConfirmPaymentSourceResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/ConfirmPaymentSourceResult.kt
@@ -4,7 +4,7 @@ import com.paypal.android.cardpayments.model.PaymentSource
 import com.paypal.android.cardpayments.model.PurchaseUnit
 import com.paypal.android.corepayments.OrderStatus
 
-internal data class ConfirmPaymentSourceResponse(
+internal data class ConfirmPaymentSourceResult(
     val orderId: String,
     val status: OrderStatus? = null,
     val payerActionHref: String? = null,

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/ConfirmPaymentSourceResult.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/ConfirmPaymentSourceResult.kt
@@ -1,6 +1,5 @@
 package com.paypal.android.cardpayments.api
 
-import com.paypal.android.cardpayments.CardPresentAuthChallengeResult
 import com.paypal.android.cardpayments.model.PaymentSource
 import com.paypal.android.cardpayments.model.PurchaseUnit
 import com.paypal.android.corepayments.OrderStatus

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
@@ -7,7 +7,7 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ApplicationProvider
 import com.paypal.android.cardpayments.api.CheckoutOrdersAPI
-import com.paypal.android.cardpayments.api.ConfirmPaymentSourceResponse
+import com.paypal.android.cardpayments.api.ConfirmPaymentSourceResult
 import com.paypal.android.corepayments.OrderStatus
 import com.paypal.android.corepayments.PayPalSDKError
 import io.mockk.Called
@@ -58,8 +58,8 @@ class CardClientUnitTest {
     private val paymentMethodTokensAPI = mockk<DataVaultPaymentMethodTokensAPI>(relaxed = true)
 
     private val cardAnalytics = mockk<CardAnalytics>(relaxed = true)
-    private val confirmPaymentSourceResponse =
-        ConfirmPaymentSourceResponse(orderId, OrderStatus.APPROVED)
+    private val confirmPaymentSourceResult =
+        ConfirmPaymentSourceResult(orderId, OrderStatus.APPROVED)
 
     private val activity = mockk<FragmentActivity>(relaxed = true)
 
@@ -90,7 +90,7 @@ class CardClientUnitTest {
     fun `approve order notifies listener of confirm payment source success`() = runTest {
         val sut = createCardClient(testScheduler)
 
-        coEvery { checkoutOrdersAPI.confirmPaymentSource(cardRequest) } returns confirmPaymentSourceResponse
+        coEvery { checkoutOrdersAPI.confirmPaymentSource(cardRequest) } returns confirmPaymentSourceResult
 
         sut.approveOrder(cardRequest)
         advanceUntilIdle()
@@ -124,7 +124,7 @@ class CardClientUnitTest {
     @Test
     fun `approveOrder() notifies listener when authorization is required`() = runTest {
         val threeDSecureAuthChallengeResponse =
-            ConfirmPaymentSourceResponse(orderId, OrderStatus.APPROVED, "/payer/action/href")
+            ConfirmPaymentSourceResult(orderId, OrderStatus.APPROVED, "/payer/action/href")
 
         coEvery { checkoutOrdersAPI.confirmPaymentSource(cardRequest) } returns threeDSecureAuthChallengeResponse
 

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardClientUnitTest.kt
@@ -59,7 +59,7 @@ class CardClientUnitTest {
 
     private val cardAnalytics = mockk<CardAnalytics>(relaxed = true)
     private val confirmPaymentSourceResult =
-        ConfirmPaymentSourceResult(orderId, OrderStatus.APPROVED)
+        ConfirmPaymentSourceResult.Success(orderId, OrderStatus.APPROVED)
 
     private val activity = mockk<FragmentActivity>(relaxed = true)
 
@@ -109,7 +109,9 @@ class CardClientUnitTest {
         val sut = createCardClient(testScheduler)
 
         val error = PayPalSDKError(0, "mock_error_message")
-        coEvery { checkoutOrdersAPI.confirmPaymentSource(cardRequest) } throws error
+        coEvery {
+            checkoutOrdersAPI.confirmPaymentSource(cardRequest)
+        } returns ConfirmPaymentSourceResult.Failure(error)
 
         sut.approveOrder(cardRequest)
         advanceUntilIdle()
@@ -124,7 +126,7 @@ class CardClientUnitTest {
     @Test
     fun `approveOrder() notifies listener when authorization is required`() = runTest {
         val threeDSecureAuthChallengeResponse =
-            ConfirmPaymentSourceResult(orderId, OrderStatus.APPROVED, "/payer/action/href")
+            ConfirmPaymentSourceResult.Success(orderId, OrderStatus.APPROVED, "/payer/action/href")
 
         coEvery { checkoutOrdersAPI.confirmPaymentSource(cardRequest) } returns threeDSecureAuthChallengeResponse
 

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CheckoutOrdersAPIUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CheckoutOrdersAPIUnitTest.kt
@@ -6,7 +6,6 @@ import com.paypal.android.corepayments.APIRequest
 import com.paypal.android.corepayments.HttpMethod
 import com.paypal.android.corepayments.HttpResponse
 import com.paypal.android.corepayments.OrderStatus
-import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.corepayments.PaymentsJSON
 import com.paypal.android.corepayments.RestClient
 import io.mockk.coEvery


### PR DESCRIPTION
### Summary of changes

 - This PR removes `try/catch` from `CardClient.approveOrder()`
 - To do this, we've renamed `ConfirmPaymentSourceResponse` to `ConfirmPaymentSourceResult` and made it a sealed class with `.Success` and `.Failure` subclasses
 - Also in Kotlin `try/catch` is unchecked, meaning the compiler will not notify us when we call a method that `throws` outside of a try/catch block.
 - Using "Result" types cleans up the codebase by providing compile time support for error handling 

 ### Checklist

 - [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
