### PR TITLE
Update gradle-nexus/publish-plugin URLs for Publishing Releases and SNAPSHOTs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ version modules.sdkVersionName // we add it here so that nexus automatically cho
 nexusPublishing {
     repositories {
         sonatype {
+            // Ref: https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+
             username = System.getenv('SONATYPE_NEXUS_USERNAME') ?: ''
             password = System.getenv('SONATYPE_NEXUS_PASSWORD') ?: ''
             repositoryDescription = "Paypal Android SDK"


### PR DESCRIPTION
### Summary of changes

 - OSSRH has [recently been sunset](https://central.sonatype.org/pages/ossrh-eol/#central-support)
 - This PR updates the URLs used by the `gradle-nexus/publish-plugin` to migrate to the new Central Portal

 ### Checklist

 - [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
