### PR TITLE
Fix Base Branch in Create Release PR Workflow

### DIFF
--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: 'develop'
           fetch-depth: 0  # Full git history to ensure branch creation works

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          ref: 'develop'
           fetch-depth: 0  # Full git history to ensure branch creation works
 
       - name: Set up Java

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
         with:
-          ref: 'develop'
+          ref: 'main'
           fetch-depth: 0  # Full git history to ensure branch creation works
 
       - name: Set up Java
@@ -30,6 +30,10 @@ jobs:
 
       - name: Update Version Files
         run: |
+          # Ref: https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#keep-a-branch-up-to-date-with-another
+          git fetch origin develop:develop
+          git reset --hard develop
+
           # Update version in build.gradle
           ./gradlew -PversionParam=${{ github.event.inputs.versionName }} changeReleaseVersion
           

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PayPal Android SDK Release Notes
 
-## 2.1.1 (2025-09-25)
+## unreleased
 * PayPalWebPayments
   * Add `PayPalWebCheckoutClient.finishStart(intent: Intent)` method
     * Deprecate `PayPalWebCheckoutClient.finishStart(intent: Intent, authState: String)` method


### PR DESCRIPTION
### Summary of changes

 - This fix ensures that all `develop` changes make it into `main` when creating a release PR

 ### Checklist

 - [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
