### PR TITLE
Add v2_MIGRATION_GUIDE onNewIntent() Revision

### DIFF
--- a/v2_MIGRATION_GUIDE.md
+++ b/v2_MIGRATION_GUIDE.md
@@ -34,11 +34,12 @@ We refactored the `CardClient` API to improve the developer experience. Use this
 +   checkForCardAuthCompletion(intent)
 + }
 
-+ override fun onNewIntent(newIntent: Intent) {
-+   super.onNewIntent(newIntent)
+  override fun onNewIntent(newIntent: Intent) {
+    super.onNewIntent(newIntent)
+-   intent = newIntent
 +   // Manually attempt auth challenge completion (via new intent deep link)
 +   checkForCardAuthCompletion(newIntent)
-+ }
+  }
 
   fun approveOrder() {
     val cardRequest: CardRequest = TODO("Create a card request.")
@@ -193,11 +194,12 @@ We refactored the `PayPalWebClient` API to improve the developer experience. Use
 +   checkForPayPalAuthCompletion(intent)
 + }
 
-+ override fun onNewIntent(newIntent: Intent) {
-+   super.onNewIntent(newIntent)
+  override fun onNewIntent(newIntent: Intent) {
+    super.onNewIntent(newIntent)
+-   intent = newIntent
 +   // Manually attempt auth challenge completion (via new intent deep link)
 +   checkForPayPalAuthCompletion(newIntent)
-+ }
+  }
 
 - override fun onDestroy() {
 -   super.onDestroy()


### PR DESCRIPTION
### Summary of changes

 - This PR addresses the removal of `intent = newIntent` when migrating from `v1` to `v2`
 - Failure to remove this line can result in undesirable behavior in `v2`

 ### Checklist

 - [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
