### PR TITLE
Remove onNewIntent Override in MainActivity

### DIFF
--- a/Demo/src/main/java/com/paypal/android/MainActivity.kt
+++ b/Demo/src/main/java/com/paypal/android/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.paypal.android
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -21,10 +20,5 @@ class MainActivity : ComponentActivity() {
         setContent {
             DemoApp()
         }
-    }
-
-    override fun onNewIntent(newIntent: Intent) {
-        super.onNewIntent(newIntent)
-        intent = newIntent
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderView.kt
@@ -27,6 +27,7 @@ import com.paypal.android.uishared.components.OrderView
 import com.paypal.android.uishared.components.StepHeader
 import com.paypal.android.uishared.state.CompletedActionState
 import com.paypal.android.utils.OnLifecycleOwnerResumeEffect
+import com.paypal.android.utils.OnNewIntentEffect
 import com.paypal.android.utils.UIConstants
 import com.paypal.android.utils.getActivityOrNull
 
@@ -48,7 +49,11 @@ fun ApproveOrderView(
     val context = LocalContext.current
     OnLifecycleOwnerResumeEffect {
         val intent = context.getActivityOrNull()?.intent
-        intent?.let { viewModel.completeAuthChallenge(intent) }
+        intent?.let { viewModel.completeAuthChallenge(it) }
+    }
+
+    OnNewIntentEffect { newIntent ->
+        viewModel.completeAuthChallenge(newIntent)
     }
 
     val contentPadding = UIConstants.paddingMedium

--- a/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
@@ -235,18 +235,25 @@ class ApproveOrderViewModel @Inject constructor(
                         OrderInfo(orderId, status, didAttemptThreeDSecureAuthentication)
                     }
                     approveOrderState = ActionState.Success(orderInfo)
+                    // discard authState
+                    authState = null
                 }
 
                 is CardFinishApproveOrderResult.Failure -> {
                     approveOrderState = ActionState.Failure(approveOrderResult.error)
+                    // discard authState
+                    authState = null
                 }
 
                 CardFinishApproveOrderResult.Canceled -> {
                     approveOrderState = ActionState.Failure(Exception("USER CANCELED"))
+                    // discard authState
+                    authState = null
                 }
 
                 CardFinishApproveOrderResult.NoResult -> {
-                    // ignore
+                    // no result; re-enable approve order button so user can retry
+                    approveOrderState = ActionState.Idle
                 }
             }
         }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalWebView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalWebView.kt
@@ -25,6 +25,7 @@ import com.paypal.android.uishared.components.OrderView
 import com.paypal.android.uishared.components.StepHeader
 import com.paypal.android.uishared.state.CompletedActionState
 import com.paypal.android.utils.OnLifecycleOwnerResumeEffect
+import com.paypal.android.utils.OnNewIntentEffect
 import com.paypal.android.utils.UIConstants
 import com.paypal.android.utils.getActivityOrNull
 
@@ -41,7 +42,12 @@ fun PayPalWebView(
 
     val context = LocalContext.current
     OnLifecycleOwnerResumeEffect {
-        context.getActivityOrNull()?.let { viewModel.handleBrowserSwitchResult(it) }
+        val intent = context.getActivityOrNull()?.intent
+        intent?.let { viewModel.completeAuthChallenge(it) }
+    }
+
+    OnNewIntentEffect { newIntent ->
+        viewModel.completeAuthChallenge(newIntent)
     }
 
     val contentPadding = UIConstants.paddingMedium

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalWebViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalWebViewModel.kt
@@ -154,16 +154,22 @@ class PayPalWebViewModel @Inject constructor(
         when (result) {
             is PayPalWebCheckoutFinishStartResult.Success -> {
                 payPalWebCheckoutState = ActionState.Success(result)
+                // discard authState
+                authState = null
             }
 
             is PayPalWebCheckoutFinishStartResult.Canceled -> {
                 val error = Exception("USER CANCELED")
                 payPalWebCheckoutState = ActionState.Failure(error)
+                // discard authState
+                authState = null
             }
 
             is PayPalWebCheckoutFinishStartResult.Failure -> {
                 Log.i(TAG, "Checkout Error: ${result.error.errorDescription}")
                 payPalWebCheckoutState = ActionState.Failure(result.error)
+                // discard authState
+                authState = null
             }
 
             null, PayPalWebCheckoutFinishStartResult.NoResult -> {

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalWebViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalWebViewModel.kt
@@ -1,6 +1,7 @@
 package com.paypal.android.ui.paypalweb
 
 import android.content.Context
+import android.content.Intent
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
@@ -148,8 +149,8 @@ class PayPalWebViewModel @Inject constructor(
         }
     }
 
-    fun handleBrowserSwitchResult(activity: ComponentActivity) {
-        val result = authState?.let { paypalClient?.finishStart(activity.intent, it) }
+    fun completeAuthChallenge(intent: Intent) {
+        val result = authState?.let { paypalClient?.finishStart(intent, it) }
         when (result) {
             is PayPalWebCheckoutFinishStartResult.Success -> {
                 payPalWebCheckoutState = ActionState.Success(result)

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalWebViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalWebViewModel.kt
@@ -167,7 +167,8 @@ class PayPalWebViewModel @Inject constructor(
             }
 
             null, PayPalWebCheckoutFinishStartResult.NoResult -> {
-                // do nothing
+                // no result; re-enable PayPal button so user can retry
+                payPalWebCheckoutState = ActionState.Idle
             }
         }
     }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultView.kt
@@ -23,6 +23,7 @@ import com.paypal.android.uishared.components.PropertyView
 import com.paypal.android.uishared.components.StepHeader
 import com.paypal.android.uishared.state.CompletedActionState
 import com.paypal.android.utils.OnLifecycleOwnerResumeEffect
+import com.paypal.android.utils.OnNewIntentEffect
 import com.paypal.android.utils.UIConstants
 import com.paypal.android.utils.getActivityOrNull
 
@@ -38,7 +39,12 @@ fun PayPalWebVaultView(viewModel: PayPalWebVaultViewModel = hiltViewModel()) {
 
     val context = LocalContext.current
     OnLifecycleOwnerResumeEffect {
-        context.getActivityOrNull()?.let { viewModel.handleBrowserSwitchResult(it) }
+        val intent = context.getActivityOrNull()?.intent
+        intent?.let { viewModel.handleBrowserSwitchResult(it) }
+    }
+
+    OnNewIntentEffect { newIntent ->
+        viewModel.handleBrowserSwitchResult(newIntent)
     }
 
     val contentPadding = UIConstants.paddingMedium

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultView.kt
@@ -40,11 +40,11 @@ fun PayPalWebVaultView(viewModel: PayPalWebVaultViewModel = hiltViewModel()) {
     val context = LocalContext.current
     OnLifecycleOwnerResumeEffect {
         val intent = context.getActivityOrNull()?.intent
-        intent?.let { viewModel.handleBrowserSwitchResult(it) }
+        intent?.let { viewModel.completeAuthChallenge(it) }
     }
 
     OnNewIntentEffect { newIntent ->
-        viewModel.handleBrowserSwitchResult(newIntent)
+        viewModel.completeAuthChallenge(newIntent)
     }
 
     val contentPadding = UIConstants.paddingMedium

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
@@ -127,19 +127,27 @@ class PayPalWebVaultViewModel @Inject constructor(
     fun completeAuthChallenge(intent: Intent) {
         val result = authState?.let { paypalClient?.finishVault(intent, it) }
         when (result) {
-            is PayPalWebCheckoutFinishVaultResult.Success ->
+            is PayPalWebCheckoutFinishVaultResult.Success -> {
                 vaultPayPalState = ActionState.Success(result)
+                // discard authState
+                authState = null
+            }
 
-            is PayPalWebCheckoutFinishVaultResult.Failure ->
+            is PayPalWebCheckoutFinishVaultResult.Failure -> {
                 vaultPayPalState = ActionState.Failure(result.error)
+                // discard authState
+                authState = null
+            }
 
-            PayPalWebCheckoutFinishVaultResult.Canceled ->
+            PayPalWebCheckoutFinishVaultResult.Canceled -> {
                 vaultPayPalState = ActionState.Failure(Exception("USER CANCELED"))
+                // discard authState
+                authState = null
+            }
 
             null, PayPalWebCheckoutFinishVaultResult.NoResult -> {
                 // no result; re-enable PayPal button so user can retry
                 vaultPayPalState = ActionState.Idle
-                // do nothing
             }
         }
     }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
@@ -1,5 +1,6 @@
 package com.paypal.android.ui.paypalwebvault
 
+import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -123,8 +124,8 @@ class PayPalWebVaultViewModel @Inject constructor(
         }
     }
 
-    fun handleBrowserSwitchResult(activity: ComponentActivity) {
-        val result = authState?.let { paypalClient?.finishVault(activity.intent, it) }
+    fun handleBrowserSwitchResult(intent: Intent) {
+        val result = authState?.let { paypalClient?.finishVault(intent, it) }
         when (result) {
             is PayPalWebCheckoutFinishVaultResult.Success ->
                 vaultPayPalState = ActionState.Success(result)

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
@@ -124,7 +124,7 @@ class PayPalWebVaultViewModel @Inject constructor(
         }
     }
 
-    fun handleBrowserSwitchResult(intent: Intent) {
+    fun completeAuthChallenge(intent: Intent) {
         val result = authState?.let { paypalClient?.finishVault(intent, it) }
         when (result) {
             is PayPalWebCheckoutFinishVaultResult.Success ->

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
@@ -137,6 +137,8 @@ class PayPalWebVaultViewModel @Inject constructor(
                 vaultPayPalState = ActionState.Failure(Exception("USER CANCELED"))
 
             null, PayPalWebCheckoutFinishVaultResult.NoResult -> {
+                // no result; re-enable PayPal button so user can retry
+                vaultPayPalState = ActionState.Idle
                 // do nothing
             }
         }

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
@@ -30,6 +30,7 @@ import com.paypal.android.uishared.components.ErrorView
 import com.paypal.android.uishared.components.StepHeader
 import com.paypal.android.uishared.state.CompletedActionState
 import com.paypal.android.utils.OnLifecycleOwnerResumeEffect
+import com.paypal.android.utils.OnNewIntentEffect
 import com.paypal.android.utils.UIConstants
 import com.paypal.android.utils.getActivityOrNull
 
@@ -51,6 +52,10 @@ fun VaultCardView(
     OnLifecycleOwnerResumeEffect {
         val intent = context.getActivityOrNull()?.intent
         intent?.let { viewModel.completeAuthChallenge(it) }
+    }
+
+    OnNewIntentEffect { newIntent ->
+        viewModel.completeAuthChallenge(newIntent)
     }
 
     val contentPadding = UIConstants.paddingMedium

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
@@ -207,18 +207,25 @@ class VaultCardViewModel @Inject constructor(
                         )
                     }
                     updateSetupTokenState = ActionState.Success(setupTokenInfo)
+                    // discard authState
+                    authState = null
                 }
 
                 CardFinishVaultResult.Canceled -> {
                     updateSetupTokenState = ActionState.Failure(Exception("USER CANCELED"))
+                    // discard authState
+                    authState = null
                 }
 
                 is CardFinishVaultResult.Failure -> {
                     updateSetupTokenState = ActionState.Failure(vaultResult.error)
+                    // discard authState
+                    authState = null
                 }
 
                 CardFinishVaultResult.NoResult -> {
-                    // ignore
+                    // no result; re-enable vault button so user can retry
+                    updateSetupTokenState = ActionState.Idle
                 }
             }
         }


### PR DESCRIPTION
### Summary of changes

 - We no longer need to override `onNewIntent` in the Demo app's `MainActivity`
 - This PR refactors each Composable to use `OnNewIntentEffect` internally

 ### Checklist

 - [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
