### PR TITLE
Fix NoResult Error

### DIFF
--- a/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
@@ -235,20 +235,17 @@ class ApproveOrderViewModel @Inject constructor(
                         OrderInfo(orderId, status, didAttemptThreeDSecureAuthentication)
                     }
                     approveOrderState = ActionState.Success(orderInfo)
-                    // discard authState
-                    authState = null
+                    discardAuthState()
                 }
 
                 is CardFinishApproveOrderResult.Failure -> {
                     approveOrderState = ActionState.Failure(approveOrderResult.error)
-                    // discard authState
-                    authState = null
+                    discardAuthState()
                 }
 
                 CardFinishApproveOrderResult.Canceled -> {
                     approveOrderState = ActionState.Failure(Exception("USER CANCELED"))
-                    // discard authState
-                    authState = null
+                    discardAuthState()
                 }
 
                 CardFinishApproveOrderResult.NoResult -> {
@@ -257,5 +254,9 @@ class ApproveOrderViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun discardAuthState() {
+        authState = null
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
@@ -10,7 +10,6 @@ import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.fraudprotection.PayPalDataCollector
 import com.paypal.android.paypalwebpayments.PayPalPresentAuthChallengeResult
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutClient
-import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFinishStartResult
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFinishVaultResult
 import com.paypal.android.paypalwebpayments.PayPalWebVaultRequest
 import com.paypal.android.uishared.state.ActionState

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalWebVaultViewModel.kt
@@ -10,6 +10,7 @@ import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.fraudprotection.PayPalDataCollector
 import com.paypal.android.paypalwebpayments.PayPalPresentAuthChallengeResult
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutClient
+import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFinishStartResult
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFinishVaultResult
 import com.paypal.android.paypalwebpayments.PayPalWebVaultRequest
 import com.paypal.android.uishared.state.ActionState
@@ -124,31 +125,36 @@ class PayPalWebVaultViewModel @Inject constructor(
         }
     }
 
+    private fun checkIfPayPalAuthFinished(intent: Intent): PayPalWebCheckoutFinishVaultResult? =
+        authState?.let { paypalClient?.finishVault(intent, it) }
+
     fun completeAuthChallenge(intent: Intent) {
-        val result = authState?.let { paypalClient?.finishVault(intent, it) }
-        when (result) {
-            is PayPalWebCheckoutFinishVaultResult.Success -> {
-                vaultPayPalState = ActionState.Success(result)
-                // discard authState
-                authState = null
-            }
+        checkIfPayPalAuthFinished(intent)?.let { result ->
+            when (result) {
+                is PayPalWebCheckoutFinishVaultResult.Success -> {
+                    vaultPayPalState = ActionState.Success(result)
+                    discardAuthState()
+                }
 
-            is PayPalWebCheckoutFinishVaultResult.Failure -> {
-                vaultPayPalState = ActionState.Failure(result.error)
-                // discard authState
-                authState = null
-            }
+                is PayPalWebCheckoutFinishVaultResult.Failure -> {
+                    vaultPayPalState = ActionState.Failure(result.error)
+                    discardAuthState()
+                }
 
-            PayPalWebCheckoutFinishVaultResult.Canceled -> {
-                vaultPayPalState = ActionState.Failure(Exception("USER CANCELED"))
-                // discard authState
-                authState = null
-            }
+                PayPalWebCheckoutFinishVaultResult.Canceled -> {
+                    vaultPayPalState = ActionState.Failure(Exception("USER CANCELED"))
+                    discardAuthState()
+                }
 
-            null, PayPalWebCheckoutFinishVaultResult.NoResult -> {
-                // no result; re-enable PayPal button so user can retry
-                vaultPayPalState = ActionState.Idle
+                PayPalWebCheckoutFinishVaultResult.NoResult -> {
+                    // no result; re-enable PayPal button so user can retry
+                    vaultPayPalState = ActionState.Idle
+                }
             }
         }
+    }
+
+    private fun discardAuthState() {
+        authState = null
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
@@ -207,20 +207,17 @@ class VaultCardViewModel @Inject constructor(
                         )
                     }
                     updateSetupTokenState = ActionState.Success(setupTokenInfo)
-                    // discard authState
-                    authState = null
+                    discardAuthState()
                 }
 
                 CardFinishVaultResult.Canceled -> {
                     updateSetupTokenState = ActionState.Failure(Exception("USER CANCELED"))
-                    // discard authState
-                    authState = null
+                    discardAuthState()
                 }
 
                 is CardFinishVaultResult.Failure -> {
                     updateSetupTokenState = ActionState.Failure(vaultResult.error)
-                    // discard authState
-                    authState = null
+                    discardAuthState()
                 }
 
                 CardFinishVaultResult.NoResult -> {
@@ -229,5 +226,9 @@ class VaultCardViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun discardAuthState() {
+        authState = null
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Fix an issue with our PayPalWebCheckout demo that causes a `NoResult` event to be fired immediately after a `Success` event
 - Initially, a `Success` event is properly parsed as a result form `OnNewIntentEffect`
 - There is a bug in `PayPalWebViewModel` that causes the UI to reset the PayPal web launch button
 - To resolve this bug, we should expect `PayPalWebViewModel.completeAuthChallenge()` to no-op when no `authState` is present

 ### Checklist

 - [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
