### PR TITLE
Hotfix: PayPal Parse Cancellation Deep Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # PayPal Android SDK Release Notes
 
+## unreleased
+
+* PayPalWebPayments
+  * Fix issue with `PayPalWebCheckoutClient.finishStart()` that caused explicit user cancelation to return a `Failure` event, instead of `Canceled`
+  * Fix issue with `PayPalWebCheckoutClient.finishVault()` that caused explicit user cancelation ro return a `Success` event, instead of `Canceled`
+
 ## 2.0.0 (2025-03-18)
 * Breaking Changes
   * PayPalNativePayments

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
@@ -155,13 +155,18 @@ internal class PayPalWebLauncher(
                 val unknownError = PayPalWebCheckoutError.unknownError
                 PayPalWebCheckoutFinishStartResult.Failure(unknownError, null)
             } else {
-                val payerId = deepLinkUrl.getQueryParameter("PayerID")
                 val orderId = metadata.optString(METADATA_KEY_ORDER_ID)
-                if (orderId.isNullOrBlank() || payerId.isNullOrBlank()) {
-                    val malformedResultError = PayPalWebCheckoutError.malformedResultError
-                    PayPalWebCheckoutFinishStartResult.Failure(malformedResultError, orderId)
+                val opType = deepLinkUrl.getQueryParameter("opType")
+                if (opType == "cancel") {
+                    PayPalWebCheckoutFinishStartResult.Canceled(orderId)
                 } else {
-                    PayPalWebCheckoutFinishStartResult.Success(orderId, payerId)
+                    val payerId = deepLinkUrl.getQueryParameter("PayerID")
+                    if (orderId.isNullOrBlank() || payerId.isNullOrBlank()) {
+                        val malformedResultError = PayPalWebCheckoutError.malformedResultError
+                        PayPalWebCheckoutFinishStartResult.Failure(malformedResultError, orderId)
+                    } else {
+                        PayPalWebCheckoutFinishStartResult.Success(orderId, payerId)
+                    }
                 }
             }
         } else {

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
@@ -148,56 +148,56 @@ internal class PayPalWebLauncher(
     private fun parseWebCheckoutSuccessResult(
         finalResult: BrowserSwitchFinalResult.Success
     ): PayPalWebCheckoutFinishStartResult {
+        if (finalResult.requestCode != BrowserSwitchRequestCodes.PAYPAL_CHECKOUT) {
+            PayPalWebCheckoutFinishStartResult.NoResult
+        }
+
         val deepLinkUrl = finalResult.returnUrl
         val metadata = finalResult.requestMetadata
-        return if (finalResult.requestCode == BrowserSwitchRequestCodes.PAYPAL_CHECKOUT) {
-            if (metadata == null) {
-                val unknownError = PayPalWebCheckoutError.unknownError
-                PayPalWebCheckoutFinishStartResult.Failure(unknownError, null)
+        return if (metadata == null) {
+            val unknownError = PayPalWebCheckoutError.unknownError
+            PayPalWebCheckoutFinishStartResult.Failure(unknownError, null)
+        } else {
+            val orderId = metadata.optString(METADATA_KEY_ORDER_ID)
+            val opType = deepLinkUrl.getQueryParameter("opType")
+            if (opType == "cancel") {
+                PayPalWebCheckoutFinishStartResult.Canceled(orderId)
             } else {
-                val orderId = metadata.optString(METADATA_KEY_ORDER_ID)
-                val opType = deepLinkUrl.getQueryParameter("opType")
-                if (opType == "cancel") {
-                    PayPalWebCheckoutFinishStartResult.Canceled(orderId)
+                val payerId = deepLinkUrl.getQueryParameter("PayerID")
+                if (orderId.isNullOrBlank() || payerId.isNullOrBlank()) {
+                    val malformedResultError = PayPalWebCheckoutError.malformedResultError
+                    PayPalWebCheckoutFinishStartResult.Failure(malformedResultError, orderId)
                 } else {
-                    val payerId = deepLinkUrl.getQueryParameter("PayerID")
-                    if (orderId.isNullOrBlank() || payerId.isNullOrBlank()) {
-                        val malformedResultError = PayPalWebCheckoutError.malformedResultError
-                        PayPalWebCheckoutFinishStartResult.Failure(malformedResultError, orderId)
-                    } else {
-                        PayPalWebCheckoutFinishStartResult.Success(orderId, payerId)
-                    }
+                    PayPalWebCheckoutFinishStartResult.Success(orderId, payerId)
                 }
             }
-        } else {
-            PayPalWebCheckoutFinishStartResult.NoResult
         }
     }
 
     private fun parseVaultSuccessResult(
         finalResult: BrowserSwitchFinalResult.Success
     ): PayPalWebCheckoutFinishVaultResult {
+        if (finalResult.requestCode != BrowserSwitchRequestCodes.PAYPAL_VAULT) {
+            PayPalWebCheckoutFinishVaultResult.NoResult
+        }
+
         val deepLinkUrl = finalResult.returnUrl
         val requestMetadata = finalResult.requestMetadata
-        return if (finalResult.requestCode == BrowserSwitchRequestCodes.PAYPAL_VAULT) {
-            if (requestMetadata == null) {
-                PayPalWebCheckoutFinishVaultResult.Failure(PayPalWebCheckoutError.unknownError)
+        return if (requestMetadata == null) {
+            PayPalWebCheckoutFinishVaultResult.Failure(PayPalWebCheckoutError.unknownError)
+        } else {
+            val isCancelUrl = deepLinkUrl.path?.contains("cancel") ?: false
+            if (isCancelUrl) {
+                PayPalWebCheckoutFinishVaultResult.Canceled
             } else {
-                val isCancelUrl = deepLinkUrl.path?.contains("cancel") ?: false
-                if (isCancelUrl) {
-                    PayPalWebCheckoutFinishVaultResult.Canceled
+                val approvalSessionId =
+                    deepLinkUrl.getQueryParameter(URL_PARAM_APPROVAL_SESSION_ID)
+                if (approvalSessionId.isNullOrEmpty()) {
+                    PayPalWebCheckoutFinishVaultResult.Failure(PayPalWebCheckoutError.malformedResultError)
                 } else {
-                    val approvalSessionId =
-                        deepLinkUrl.getQueryParameter(URL_PARAM_APPROVAL_SESSION_ID)
-                    if (approvalSessionId.isNullOrEmpty()) {
-                        PayPalWebCheckoutFinishVaultResult.Failure(PayPalWebCheckoutError.malformedResultError)
-                    } else {
-                        PayPalWebCheckoutFinishVaultResult.Success(approvalSessionId)
-                    }
+                    PayPalWebCheckoutFinishVaultResult.Success(approvalSessionId)
                 }
             }
-        } else {
-            PayPalWebCheckoutFinishVaultResult.NoResult
         }
     }
 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
@@ -183,11 +183,17 @@ internal class PayPalWebLauncher(
             if (requestMetadata == null) {
                 PayPalWebCheckoutFinishVaultResult.Failure(PayPalWebCheckoutError.unknownError)
             } else {
-                val approvalSessionId = deepLinkUrl.getQueryParameter(URL_PARAM_APPROVAL_SESSION_ID)
-                if (approvalSessionId.isNullOrEmpty()) {
-                    PayPalWebCheckoutFinishVaultResult.Failure(PayPalWebCheckoutError.malformedResultError)
+                val isCancelUrl = deepLinkUrl.path?.contains("cancel") ?: false
+                if (isCancelUrl) {
+                    PayPalWebCheckoutFinishVaultResult.Canceled
                 } else {
-                    PayPalWebCheckoutFinishVaultResult.Success(approvalSessionId)
+                    val approvalSessionId =
+                        deepLinkUrl.getQueryParameter(URL_PARAM_APPROVAL_SESSION_ID)
+                    if (approvalSessionId.isNullOrEmpty()) {
+                        PayPalWebCheckoutFinishVaultResult.Failure(PayPalWebCheckoutError.malformedResultError)
+                    } else {
+                        PayPalWebCheckoutFinishVaultResult.Success(approvalSessionId)
+                    }
                 }
             }
         } else {

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
@@ -149,7 +149,7 @@ internal class PayPalWebLauncher(
         finalResult: BrowserSwitchFinalResult.Success
     ): PayPalWebCheckoutFinishStartResult {
         if (finalResult.requestCode != BrowserSwitchRequestCodes.PAYPAL_CHECKOUT) {
-            PayPalWebCheckoutFinishStartResult.NoResult
+            return PayPalWebCheckoutFinishStartResult.NoResult
         }
 
         val deepLinkUrl = finalResult.returnUrl
@@ -178,7 +178,7 @@ internal class PayPalWebLauncher(
         finalResult: BrowserSwitchFinalResult.Success
     ): PayPalWebCheckoutFinishVaultResult {
         if (finalResult.requestCode != BrowserSwitchRequestCodes.PAYPAL_VAULT) {
-            PayPalWebCheckoutFinishVaultResult.NoResult
+            return PayPalWebCheckoutFinishVaultResult.NoResult
         }
 
         val deepLinkUrl = finalResult.returnUrl

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
@@ -2,6 +2,7 @@ package com.paypal.android.paypalwebpayments
 
 import android.content.Intent
 import android.net.Uri
+import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import com.braintreepayments.api.BrowserSwitchClient
 import com.braintreepayments.api.BrowserSwitchFinalResult
@@ -14,6 +15,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
@@ -312,6 +314,23 @@ class PayPalWebLauncherUnitTest {
     }
 
     @Test
+    fun `completeCheckoutAuthRequest() parses checkout cancellation deep link url indicates failure`() {
+        val browserSwitchResult = createCheckoutCancellationBrowserSwitchResult(
+            requestCode = BrowserSwitchRequestCodes.PAYPAL_CHECKOUT,
+            orderId= "fake-order-id"
+        )
+
+        every {
+            browserSwitchClient.completeRequest(intent, "pending request")
+        } returns browserSwitchResult
+
+        sut = PayPalWebLauncher("custom_url_scheme", liveConfig, browserSwitchClient)
+
+        val result = sut.completeCheckoutAuthRequest(intent, "pending request")
+        assertTrue(result is PayPalWebCheckoutFinishStartResult.Canceled)
+    }
+
+    @Test
     fun `completeVaultAuthRequest() parses successful vault result`() {
         val browserSwitchResult = createVaultSuccessBrowserSwitchResult(
             requestCode = BrowserSwitchRequestCodes.PAYPAL_VAULT,
@@ -360,6 +379,15 @@ class PayPalWebLauncherUnitTest {
         metadata: JSONObject? = createCheckoutMetadata(orderId!!),
         deepLinkUrl: Uri = createCheckoutDeepLinkUrl(payerId!!)
     ) = createBrowserSwitchSuccessFinalResult(requestCode, metadata, deepLinkUrl)
+
+    private fun createCheckoutCancellationBrowserSwitchResult(
+        requestCode: Int,
+        orderId: String,
+    ): BrowserSwitchFinalResult.Success {
+        val deepLinkUrl = "http://testurl.com/checkout?opType=cancel".toUri()
+        val metadata = createCheckoutMetadata(orderId)
+        return createBrowserSwitchSuccessFinalResult(requestCode, metadata, deepLinkUrl)
+    }
 
     private fun createVaultMetadata(setupTokenId: String) = JSONObject()
         .put("setup_token_id", setupTokenId)


### PR DESCRIPTION
### Summary of changes

 - This PR fixes a bug that caused cancelation links to:
   - Result in a failure for `PayPalWebCheckoutClient.start()` flows
   - Result in a false-positive success for `PayPalWebCheckoutClient.vault()` flows
 - The expected behavior for both of these scenarios should result in the SDK returning an explicit `Canceled` event

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
