### PR TITLE
Remove auth state deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * CardPayments
   * Migrate `CardClient.presentAuthChallenge()` method to take a plain `Activity` reference instead of a `ComponentActivity` reference
 * PayPalWebPayments
+  * Fix breaking change bug where `PayPalPresentAuthChallengeResult.authState` was marked as `internal`
   * Migrate `PayPalWebCheckoutClient.start()` method to take a plain `Activity` reference instead of a `ComponentActivity` reference
   * Migrate `PayPalWebCheckoutClient.vault()` method to take a plain `Activity` reference instead of a `ComponentActivity` reference
 

--- a/PayPalWebPayments/api/PayPalWebPayments.api
+++ b/PayPalWebPayments/api/PayPalWebPayments.api
@@ -21,9 +21,11 @@ public final class com/paypal/android/paypalwebpayments/PayPalPresentAuthChallen
 
 public final class com/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult$Success : com/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult {
 	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult$Success;
 	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult$Success;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult$Success;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthState ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult.kt
@@ -6,7 +6,7 @@ sealed class PayPalPresentAuthChallengeResult {
     data class Success(
         // TODO: v3 – remove public facing authState property
         @Deprecated("This accessor is no longer supported. Auth state is now managed internally by the SDK.")
-        internal val authState: String
+        val authState: String
     ) : PayPalPresentAuthChallengeResult()
 
     data class Failure(val error: PayPalSDKError) : PayPalPresentAuthChallengeResult()


### PR DESCRIPTION
### Summary of changes

 - Fix breaking change bug where `PayPalPresentAuthChallengeResult.authState` was marked as `internal`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
