### PR TITLE
 Migrate GraphQL serialization to kotlin serialization 

### DIFF
--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardError.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardError.kt
@@ -2,6 +2,7 @@ package com.paypal.android.cardpayments
 
 import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.corepayments.graphql.GraphQLError
+import kotlinx.serialization.InternalSerializationApi
 
 internal object CardError {
 
@@ -29,6 +30,7 @@ internal object CardError {
         errorDescription = cause.message ?: "Unable to Browser Switch"
     )
 
+    @OptIn(InternalSerializationApi::class)
     fun updateSetupTokenResponseBodyMissing(errors: List<GraphQLError>?, correlationId: String?) = PayPalSDKError(
         0,
         "Error updating setup token: $errors",

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/api/UpdateSetupTokenRequest.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/api/UpdateSetupTokenRequest.kt
@@ -1,0 +1,79 @@
+package com.paypal.android.cardpayments.api
+
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Data classes for Kotlin serialization of update vault setup token GraphQL request
+ */
+@InternalSerializationApi
+@Serializable
+internal data class UpdateSetupTokenVariables(
+    @SerialName("clientId")
+    val clientId: String,
+    @SerialName("vaultSetupToken")
+    val vaultSetupToken: String,
+    @SerialName("paymentSource")
+    val paymentSource: VaultPaymentSource
+)
+
+@InternalSerializationApi
+@Serializable
+internal data class VaultPaymentSource(
+    val card: VaultCard
+)
+
+@InternalSerializationApi
+@Serializable
+internal data class VaultCard(
+    val number: String,
+    val expiry: String,
+    val name: String? = null,
+    @SerialName("securityCode")
+    val securityCode: String,
+    @SerialName("billingAddress")
+    val billingAddress: VaultBillingAddress? = null
+)
+
+@InternalSerializationApi
+@Serializable
+internal data class VaultBillingAddress(
+    @SerialName("addressLine1")
+    val addressLine1: String? = null,
+    @SerialName("addressLine2")
+    val addressLine2: String? = null,
+    @SerialName("adminArea1")
+    val adminArea1: String? = null,
+    @SerialName("adminArea2")
+    val adminArea2: String? = null,
+    @SerialName("postalCode")
+    val postalCode: String? = null,
+    @SerialName("countryCode")
+    val countryCode: String
+)
+
+/**
+ * Data classes for update vault setup token GraphQL response
+ */
+@InternalSerializationApi
+@Serializable
+internal data class UpdateSetupTokenResponse(
+    @SerialName("updateVaultSetupToken")
+    val updateVaultSetupToken: SetupTokenData
+)
+
+@InternalSerializationApi
+@Serializable
+internal data class SetupTokenData(
+    val id: String,
+    val status: String,
+    val links: List<LinkData>? = null
+)
+
+@InternalSerializationApi
+@Serializable
+internal data class LinkData(
+    val rel: String,
+    val href: String
+)

--- a/CorePayments/api/CorePayments.api
+++ b/CorePayments/api/CorePayments.api
@@ -232,14 +232,14 @@ public final class com/paypal/android/corepayments/graphql/GraphQLClient {
 	public static final field Companion Lcom/paypal/android/corepayments/graphql/GraphQLClient$Companion;
 	public static final field PAYPAL_DEBUG_ID Ljava/lang/String;
 	public fun <init> (Lcom/paypal/android/corepayments/CoreConfig;)V
-	public final fun send (Lorg/json/JSONObject;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun send$default (Lcom/paypal/android/corepayments/graphql/GraphQLClient;Lorg/json/JSONObject;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun send (Lcom/paypal/android/corepayments/graphql/GraphQLRequest;Lkotlinx/serialization/DeserializationStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/paypal/android/corepayments/graphql/GraphQLClient$Companion {
 }
 
 public final class com/paypal/android/corepayments/graphql/GraphQLError {
+	public static final field Companion Lcom/paypal/android/corepayments/graphql/GraphQLError$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -253,7 +253,23 @@ public final class com/paypal/android/corepayments/graphql/GraphQLError {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/paypal/android/corepayments/graphql/GraphQLError$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/paypal/android/corepayments/graphql/GraphQLError$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/paypal/android/corepayments/graphql/GraphQLError;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/paypal/android/corepayments/graphql/GraphQLError;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/paypal/android/corepayments/graphql/GraphQLError$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/paypal/android/corepayments/graphql/GraphQLExtension {
+	public static final field Companion Lcom/paypal/android/corepayments/graphql/GraphQLExtension$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -265,6 +281,75 @@ public final class com/paypal/android/corepayments/graphql/GraphQLExtension {
 	public final fun getCorrelationId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/paypal/android/corepayments/graphql/GraphQLExtension$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/paypal/android/corepayments/graphql/GraphQLExtension$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/paypal/android/corepayments/graphql/GraphQLExtension;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/paypal/android/corepayments/graphql/GraphQLExtension;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/paypal/android/corepayments/graphql/GraphQLExtension$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/paypal/android/corepayments/graphql/GraphQLRequest {
+	public static final field Companion Lcom/paypal/android/corepayments/graphql/GraphQLRequest$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;)Lcom/paypal/android/corepayments/graphql/GraphQLRequest;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLRequest;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOperationName ()Ljava/lang/String;
+	public final fun getQuery ()Ljava/lang/String;
+	public final fun getVariables ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/paypal/android/corepayments/graphql/GraphQLRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/paypal/android/corepayments/graphql/GraphQLRequest$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/paypal/android/corepayments/graphql/GraphQLRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/paypal/android/corepayments/graphql/GraphQLRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/paypal/android/corepayments/graphql/GraphQLRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/paypal/android/corepayments/graphql/GraphQLResponse {
+	public static final field Companion Lcom/paypal/android/corepayments/graphql/GraphQLResponse$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Object;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Object;Ljava/util/List;Ljava/util/List;)Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/Object;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/Object;
+	public final fun getErrors ()Ljava/util/List;
+	public final fun getExtensions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/paypal/android/corepayments/graphql/GraphQLResponse$Companion {
+	public final fun serializer (Lkotlinx/serialization/DeserializationStrategy;)Lkotlinx/serialization/KSerializer;
 }
 
 public abstract class com/paypal/android/corepayments/graphql/GraphQLResult {
@@ -282,20 +367,15 @@ public final class com/paypal/android/corepayments/graphql/GraphQLResult$Failure
 }
 
 public final class com/paypal/android/corepayments/graphql/GraphQLResult$Success : com/paypal/android/corepayments/graphql/GraphQLResult {
-	public fun <init> ()V
-	public fun <init> (Lorg/json/JSONObject;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)V
-	public synthetic fun <init> (Lorg/json/JSONObject;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lorg/json/JSONObject;
-	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Ljava/util/List;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Lorg/json/JSONObject;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;Lorg/json/JSONObject;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;
+	public fun <init> (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCorrelationId ()Ljava/lang/String;
-	public final fun getData ()Lorg/json/JSONObject;
-	public final fun getErrors ()Ljava/util/List;
-	public final fun getExtensions ()Ljava/util/List;
+	public final fun getResponse ()Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/CorePayments/api/CorePayments.api
+++ b/CorePayments/api/CorePayments.api
@@ -335,17 +335,17 @@ public final class com/paypal/android/corepayments/graphql/GraphQLRequest$Compan
 public final class com/paypal/android/corepayments/graphql/GraphQLResponse {
 	public static final field Companion Lcom/paypal/android/corepayments/graphql/GraphQLResponse$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Object;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/Object;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
-	public final fun component2 ()Ljava/util/List;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
 	public final fun component3 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/Object;Ljava/util/List;Ljava/util/List;)Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/Object;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
+	public final fun copy (Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;)Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/Object;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Ljava/lang/Object;
 	public final fun getErrors ()Ljava/util/List;
-	public final fun getExtensions ()Ljava/util/List;
+	public final fun getExtensions ()Lkotlinx/serialization/json/JsonObject;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/CorePayments/api/CorePayments.api
+++ b/CorePayments/api/CorePayments.api
@@ -2,14 +2,16 @@ public final class com/paypal/android/corepayments/APIClientError {
 	public static final field INSTANCE Lcom/paypal/android/corepayments/APIClientError;
 	public final fun clientIDNotFoundError (ILjava/lang/String;)Lcom/paypal/android/corepayments/PayPalSDKError;
 	public final fun dataParsingError (Ljava/lang/String;)Lcom/paypal/android/corepayments/PayPalSDKError;
+	public static synthetic fun dataParsingError$default (Lcom/paypal/android/corepayments/APIClientError;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/PayPalSDKError;
 	public final fun getInvalidUrlRequest ()Lcom/paypal/android/corepayments/PayPalSDKError;
 	public final fun getPayPalCheckoutError ()Lkotlin/jvm/functions/Function1;
 	public final fun getPayPalNativeCheckoutError ()Lkotlin/jvm/functions/Function2;
-	public final fun graphQLJSONParseError (Ljava/lang/String;Ljava/lang/Exception;)Lcom/paypal/android/corepayments/PayPalSDKError;
+	public final fun graphQLJSONParseError (Ljava/lang/String;Ljava/lang/Throwable;)Lcom/paypal/android/corepayments/PayPalSDKError;
 	public final fun httpURLConnectionError (ILjava/lang/String;Ljava/lang/String;)Lcom/paypal/android/corepayments/PayPalSDKError;
 	public final fun noResponseData (Ljava/lang/String;)Lcom/paypal/android/corepayments/PayPalSDKError;
 	public final fun serverResponseError (Ljava/lang/String;)Lcom/paypal/android/corepayments/PayPalSDKError;
 	public final fun unknownError (Ljava/lang/String;)Lcom/paypal/android/corepayments/PayPalSDKError;
+	public static synthetic fun unknownError$default (Lcom/paypal/android/corepayments/APIClientError;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/PayPalSDKError;
 	public final fun unknownHost (Ljava/lang/String;)Lcom/paypal/android/corepayments/PayPalSDKError;
 }
 
@@ -232,7 +234,7 @@ public final class com/paypal/android/corepayments/graphql/GraphQLClient {
 	public static final field Companion Lcom/paypal/android/corepayments/graphql/GraphQLClient$Companion;
 	public static final field PAYPAL_DEBUG_ID Ljava/lang/String;
 	public fun <init> (Lcom/paypal/android/corepayments/CoreConfig;)V
-	public final fun send (Lcom/paypal/android/corepayments/graphql/GraphQLRequest;Lkotlinx/serialization/DeserializationStrategy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun sendInternal (Lcom/paypal/android/corepayments/graphql/GraphQLRequest;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/paypal/android/corepayments/graphql/GraphQLClient$Companion {
@@ -300,23 +302,23 @@ public final class com/paypal/android/corepayments/graphql/GraphQLExtension$Comp
 
 public final class com/paypal/android/corepayments/graphql/GraphQLRequest {
 	public static final field Companion Lcom/paypal/android/corepayments/graphql/GraphQLRequest$Companion;
-	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component2 ()Ljava/lang/Object;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;)Lcom/paypal/android/corepayments/graphql/GraphQLRequest;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLRequest;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLRequest;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)Lcom/paypal/android/corepayments/graphql/GraphQLRequest;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLRequest;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getOperationName ()Ljava/lang/String;
 	public final fun getQuery ()Ljava/lang/String;
-	public final fun getVariables ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getVariables ()Ljava/lang/Object;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/paypal/android/corepayments/graphql/GraphQLRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lcom/paypal/android/corepayments/graphql/GraphQLRequest$$serializer;
+	public synthetic fun <init> (Lkotlinx/serialization/KSerializer;)V
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/paypal/android/corepayments/graphql/GraphQLRequest;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
@@ -327,7 +329,7 @@ public final class com/paypal/android/corepayments/graphql/GraphQLRequest$$seria
 }
 
 public final class com/paypal/android/corepayments/graphql/GraphQLRequest$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/paypal/android/corepayments/graphql/GraphQLResponse {
@@ -348,8 +350,19 @@ public final class com/paypal/android/corepayments/graphql/GraphQLResponse {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/paypal/android/corepayments/graphql/GraphQLResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public synthetic fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/paypal/android/corepayments/graphql/GraphQLResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/paypal/android/corepayments/graphql/GraphQLResponse$Companion {
-	public final fun serializer (Lkotlinx/serialization/DeserializationStrategy;)Lkotlinx/serialization/KSerializer;
+	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
 }
 
 public abstract class com/paypal/android/corepayments/graphql/GraphQLResult {

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/APIClientError.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/APIClientError.kt
@@ -9,14 +9,14 @@ import androidx.annotation.RestrictTo
 object APIClientError {
 
     // 0. An unknown error occurred.
-    fun unknownError(correlationId: String?) = PayPalSDKError(
+    fun unknownError(correlationId: String? = null) = PayPalSDKError(
         code = PayPalSDKErrorCode.UNKNOWN.ordinal,
         errorDescription = "An unknown error occurred. Contact developer.paypal.com/support.",
         correlationId = correlationId
     )
 
     // 1. Error parsing HTTP response data.
-    fun dataParsingError(correlationId: String?) = PayPalSDKError(
+    fun dataParsingError(correlationId: String? = null) = PayPalSDKError(
         code = PayPalSDKErrorCode.DATA_PARSING_ERROR.ordinal,
         errorDescription = "An error occurred parsing HTTP response data." +
                 " Contact developer.paypal.com/support.",
@@ -80,7 +80,7 @@ object APIClientError {
         correlationId = correlationId
     )
 
-    fun graphQLJSONParseError(correlationId: String?, reason: Exception): PayPalSDKError {
+    fun graphQLJSONParseError(correlationId: String?, reason: Throwable): PayPalSDKError {
         val message =
             "An error occurred while parsing the GraphQL response JSON. Contact developer.paypal.com/support."
         val error = PayPalSDKError(

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLClient.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLClient.kt
@@ -1,14 +1,20 @@
 package com.paypal.android.corepayments.graphql
 
 import androidx.annotation.RestrictTo
-import com.paypal.android.corepayments.APIClientError
+import com.paypal.android.corepayments.APIClientError.graphQLJSONParseError
+import com.paypal.android.corepayments.APIClientError.invalidUrlRequest
+import com.paypal.android.corepayments.APIClientError.noResponseData
+import com.paypal.android.corepayments.APIClientError.unknownError
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Http
 import com.paypal.android.corepayments.HttpMethod
 import com.paypal.android.corepayments.HttpRequest
-import org.json.JSONException
-import org.json.JSONObject
-import java.net.HttpURLConnection
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import java.net.HttpURLConnection.HTTP_OK
 import java.net.URL
 
 /**
@@ -19,12 +25,13 @@ class GraphQLClient internal constructor(
     coreConfig: CoreConfig,
     private val http: Http = Http(),
 ) {
-
     companion object {
         const val PAYPAL_DEBUG_ID = "Paypal-Debug-Id"
     }
 
     constructor(coreConfig: CoreConfig) : this(coreConfig, Http())
+
+    private val json = Json { ignoreUnknownKeys = true }
 
     private val graphQLEndpoint = coreConfig.environment.graphQLEndpoint
     private val graphQLURL = "$graphQLEndpoint/graphql"
@@ -36,29 +43,74 @@ class GraphQLClient internal constructor(
         "Origin" to coreConfig.environment.graphQLEndpoint
     )
 
-    suspend fun send(graphQLRequestBody: JSONObject, queryName: String? = null): GraphQLResult {
-        val body = graphQLRequestBody.toString()
-        val urlString = if (queryName != null) "$graphQLURL?$queryName" else graphQLURL
-        val httpRequest = HttpRequest(URL(urlString), HttpMethod.POST, body, httpRequestHeaders)
+    /**
+     * Implementation for sending GraphQL requests.
+     * Marked with @PublishedApi so it can be accessed from the inline public function.
+     */
+    @OptIn(InternalSerializationApi::class)
+    @PublishedApi
+    internal suspend fun <R, V> sendInternal(
+        graphQLRequest: GraphQLRequest<V>,
+        variablesSerializer: KSerializer<V>,
+        responseSerializer: KSerializer<R>,
+    ): GraphQLResult<R> {
+        val httpRequest = createHttpRequest(graphQLRequest, variablesSerializer)
 
         val httpResponse = http.send(httpRequest)
-        val correlationId: String? = httpResponse.headers[PAYPAL_DEBUG_ID]
-        val status = httpResponse.status
-        return if (status == HttpURLConnection.HTTP_OK) {
-            if (httpResponse.body.isNullOrBlank()) {
-                val error = APIClientError.noResponseData(correlationId)
-                GraphQLResult.Failure(error)
-            } else {
-                try {
-                    val responseAsJSON = JSONObject(httpResponse.body)
-                    GraphQLResult.Success(responseAsJSON.getJSONObject("data"), correlationId = correlationId)
-                } catch (jsonParseError: JSONException) {
-                    val error = APIClientError.graphQLJSONParseError(correlationId, jsonParseError)
-                    GraphQLResult.Failure(error)
-                }
+        val correlationId = httpResponse.headers[PAYPAL_DEBUG_ID]
+
+        return when {
+            httpResponse.status != HTTP_OK -> {
+                val emptyResponse = GraphQLResponse<R>(null, null, null)
+                GraphQLResult.Success(emptyResponse, correlationId = correlationId)
             }
-        } else {
-            GraphQLResult.Success(null, correlationId = correlationId)
+
+            httpResponse.body.isNullOrBlank() -> {
+                GraphQLResult.Failure(noResponseData(correlationId))
+            }
+
+            else -> runCatching {
+                val response = json.decodeFromString(
+                    deserializer = GraphQLResponse.serializer(responseSerializer),
+                    string = httpResponse.body
+                )
+                GraphQLResult.Success(response, correlationId = correlationId)
+            }.getOrElse { error ->
+                GraphQLResult.Failure(graphQLJSONParseError(correlationId, error))
+            }
         }
+    }
+
+    private fun <V> createHttpRequest(
+        graphQLRequest: GraphQLRequest<V>,
+        variablesSerializer: KSerializer<V>
+    ): HttpRequest {
+        val urlString = graphQLRequest.operationName?.let { "$graphQLURL?$it" } ?: graphQLURL
+        val requestBody =
+            json.encodeToString(GraphQLRequest.serializer(variablesSerializer), graphQLRequest)
+
+        return HttpRequest(
+            url = URL(urlString),
+            method = HttpMethod.POST,
+            body = requestBody,
+            headers = httpRequestHeaders
+        )
+    }
+
+    /**
+     * Public API for sending GraphQL requests.
+     * Uses reified type parameters for automatic serializer selection.
+     */
+    @OptIn(InternalSerializationApi::class)
+    suspend inline fun <reified R, reified V> send(
+        graphQLRequest: GraphQLRequest<V>
+    ): GraphQLResult<R> = runCatching {
+        sendInternal(graphQLRequest, serializer<V>(), serializer<R>())
+    }.getOrElse { throwable ->
+        val error = when (throwable) {
+            is SerializationException -> invalidUrlRequest
+            else -> unknownError()
+        }
+        GraphQLResult.Failure(error)
     }
 }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLClient.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLClient.kt
@@ -1,6 +1,7 @@
 package com.paypal.android.corepayments.graphql
 
 import androidx.annotation.RestrictTo
+import com.paypal.android.corepayments.APIClientError
 import com.paypal.android.corepayments.APIClientError.graphQLJSONParseError
 import com.paypal.android.corepayments.APIClientError.invalidUrlRequest
 import com.paypal.android.corepayments.APIClientError.noResponseData
@@ -62,8 +63,7 @@ class GraphQLClient internal constructor(
 
         return when {
             httpResponse.status != HTTP_OK -> {
-                val emptyResponse = GraphQLResponse<R>(null, null, null)
-                GraphQLResult.Success(emptyResponse, correlationId = correlationId)
+                GraphQLResult.Failure(APIClientError.serverResponseError(correlationId))
             }
 
             httpResponse.body.isNullOrBlank() -> {

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLExtension.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLExtension.kt
@@ -1,11 +1,15 @@
 package com.paypal.android.corepayments.graphql
 
 import androidx.annotation.RestrictTo
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.Serializable
 
 /**
  * @suppress
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@InternalSerializationApi
+@Serializable
 data class GraphQLExtension(
     val correlationId: String,
     val code: String? = null

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLRequest.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLRequest.kt
@@ -4,13 +4,12 @@ import androidx.annotation.RestrictTo
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * @suppress
- */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-@InternalSerializationApi
+@OptIn(InternalSerializationApi::class)
 @Serializable
-data class GraphQLError(
-    val message: String,
-    val extensions: List<GraphQLExtension>? = null
+data class GraphQLRequest<V>(
+    val query: String,
+    val variables: V? = null,
+    @kotlinx.serialization.Transient
+    val operationName: String? = null
 )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLResponse.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLResponse.kt
@@ -4,13 +4,11 @@ import androidx.annotation.RestrictTo
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
 
-/**
- * @suppress
- */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalSerializationApi
 @Serializable
-data class GraphQLError(
-    val message: String,
-    val extensions: List<GraphQLExtension>? = null
+data class GraphQLResponse<out T> @OptIn(InternalSerializationApi::class) constructor(
+    val data: T? = null,
+    val extensions: List<GraphQLExtension>? = null,
+    val errors: List<GraphQLError>? = null,
 )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLResponse.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLResponse.kt
@@ -3,12 +3,13 @@ package com.paypal.android.corepayments.graphql
 import androidx.annotation.RestrictTo
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalSerializationApi
 @Serializable
 data class GraphQLResponse<out T> @OptIn(InternalSerializationApi::class) constructor(
     val data: T? = null,
-    val extensions: List<GraphQLExtension>? = null,
+    val extensions: JsonObject? = null,
     val errors: List<GraphQLError>? = null,
 )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLResult.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLResult.kt
@@ -2,20 +2,19 @@ package com.paypal.android.corepayments.graphql
 
 import androidx.annotation.RestrictTo
 import com.paypal.android.corepayments.PayPalSDKError
-import org.json.JSONObject
+import kotlinx.serialization.InternalSerializationApi
 
 /**
  * @suppress
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-sealed class GraphQLResult {
+sealed class GraphQLResult<out T> {
 
-    data class Success(
-        val data: JSONObject? = null,
-        val extensions: List<GraphQLExtension>? = null,
-        val errors: List<GraphQLError>? = null,
+    @OptIn(InternalSerializationApi::class)
+    data class Success<out T>(
+        val response: GraphQLResponse<T>,
         val correlationId: String? = null
-    ) : GraphQLResult()
+    ) : GraphQLResult<T>()
 
-    data class Failure(val error: PayPalSDKError) : GraphQLResult()
+    data class Failure(val error: PayPalSDKError) : GraphQLResult<Nothing>()
 }

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/GraphQLClientUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/GraphQLClientUnitTest.kt
@@ -7,15 +7,19 @@ import com.paypal.android.corepayments.HttpMethod
 import com.paypal.android.corepayments.HttpRequest
 import com.paypal.android.corepayments.HttpResponse
 import com.paypal.android.corepayments.PayPalSDKErrorCode
-import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.json.JSONObject
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.Serializable
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,149 +27,260 @@ import org.robolectric.RobolectricTestRunner
 import java.net.URL
 
 @ExperimentalCoroutinesApi
+@OptIn(InternalSerializationApi::class)
 @RunWith(RobolectricTestRunner::class)
 internal class GraphQLClientUnitTest {
 
-    private val sandboxConfig = CoreConfig("fake-client-id", Environment.SANDBOX)
-    private val liveConfig = CoreConfig("fake-client-id", Environment.LIVE)
+    // Test data and fixtures
+    @Serializable
+    private data class TestRequest(val id: String)
 
-    private val graphQLRequestBody = JSONObject("""{"fake":"json"}""")
+    @Serializable
+    private data class TestResponse(val result: String)
 
-    private lateinit var http: Http
-    private lateinit var httpRequestSlot: CapturingSlot<HttpRequest>
+    // Constants for tests
+    private val testQuery = "query { test }"
+    private val testVariables = TestRequest("test-id")
+    private val testOperationName = "TestOperation"
+    private val testCorrelationId = "test-correlation-id"
 
-    private lateinit var sut: GraphQLClient
-
+    // Mocks
+    private lateinit var mockHttp: Http
+    private lateinit var mockCoreConfig: CoreConfig
+    private lateinit var graphQLClient: GraphQLClient
     @Before
-    fun setUp() {
-        http = mockk(relaxed = true)
-        httpRequestSlot = slot()
+    fun setup() {
+        mockHttp = mockk(relaxed = true)
+        mockCoreConfig = mockk(relaxed = true)
+
+        // Setup mock environment for the CoreConfig
+        val mockEnvironment = mockk<Environment>(relaxed = true)
+        every { mockEnvironment.graphQLEndpoint } returns "https://test-api.paypal.com"
+        every { mockCoreConfig.environment } returns mockEnvironment
+
+        // Create the GraphQLClient with mocked dependencies
+        graphQLClient = GraphQLClient(mockCoreConfig, mockHttp)
     }
 
     @Test
-    fun `send sends an http request to sandbox environment`() = runTest {
-        sut = GraphQLClient(sandboxConfig, http)
-        sut.send(graphQLRequestBody)
-        coVerify { http.send(capture(httpRequestSlot)) }
+    fun `test successful GraphQL request and response`() = runTest {
+        // Arrange
+        val expectedUrl = URL("https://test-api.paypal.com/graphql?$testOperationName")
+        val graphQLRequest = GraphQLRequest(
+            query = testQuery,
+            variables = testVariables,
+            operationName = testOperationName
+        )
 
-        val httpRequest = httpRequestSlot.captured
-        assertEquals(URL("https://www.sandbox.paypal.com/graphql"), httpRequest.url)
-        assertEquals("https://www.sandbox.paypal.com", httpRequest.headers["Origin"])
+        // Mock HTTP response
+        val successfulResponseJson = """
+            {
+                "data": {
+                    "result": "success"
+                }
+            }
+        """.trimIndent()
+
+        val headers = mapOf(GraphQLClient.PAYPAL_DEBUG_ID to testCorrelationId)
+        val mockResponse = HttpResponse(
+            status = 200,
+            body = successfulResponseJson,
+            headers = headers
+        )
+
+        // Capture the HttpRequest to verify it later
+        val httpRequestSlot = slot<HttpRequest>()
+        coEvery { mockHttp.send(capture(httpRequestSlot)) } returns mockResponse
+
+        // Act
+        val result = graphQLClient.send<TestResponse, TestRequest>(
+            graphQLRequest
+        )
+
+        // Assert
+        assertTrue(result is GraphQLResult.Success)
+        val successResult = result as GraphQLResult.Success<TestResponse>
+
+        // Verify response data
+        assertEquals(testCorrelationId, successResult.correlationId)
+        assertNotNull(successResult.response.data)
+        assertEquals("success", successResult.response.data?.result)
+
+        // Verify the HTTP request was created correctly
+        val capturedRequest = httpRequestSlot.captured
+        assertEquals(expectedUrl, capturedRequest.url)
+        assertEquals(HttpMethod.POST, capturedRequest.method)
+        val expectedRequestBody = """{"query":"$testQuery","variables":{"id":"test-id"}}"""
+        assertEquals(expectedRequestBody, capturedRequest.body)
+
+        // Verify HTTP send was called
+        coVerify(exactly = 1) { mockHttp.send(any()) }
+    }
+
+    @OptIn(InternalSerializationApi::class)
+    @Test
+    fun `test HTTP error response handling`() = runTest {
+        // Arrange
+        val graphQLRequest = GraphQLRequest(
+            query = testQuery,
+            variables = testVariables
+        )
+
+        // Create an HTTP error response (non-200 status code)
+        val headers = mapOf(GraphQLClient.PAYPAL_DEBUG_ID to testCorrelationId)
+        val mockResponse = HttpResponse(
+            status = 400, // Bad Request
+            body = null,
+            headers = headers
+        )
+
+        coEvery { mockHttp.send(any()) } returns mockResponse
+
+        // Act
+        val result = graphQLClient.send<TestResponse, TestRequest>(
+            graphQLRequest
+        )
+
+        // Assert
+        assertTrue(result is GraphQLResult.Success)
+        val successResult = result as GraphQLResult.Success<TestResponse>
+
+        // Verify we get a response object with null data
+        assertEquals(testCorrelationId, successResult.correlationId)
+        assertNull(successResult.response.data)
+        assertNull(successResult.response.errors)
+        assertNull(successResult.response.extensions)
+
+        // Verify HTTP send was called
+        coVerify(exactly = 1) { mockHttp.send(any()) }
     }
 
     @Test
-    fun `send sends an http request to sandbox environment with query name appended`() = runTest {
-        sut = GraphQLClient(sandboxConfig, http)
-        sut.send(graphQLRequestBody, "QueryName")
-        coVerify { http.send(capture(httpRequestSlot)) }
+    fun `test empty response body handling`() = runTest {
+        // Arrange
+        val graphQLRequest = GraphQLRequest(
+            query = testQuery,
+            variables = testVariables
+        )
 
-        val httpRequest = httpRequestSlot.captured
-        assertEquals(URL("https://www.sandbox.paypal.com/graphql?QueryName"), httpRequest.url)
-        assertEquals("https://www.sandbox.paypal.com", httpRequest.headers["Origin"])
+        // Create a response with empty body but 200 status
+        val headers = mapOf(GraphQLClient.PAYPAL_DEBUG_ID to testCorrelationId)
+        val mockResponse = HttpResponse(
+            status = 200,
+            body = "", // Empty body
+            headers = headers
+        )
+
+        coEvery { mockHttp.send(any()) } returns mockResponse
+
+        // Act
+        val result = graphQLClient.send<TestResponse, TestRequest>(
+            graphQLRequest
+        )
+
+        // Assert
+        assertTrue(result is GraphQLResult.Failure)
+        val failureResult = result as GraphQLResult.Failure
+
+        // Verify we get an error about no response data
+        assertEquals(PayPalSDKErrorCode.NO_RESPONSE_DATA.ordinal, failureResult.error.code)
+        assertEquals(testCorrelationId, failureResult.error.correlationId)
+
+        // Verify HTTP send was called
+        coVerify(exactly = 1) { mockHttp.send(any()) }
     }
 
     @Test
-    fun `send sends an http request to live environment`() = runTest {
-        sut = GraphQLClient(liveConfig, http)
-        sut.send(graphQLRequestBody)
-        coVerify { http.send(capture(httpRequestSlot)) }
+    fun `test JSON parse error handling`() = runTest {
+        // Arrange
+        val graphQLRequest = GraphQLRequest(
+            query = testQuery,
+            variables = testVariables
+        )
 
-        val httpRequest = httpRequestSlot.captured
-        assertEquals(URL("https://www.paypal.com/graphql"), httpRequest.url)
-        assertEquals("https://www.paypal.com", httpRequest.headers["Origin"])
+        // Create a response with invalid JSON
+        val headers = mapOf(GraphQLClient.PAYPAL_DEBUG_ID to testCorrelationId)
+        val mockResponse = HttpResponse(
+            status = 200,
+            body = "{invalid json that will cause parsing error", // Invalid JSON
+            headers = headers
+        )
+
+        coEvery { mockHttp.send(any()) } returns mockResponse
+
+        // Act
+        val result = graphQLClient.send<TestResponse, TestRequest>(
+            graphQLRequest
+        )
+
+        // Assert
+        assertTrue(result is GraphQLResult.Failure)
+        val failureResult = result as GraphQLResult.Failure
+
+        // Verify we get an error about JSON parsing
+        assertEquals(
+            PayPalSDKErrorCode.GRAPHQL_JSON_INVALID_ERROR.ordinal,
+            failureResult.error.code
+        )
+        assertEquals(testCorrelationId, failureResult.error.correlationId)
+
+        // Verify HTTP send was called
+        coVerify(exactly = 1) { mockHttp.send(any()) }
     }
 
     @Test
-    fun `send sends an http request to live environment with query name appended`() = runTest {
-        sut = GraphQLClient(liveConfig, http)
-        sut.send(graphQLRequestBody, "QueryName")
-        coVerify { http.send(capture(httpRequestSlot)) }
+    fun `test invalid URL handling`() = runTest {
+        // Arrange - setup a situation where creating the URL will fail
+        // We'll use a mock environment with an invalid URL format
+        val invalidMockEnvironment = mockk<Environment>(relaxed = true)
+        every { invalidMockEnvironment.graphQLEndpoint } returns "invalid://endpoint"
 
-        val httpRequest = httpRequestSlot.captured
-        assertEquals(URL("https://www.paypal.com/graphql?QueryName"), httpRequest.url)
-        assertEquals("https://www.paypal.com", httpRequest.headers["Origin"])
+        val invalidMockCoreConfig = mockk<CoreConfig>(relaxed = true)
+        every { invalidMockCoreConfig.environment } returns invalidMockEnvironment
+
+        val invalidUrlClient = GraphQLClient(invalidMockCoreConfig, mockHttp)
+
+        val graphQLRequest = GraphQLRequest(
+            query = testQuery,
+            variables = testVariables,
+            operationName = "$" // Invalid character in URL
+        )
+
+        // Act
+        val result = invalidUrlClient.send<TestResponse, TestRequest>(
+            graphQLRequest
+        )
+
+        // Assert
+        assertTrue(result is GraphQLResult.Failure)
+        val failureResult = result as GraphQLResult.Failure
+
+        // Verify we get an error about invalid URL
+        assertEquals(PayPalSDKErrorCode.INVALID_URL_REQUEST.ordinal, failureResult.error.code)
+
+        // Verify HTTP send was not called (since URL creation failed)
+        coVerify(exactly = 0) { mockHttp.send(any()) }
     }
 
     @Test
-    fun `send forwards graphQL request body as an http request body`() = runTest {
-        sut = GraphQLClient(liveConfig, http)
-        sut.send(graphQLRequestBody)
-        coVerify { http.send(capture(httpRequestSlot)) }
+    fun `test request serialization failure`() = runTest {
 
-        val httpRequest = httpRequestSlot.captured
-        assertEquals("""{"fake":"json"}""", httpRequest.body)
+        data class NonSerializable(val s: String)
+
+        val graphQLRequest = GraphQLRequest(
+            query = testQuery,
+            variables = NonSerializable("non serializable")
+        )
+
+        // Act
+        val result: GraphQLResult<TestResponse> = graphQLClient.send(graphQLRequest)
+
+        // Assert
+        assertTrue(result is GraphQLResult.Failure)
+        val failureResult = result as GraphQLResult.Failure
+        assertEquals(PayPalSDKErrorCode.UNKNOWN.ordinal, failureResult.error.code)
+
+        // Verify HTTP send was NOT called since the request creation failed
+        coVerify(exactly = 0) { mockHttp.send(any()) }
     }
-
-    @Test
-    fun `send sends an HTTP POST request`() = runTest {
-        sut = GraphQLClient(sandboxConfig, http)
-        sut.send(graphQLRequestBody)
-        coVerify { http.send(capture(httpRequestSlot)) }
-
-        val httpRequest = httpRequestSlot.captured
-        assertEquals(HttpMethod.POST, httpRequest.method)
-    }
-
-    @Test
-    fun `send sets default headers`() = runTest {
-        sut = GraphQLClient(sandboxConfig, http)
-        sut.send(graphQLRequestBody)
-        coVerify { http.send(capture(httpRequestSlot)) }
-
-        val httpRequest = httpRequestSlot.captured
-        assertEquals("application/json", httpRequest.headers["Content-Type"])
-        assertEquals("application/json", httpRequest.headers["Accept"])
-        assertEquals("nativecheckout", httpRequest.headers["x-app-name"])
-    }
-
-    @Test
-    fun `send parses GraphQL success response`() = runTest {
-        // language=JSON
-        val successBody = """{ "data": { "fake": "success_data" } }"""
-        val successHeaders = mapOf("Paypal-Debug-Id" to "fake-debug-id")
-        val successHttpResponse = HttpResponse(200, successHeaders, successBody)
-        coEvery { http.send(any()) } returns successHttpResponse
-
-        sut = GraphQLClient(sandboxConfig, http)
-        val result = sut.send(graphQLRequestBody) as GraphQLResult.Success
-
-        assertEquals("""{"fake":"success_data"}""", result.data?.toString())
-        assertEquals("fake-debug-id", result.correlationId)
-    }
-
-    @Test
-    fun `send returns an error when GraphQL response is successful with an empty body`() = runTest {
-        // language=JSON
-        val emptyBody = ""
-        val successHeaders = mapOf("Paypal-Debug-Id" to "fake-debug-id")
-        val successHttpResponse = HttpResponse(200, successHeaders, emptyBody)
-        coEvery { http.send(any()) } returns successHttpResponse
-
-        sut = GraphQLClient(sandboxConfig, http)
-        val result = sut.send(graphQLRequestBody) as GraphQLResult.Failure
-        assertEquals(PayPalSDKErrorCode.NO_RESPONSE_DATA.ordinal, result.error.code)
-
-        val expectedErrorMessage =
-            "An error occurred due to missing HTTP response data. Contact developer.paypal.com/support."
-        assertEquals(expectedErrorMessage, result.error.errorDescription)
-        assertEquals("fake-debug-id", result.error.correlationId)
-    }
-
-    @Test
-    fun `send returns an error when GraphQL response is successful with an invalid JSON body`() =
-        runTest {
-            val invalidJSON = """{ invalid: """
-            val successHeaders = mapOf("Paypal-Debug-Id" to "fake-debug-id")
-            val successHttpResponse = HttpResponse(200, successHeaders, invalidJSON)
-            coEvery { http.send(any()) } returns successHttpResponse
-
-            sut = GraphQLClient(sandboxConfig, http)
-            val result = sut.send(graphQLRequestBody) as GraphQLResult.Failure
-            assertEquals(PayPalSDKErrorCode.GRAPHQL_JSON_INVALID_ERROR.ordinal, result.error.code)
-
-            val expectedErrorMessage =
-                "An error occurred while parsing the GraphQL response JSON. Contact developer.paypal.com/support."
-            assertEquals(expectedErrorMessage, result.error.errorDescription)
-            assertEquals("fake-debug-id", result.error.correlationId)
-        }
 }

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/GraphQLClientUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/GraphQLClientUnitTest.kt
@@ -278,7 +278,7 @@ internal class GraphQLClientUnitTest {
         // Assert
         assertTrue(result is GraphQLResult.Failure)
         val failureResult = result as GraphQLResult.Failure
-        assertEquals(PayPalSDKErrorCode.UNKNOWN.ordinal, failureResult.error.code)
+        assertEquals(PayPalSDKErrorCode.INVALID_URL_REQUEST.ordinal, failureResult.error.code)
 
         // Verify HTTP send was NOT called since the request creation failed
         coVerify(exactly = 0) { mockHttp.send(any()) }

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/GraphQLClientUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/GraphQLClientUnitTest.kt
@@ -14,7 +14,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
-import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -142,14 +141,11 @@ internal class GraphQLClientUnitTest {
         )
 
         // Assert
-        assertTrue(result is GraphQLResult.Success)
-        val successResult = result as GraphQLResult.Success<TestResponse>
+        assertTrue(result is GraphQLResult.Failure)
+        val failureResult = result as GraphQLResult.Failure
 
-        // Verify we get a response object with null data
-        assertEquals(testCorrelationId, successResult.correlationId)
-        assertNull(successResult.response.data)
-        assertNull(successResult.response.errors)
-        assertNull(successResult.response.extensions)
+        // Verify we get an error response for HTTP error
+        assertEquals(testCorrelationId, failureResult.error.correlationId)
 
         // Verify HTTP send was called
         coVerify(exactly = 1) { mockHttp.send(any()) }


### PR DESCRIPTION
### Summary of changes
- added GraphQLResponse, GraphQLRequest
- used kotlin serialization for serialization and deserialization in GraphQLClient
- migrated DataVaultPaymentMethodTokensAPI to use kotlin serialization and strong data types

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
