### PR TITLE
fixUniversalLink

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
@@ -40,6 +39,7 @@
       </map>
     </option>
   </component>
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-* Add overloaded functions with callbacks for `start` and `vault` methods in
-  `PayPalWebCheckoutClient`
 * Adds new property `appSwitchWhenEligible`in `PayPalWebCheckoutRequest` to include to control app
   switch behavior
 * Adds new property `appSwitchWhenEligible`in `PayPalWebVaultRequest` to include to control app
@@ -13,6 +11,8 @@
 * Adds new property `appLinkUrl` in `PayPalWebVaultRequest` to specify app link url that will be
   used to recognize app after vaulting
 * Deprecates `urlScheme` property in `PayPalWebCheckoutClient`
+* Adds new functions `startAsync` and `vaultAsync` in `PayPalWebCheckoutClient` to support Kotlin
+  coroutines
 
 ## 2.3.0 (2025-11-03)
 * PayPalWebPayments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@
 
 * Add overloaded functions with callbacks for `start` and `vault` methods in
   `PayPalWebCheckoutClient`
-* Modify `PayPalWebCheckoutRequest` to include `appSwitchWhenEligible` property to control app
+* Adds new property `appSwitchWhenEligible`in `PayPalWebCheckoutRequest` to include to control app
   switch behavior
-* Breaking Changes
-  * Make start and vault functions in `PayPalWebCheckoutClient` suspend functions
+* Adds new property `appSwitchWhenEligible`in `PayPalWebVaultRequest` to include to control app
+  switch behavior
+* Adds new property `appLinkUrl` in `PayPalWebCheckoutRequest` to specify app link url that will be
+  used to recognize app after approving order
+* Adds new property `appLinkUrl` in `PayPalWebVaultRequest` to specify app link url that will be
+  used to recognize app after vaulting
+* Deprecates `urlScheme` property in `PayPalWebCheckoutClient`
 
 ## 2.3.0 (2025-11-03)
 * PayPalWebPayments

--- a/CorePayments/api/CorePayments.api
+++ b/CorePayments/api/CorePayments.api
@@ -112,18 +112,6 @@ public final class com/paypal/android/corepayments/UpdateClientConfigAPI$Default
 	public static final field USER_EXPERIENCE_FLOW Ljava/lang/String;
 }
 
-public final class com/paypal/android/corepayments/UpdateClientConfigResponse {
-	public static final field Companion Lcom/paypal/android/corepayments/UpdateClientConfigResponse$Companion;
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/paypal/android/corepayments/UpdateClientConfigResponse;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/UpdateClientConfigResponse;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/UpdateClientConfigResponse;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getUpdateClientConfig ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class com/paypal/android/corepayments/UpdateClientConfigResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/paypal/android/corepayments/UpdateClientConfigResponse$$serializer;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
@@ -137,9 +125,6 @@ public final class com/paypal/android/corepayments/UpdateClientConfigResponse$$s
 
 public final class com/paypal/android/corepayments/UpdateClientConfigResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public abstract class com/paypal/android/corepayments/UpdateClientConfigResult {
 }
 
 public final class com/paypal/android/corepayments/UpdateClientConfigResult$Failure : com/paypal/android/corepayments/UpdateClientConfigResult {
@@ -156,29 +141,6 @@ public final class com/paypal/android/corepayments/UpdateClientConfigResult$Fail
 public final class com/paypal/android/corepayments/UpdateClientConfigResult$Success : com/paypal/android/corepayments/UpdateClientConfigResult {
 	public static final field INSTANCE Lcom/paypal/android/corepayments/UpdateClientConfigResult$Success;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/paypal/android/corepayments/UpdateClientConfigVariables {
-	public static final field Companion Lcom/paypal/android/corepayments/UpdateClientConfigVariables$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/paypal/android/corepayments/UpdateClientConfigVariables;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/UpdateClientConfigVariables;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/UpdateClientConfigVariables;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getButtonSessionId ()Ljava/lang/String;
-	public final fun getFundingSource ()Ljava/lang/String;
-	public final fun getIntegrationArtifact ()Ljava/lang/String;
-	public final fun getProductFlow ()Ljava/lang/String;
-	public final fun getToken ()Ljava/lang/String;
-	public final fun getUserExperienceFlow ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/Demo/src/main/AndroidManifest.xml
+++ b/Demo/src/main/AndroidManifest.xml
@@ -28,6 +28,17 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="ppcp-mobile-demo-sandbox-87bbd7f0a27f.herokuapp.com"
+                    android:pathPrefix="/"
+                    android:scheme="https" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/Demo/src/main/java/com/paypal/android/DemoConstants.kt
+++ b/Demo/src/main/java/com/paypal/android/DemoConstants.kt
@@ -1,10 +1,10 @@
 package com.paypal.android
 
 object DemoConstants {
-    const val APP_URL = "https://ppcp-mobile-demo-sandbox-87bbd7f0a27f.herokuapp.com/"
-    const val SUCCESS_URL = "${APP_URL}success"
-    const val CANCEL_URL = "${APP_URL}cancel"
-    const val VAULT_SUCCESS_URL = "${APP_URL}vault/success"
-    const val VAULT_CANCEL_URL = "${APP_URL}vault/cancel"
-    const val RETURN_URL = "${APP_URL}example.com/returnUrl"
+    const val APP_URL = "https://ppcp-mobile-demo-sandbox-87bbd7f0a27f.herokuapp.com"
+    const val SUCCESS_URL = "${APP_URL}/success"
+    const val CANCEL_URL = "${APP_URL}/cancel"
+    const val VAULT_SUCCESS_URL = "${APP_URL}/vault/success"
+    const val VAULT_CANCEL_URL = "${APP_URL}/vault/cancel"
+
 }

--- a/Demo/src/main/java/com/paypal/android/DemoConstants.kt
+++ b/Demo/src/main/java/com/paypal/android/DemoConstants.kt
@@ -2,6 +2,7 @@ package com.paypal.android
 
 object DemoConstants {
     const val APP_URL = "https://ppcp-mobile-demo-sandbox-87bbd7f0a27f.herokuapp.com"
+    const val APP_FALLBACK_URL_SCHEME = "com.paypal.android.demo"
     const val SUCCESS_URL = "${APP_URL}/success"
     const val CANCEL_URL = "${APP_URL}/cancel"
     const val VAULT_SUCCESS_URL = "${APP_URL}/vault/success"

--- a/Demo/src/main/java/com/paypal/android/DemoConstants.kt
+++ b/Demo/src/main/java/com/paypal/android/DemoConstants.kt
@@ -3,9 +3,8 @@ package com.paypal.android
 object DemoConstants {
     const val APP_URL = "https://ppcp-mobile-demo-sandbox-87bbd7f0a27f.herokuapp.com"
     const val APP_FALLBACK_URL_SCHEME = "com.paypal.android.demo"
-    const val SUCCESS_URL = "${APP_URL}/success"
-    const val CANCEL_URL = "${APP_URL}/cancel"
-    const val VAULT_SUCCESS_URL = "${APP_URL}/vault/success"
-    const val VAULT_CANCEL_URL = "${APP_URL}/vault/cancel"
-
+    const val SUCCESS_URL = "$APP_URL/success"
+    const val CANCEL_URL = "$APP_URL/cancel"
+    const val VAULT_SUCCESS_URL = "$APP_URL/vault/success"
+    const val VAULT_CANCEL_URL = "$APP_URL/vault/cancel"
 }

--- a/Demo/src/main/java/com/paypal/android/DemoConstants.kt
+++ b/Demo/src/main/java/com/paypal/android/DemoConstants.kt
@@ -1,7 +1,7 @@
 package com.paypal.android
 
 object DemoConstants {
-    const val APP_URL = "com.paypal.android.demo://"
+    const val APP_URL = "https://ppcp-mobile-demo-sandbox-87bbd7f0a27f.herokuapp.com/"
     const val SUCCESS_URL = "${APP_URL}success"
     const val CANCEL_URL = "${APP_URL}cancel"
     const val VAULT_SUCCESS_URL = "${APP_URL}vault/success"

--- a/Demo/src/main/java/com/paypal/android/MainActivity.kt
+++ b/Demo/src/main/java/com/paypal/android/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.paypal.android
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -21,11 +20,5 @@ class MainActivity : ComponentActivity() {
         setContent {
             DemoApp()
         }
-    }
-
-    override fun onNewIntent(intent: Intent?) {
-        println("MainActivity: $intent")
-        println("MainActivity: ${intent?.data}")
-        super.onNewIntent(intent)
     }
 }

--- a/Demo/src/main/java/com/paypal/android/MainActivity.kt
+++ b/Demo/src/main/java/com/paypal/android/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.paypal.android
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -20,5 +21,11 @@ class MainActivity : ComponentActivity() {
         setContent {
             DemoApp()
         }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        println("MainActivity: $intent")
+        println("MainActivity: ${intent?.data}")
+        super.onNewIntent(intent)
     }
 }

--- a/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
@@ -132,7 +132,7 @@ class ApproveOrderViewModel @Inject constructor(
             expirationYear = dateString.formattedYear,
             securityCode = cardSecurityCode
         )
-        CardRequest(orderId, card, DemoConstants.RETURN_URL, scaOption)
+        CardRequest(orderId, card, DemoConstants.APP_URL, scaOption)
     }
 
     private var createOrderState

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
@@ -108,13 +108,11 @@ class PayPalCheckoutViewModel @Inject constructor(
         if (orderId == null) {
             payPalWebCheckoutState = ActionState.Failure(Exception("Create an order to continue."))
         } else {
-            viewModelScope.launch {
-                startCheckoutWithOrderId(activity, orderId)
-            }
+            startCheckoutWithOrderId(activity, orderId)
         }
     }
 
-    private suspend fun startCheckoutWithOrderId(activity: ComponentActivity, orderId: String) {
+    private fun startCheckoutWithOrderId(activity: ComponentActivity, orderId: String) {
         payPalWebCheckoutState = ActionState.Loading
 
         val checkoutRequest = PayPalWebCheckoutRequest(
@@ -124,13 +122,16 @@ class PayPalCheckoutViewModel @Inject constructor(
             APP_URL,
             APP_FALLBACK_URL_SCHEME
         )
-        when (val startResult = paypalClient.startAsync(activity, checkoutRequest)) {
-            is PayPalPresentAuthChallengeResult.Success -> {
-                // do nothing; wait for user to authenticate PayPal checkout in Chrome Custom Tab
-            }
 
-            is PayPalPresentAuthChallengeResult.Failure ->
-                payPalWebCheckoutState = ActionState.Failure(startResult.error)
+        paypalClient.start(activity, checkoutRequest) { startResult ->
+            when (startResult) {
+                is PayPalPresentAuthChallengeResult.Success -> {
+                    // do nothing; wait for user to authenticate PayPal checkout in Chrome Custom Tab
+                }
+
+                is PayPalPresentAuthChallengeResult.Failure ->
+                    payPalWebCheckoutState = ActionState.Failure(startResult.error)
+            }
         }
     }
 

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.paypal.android.DemoConstants.APP_FALLBACK_URL_SCHEME
 import com.paypal.android.DemoConstants.APP_URL
 import com.paypal.android.api.model.Order
 import com.paypal.android.api.model.OrderIntent
@@ -116,17 +117,22 @@ class PayPalCheckoutViewModel @Inject constructor(
     private suspend fun startCheckoutWithOrderId(activity: ComponentActivity, orderId: String) {
         payPalWebCheckoutState = ActionState.Loading
 
-                val checkoutRequest =
-                    PayPalWebCheckoutRequest(orderId, fundingSource, appSwitchWhenEligible, APP_URL)
+        val checkoutRequest = PayPalWebCheckoutRequest(
+            orderId,
+            fundingSource,
+            appSwitchWhenEligible,
+            APP_URL,
+            APP_FALLBACK_URL_SCHEME
+        )
         when (val startResult = paypalClient.startAsync(activity, checkoutRequest)) {
-                    is PayPalPresentAuthChallengeResult.Success -> {
-                        // do nothing; wait for user to authenticate PayPal checkout in Chrome Custom Tab
-                    }
-
-                    is PayPalPresentAuthChallengeResult.Failure ->
-                        payPalWebCheckoutState = ActionState.Failure(startResult.error)
-                }
+            is PayPalPresentAuthChallengeResult.Success -> {
+                // do nothing; wait for user to authenticate PayPal checkout in Chrome Custom Tab
             }
+
+            is PayPalPresentAuthChallengeResult.Failure ->
+                payPalWebCheckoutState = ActionState.Failure(startResult.error)
+        }
+    }
 
     fun completeOrder(context: Context) {
         val orderId = createdOrder?.id

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
@@ -118,7 +118,7 @@ class PayPalCheckoutViewModel @Inject constructor(
 
                 val checkoutRequest =
                     PayPalWebCheckoutRequest(orderId, fundingSource, appSwitchWhenEligible, APP_URL)
-                when (val startResult = paypalClient.start(activity, checkoutRequest)) {
+        when (val startResult = paypalClient.startTemp(activity, checkoutRequest)) {
                     is PayPalPresentAuthChallengeResult.Success -> {
                         // do nothing; wait for user to authenticate PayPal checkout in Chrome Custom Tab
                     }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.paypal.android.DemoConstants.APP_URL
 import com.paypal.android.api.model.Order
 import com.paypal.android.api.model.OrderIntent
 import com.paypal.android.api.services.SDKSampleServerAPI
@@ -43,7 +44,7 @@ class PayPalCheckoutViewModel @Inject constructor(
     private val coreConfig = CoreConfig(SDKSampleServerAPI.clientId)
     private val payPalDataCollector = PayPalDataCollector(coreConfig)
     private val paypalClient =
-        PayPalWebCheckoutClient(applicationContext, coreConfig, "com.paypal.android.demo")
+        PayPalWebCheckoutClient(applicationContext, coreConfig)
 
     private val _uiState = MutableStateFlow(PayPalUiState())
     val uiState = _uiState.asStateFlow()
@@ -116,7 +117,7 @@ class PayPalCheckoutViewModel @Inject constructor(
         payPalWebCheckoutState = ActionState.Loading
 
                 val checkoutRequest =
-                    PayPalWebCheckoutRequest(orderId, fundingSource, appSwitchWhenEligible)
+                    PayPalWebCheckoutRequest(orderId, fundingSource, appSwitchWhenEligible, APP_URL)
                 when (val startResult = paypalClient.start(activity, checkoutRequest)) {
                     is PayPalPresentAuthChallengeResult.Success -> {
                         // do nothing; wait for user to authenticate PayPal checkout in Chrome Custom Tab

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
@@ -118,7 +118,7 @@ class PayPalCheckoutViewModel @Inject constructor(
 
                 val checkoutRequest =
                     PayPalWebCheckoutRequest(orderId, fundingSource, appSwitchWhenEligible, APP_URL)
-        when (val startResult = paypalClient.startTemp(activity, checkoutRequest)) {
+        when (val startResult = paypalClient.startAsync(activity, checkoutRequest)) {
                     is PayPalPresentAuthChallengeResult.Success -> {
                         // do nothing; wait for user to authenticate PayPal checkout in Chrome Custom Tab
                     }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.paypal.android.DemoConstants.APP_URL
 import com.paypal.android.api.model.PayPalSetupToken
 import com.paypal.android.api.services.SDKSampleServerAPI
 import com.paypal.android.corepayments.CoreConfig
@@ -35,7 +36,7 @@ class PayPalVaultViewModel @Inject constructor(
     }
 
     private val coreConfig = CoreConfig(SDKSampleServerAPI.clientId)
-    private val paypalClient = PayPalWebCheckoutClient(applicationContext, coreConfig, URL_SCHEME)
+    private val paypalClient = PayPalWebCheckoutClient(applicationContext, coreConfig)
 
     private val _uiState = MutableStateFlow(PayPalVaultUiState())
     val uiState = _uiState.asStateFlow()
@@ -83,7 +84,8 @@ class PayPalVaultViewModel @Inject constructor(
             viewModelScope.launch {
                 val request = PayPalWebVaultRequest(
                     setupTokenId,
-                    appSwitchWhenEligible
+                    appSwitchWhenEligible,
+                    APP_URL
                 )
                 vaultSetupTokenWithRequest(activity, request)
             }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.paypal.android.DemoConstants.APP_FALLBACK_URL_SCHEME
 import com.paypal.android.DemoConstants.APP_URL
 import com.paypal.android.api.model.PayPalSetupToken
 import com.paypal.android.api.services.SDKSampleServerAPI
@@ -30,11 +31,6 @@ class PayPalVaultViewModel @Inject constructor(
     val createPayPalSetupTokenUseCase: CreatePayPalSetupTokenUseCase,
     val createPayPalPaymentTokenUseCase: CreatePayPalPaymentTokenUseCase,
 ) : ViewModel() {
-
-    companion object {
-        const val URL_SCHEME = "com.paypal.android.demo"
-    }
-
     private val coreConfig = CoreConfig(SDKSampleServerAPI.clientId)
     private val paypalClient = PayPalWebCheckoutClient(applicationContext, coreConfig)
 
@@ -85,7 +81,8 @@ class PayPalVaultViewModel @Inject constructor(
                 val request = PayPalWebVaultRequest(
                     setupTokenId,
                     appSwitchWhenEligible,
-                    APP_URL
+                    APP_URL,
+                    APP_FALLBACK_URL_SCHEME
                 )
                 vaultSetupTokenWithRequest(activity, request)
             }
@@ -98,8 +95,8 @@ class PayPalVaultViewModel @Inject constructor(
     ) {
         vaultPayPalState = ActionState.Loading
 
-        viewModelScope.launch {
-            when (val result = paypalClient.vaultAsync(activity, request)) {
+        paypalClient.vault(activity, request) { result ->
+            when (result) {
                 is PayPalPresentAuthChallengeResult.Success -> {
                     // do nothing; wait for user to authenticate PayPal vault in Chrome Custom Tab
                 }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
@@ -99,7 +99,7 @@ class PayPalVaultViewModel @Inject constructor(
         vaultPayPalState = ActionState.Loading
 
         viewModelScope.launch {
-            when (val result = paypalClient.vault(activity, request)) {
+            when (val result = paypalClient.vaultTemp(activity, request)) {
                 is PayPalPresentAuthChallengeResult.Success -> {
                     // do nothing; wait for user to authenticate PayPal vault in Chrome Custom Tab
                 }

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
@@ -99,7 +99,7 @@ class PayPalVaultViewModel @Inject constructor(
         vaultPayPalState = ActionState.Loading
 
         viewModelScope.launch {
-            when (val result = paypalClient.vaultTemp(activity, request)) {
+            when (val result = paypalClient.vaultAsync(activity, request)) {
                 is PayPalPresentAuthChallengeResult.Success -> {
                     // do nothing; wait for user to authenticate PayPal vault in Chrome Custom Tab
                 }

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.paypal.android.DemoConstants
+import com.paypal.android.DemoConstants.RETURN_URL
 import com.paypal.android.api.model.CardSetupToken
 import com.paypal.android.api.services.SDKSampleServerAPI
 import com.paypal.android.cardpayments.Card
@@ -123,8 +123,7 @@ class VaultCardViewModel @Inject constructor(
     private fun updateSetupTokenWithId(activity: ComponentActivity, setupTokenId: String) {
         updateSetupTokenState = ActionState.Loading
         val card = parseCard(_uiState.value)
-        val returnUrl = DemoConstants.RETURN_URL
-        val cardVaultRequest = CardVaultRequest(setupTokenId, card, returnUrl)
+        val cardVaultRequest = CardVaultRequest(setupTokenId, card, RETURN_URL)
         cardClient.vault(cardVaultRequest) { result ->
             when (result) {
                 is CardVaultResult.Success -> {

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.paypal.android.DemoConstants.RETURN_URL
+import com.paypal.android.DemoConstants.APP_URL
 import com.paypal.android.api.model.CardSetupToken
 import com.paypal.android.api.services.SDKSampleServerAPI
 import com.paypal.android.cardpayments.Card
@@ -123,7 +123,7 @@ class VaultCardViewModel @Inject constructor(
     private fun updateSetupTokenWithId(activity: ComponentActivity, setupTokenId: String) {
         updateSetupTokenState = ActionState.Loading
         val card = parseCard(_uiState.value)
-        val cardVaultRequest = CardVaultRequest(setupTokenId, card, RETURN_URL)
+        val cardVaultRequest = CardVaultRequest(setupTokenId, card, APP_URL)
         cardClient.vault(cardVaultRequest) { result ->
             when (result) {
                 is CardVaultResult.Success -> {

--- a/PayPalWebPayments/api/PayPalWebPayments.api
+++ b/PayPalWebPayments/api/PayPalWebPayments.api
@@ -120,16 +120,19 @@ public final class com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest
 	public fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;)V
 	public fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;Z)V
 	public fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;
 	public final fun component3 ()Z
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;
-	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;Ljava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;
+	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppLinkUrl ()Ljava/lang/String;
 	public final fun getAppSwitchWhenEligible ()Z
+	public final fun getFallbackUrlScheme ()Ljava/lang/String;
 	public final fun getFundingSource ()Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;
 	public final fun getOrderId ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -145,20 +148,22 @@ public abstract interface class com/paypal/android/paypalwebpayments/PayPalWebVa
 }
 
 public final class com/paypal/android/paypalwebpayments/PayPalWebVaultRequest {
-	public fun <init> (Ljava/lang/String;ZLjava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;
-	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;
+	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppLinkUrl ()Ljava/lang/String;
 	public final fun getAppSwitchWhenEligible ()Z
 	public final fun getApproveVaultHref ()Ljava/lang/String;
+	public final fun getFallbackUrlScheme ()Ljava/lang/String;
 	public final fun getSetupTokenId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/PayPalWebPayments/api/PayPalWebPayments.api
+++ b/PayPalWebPayments/api/PayPalWebPayments.api
@@ -35,6 +35,7 @@ public abstract interface class com/paypal/android/paypalwebpayments/PayPalWebCh
 }
 
 public final class com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient {
+	public fun <init> (Landroid/content/Context;Lcom/paypal/android/corepayments/CoreConfig;)V
 	public fun <init> (Landroid/content/Context;Lcom/paypal/android/corepayments/CoreConfig;Ljava/lang/String;)V
 	public final fun finishStart (Landroid/content/Intent;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFinishStartResult;
 	public final fun finishStart (Landroid/content/Intent;Ljava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFinishStartResult;
@@ -42,10 +43,12 @@ public final class com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient 
 	public final fun finishVault (Landroid/content/Intent;Ljava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFinishVaultResult;
 	public final fun getInstanceState ()Ljava/lang/String;
 	public final fun restore (Ljava/lang/String;)V
+	public final fun start (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;)Lcom/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult;
 	public final fun start (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;Lcom/paypal/android/paypalwebpayments/PayPalWebStartCallback;)V
-	public final fun start (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun vault (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun startAsync (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun vault (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;)Lcom/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult;
 	public final fun vault (Landroidx/activity/ComponentActivity;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultCallback;)V
+	public final fun vaultAsync (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class com/paypal/android/paypalwebpayments/PayPalWebCheckoutFinishStartResult {
@@ -116,13 +119,16 @@ public final class com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;)V
 	public fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;
 	public final fun component3 ()Z
-	public final fun copy (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;Z)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;
-	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;
+	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppLinkUrl ()Ljava/lang/String;
 	public final fun getAppSwitchWhenEligible ()Z
 	public final fun getFundingSource ()Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;
 	public final fun getOrderId ()Ljava/lang/String;
@@ -139,15 +145,18 @@ public abstract interface class com/paypal/android/paypalwebpayments/PayPalWebVa
 }
 
 public final class com/paypal/android/paypalwebpayments/PayPalWebVaultRequest {
-	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;ZLjava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;ZLjava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;
-	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;
+	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppLinkUrl ()Ljava/lang/String;
 	public final fun getAppSwitchWhenEligible ()Z
 	public final fun getApproveVaultHref ()Ljava/lang/String;
 	public final fun getSetupTokenId ()Ljava/lang/String;

--- a/PayPalWebPayments/api/PayPalWebPayments.api
+++ b/PayPalWebPayments/api/PayPalWebPayments.api
@@ -45,10 +45,8 @@ public final class com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient 
 	public final fun restore (Ljava/lang/String;)V
 	public final fun start (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;)Lcom/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult;
 	public final fun start (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;Lcom/paypal/android/paypalwebpayments/PayPalWebStartCallback;)V
-	public final fun startAsync (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun vault (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;)Lcom/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult;
 	public final fun vault (Landroidx/activity/ComponentActivity;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultCallback;)V
-	public final fun vaultAsync (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class com/paypal/android/paypalwebpayments/PayPalWebCheckoutFinishStartResult {

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -168,6 +168,7 @@ class PayPalWebCheckoutClient internal constructor(
         analytics.notify(CheckoutEvent.STARTED, checkoutOrderId)
 
         val launchUri = withContext(Dispatchers.IO) {
+            // perform updateCCO and getLaunchUri in parallel
             val updateConfigDeferred = async {
                 updateClientConfigAPI.updateClientConfig(
                     request.orderId,

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.activity.ComponentActivity
+import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
@@ -108,8 +109,8 @@ class PayPalWebCheckoutClient internal constructor(
      * @param request [PayPalWebCheckoutRequest] for requesting an order approval
      */
     @Deprecated(
-        message = "Use startAsync(activity, request) or start(activity, request, callback) instead.",
-        replaceWith = ReplaceWith("startAsync(activity, request)")
+        message = "Use start(activity, request, callback) for callback-based flows, includes app switching feature",
+        replaceWith = ReplaceWith("start(activity, request, callback)")
     )
     fun start(
         activity: Activity,
@@ -159,7 +160,8 @@ class PayPalWebCheckoutClient internal constructor(
      *
      * @param request [PayPalWebCheckoutRequest] for requesting an order approval
      */
-    suspend fun startAsync(
+    @VisibleForTesting
+    internal suspend fun startAsync(
         activity: Activity,
         request: PayPalWebCheckoutRequest
     ): PayPalPresentAuthChallengeResult {
@@ -250,8 +252,8 @@ class PayPalWebCheckoutClient internal constructor(
      * @param request [PayPalWebVaultRequest] for vaulting PayPal as a payment method
      */
     @Deprecated(
-        message = "Use vaultAsync(activity, request) or vault(activity, request, callback) instead.",
-        replaceWith = ReplaceWith("vaultAsync(activity, request)")
+        message = "Use vault(activity, request, callback) for callback-based flows, includes app switching feature",
+        replaceWith = ReplaceWith("vault(activity, request, callback)")
     )
     fun vault(
         activity: Activity,
@@ -298,7 +300,8 @@ class PayPalWebCheckoutClient internal constructor(
      *
      * @param request [PayPalWebVaultRequest] for vaulting PayPal as a payment method
      */
-    suspend fun vaultAsync(
+    @VisibleForTesting
+    internal suspend fun vaultAsync(
         activity: Activity,
         request: PayPalWebVaultRequest
     ): PayPalPresentAuthChallengeResult {
@@ -359,20 +362,20 @@ class PayPalWebCheckoutClient internal constructor(
         request: PayPalWebVaultRequest,
         callback: PayPalWebVaultCallback
     ) {
-        CoroutineScope(Dispatchers.Main).launch {
+        applicationScope.launch(Dispatchers.Main) {
             callback.onPayPalWebVaultResult(vaultAsync(activity, request))
         }
     }
 
     /**
      * After a merchant app has re-entered the foreground following an auth challenge
-     * (@see [PayPalWebCheckoutClient.startAsync]), call this method to see if a user has
+     * (@see [PayPalWebCheckoutClient.start]), call this method to see if a user has
      * successfully authorized a PayPal account as a payment source.
      *
      * @param [intent] An Android intent that holds the deep link put the merchant app
      * back into the foreground after an auth challenge.
      * @param [authState] A continuation state received from [PayPalPresentAuthChallengeResult.Success]
-     * when calling [PayPalWebCheckoutClient.startAsync]. This is needed to properly verify that an
+     * when calling [PayPalWebCheckoutClient.start]. This is needed to properly verify that an
      * authorization completed successfully.
      */
     @Deprecated(
@@ -400,7 +403,7 @@ class PayPalWebCheckoutClient internal constructor(
 
     /**
      * After a merchant app has re-entered the foreground following an auth challenge
-     * (@see [PayPalWebCheckoutClient.startAsync]), call this method to see if a user has
+     * (@see [PayPalWebCheckoutClient.start]), call this method to see if a user has
      * successfully authorized a PayPal account as a payment source.
      *
      * @param [intent] An Android intent that holds the deep link put the merchant app
@@ -434,13 +437,13 @@ class PayPalWebCheckoutClient internal constructor(
 
     /**
      * After a merchant app has re-entered the foreground following an auth challenge
-     * (@see [PayPalWebCheckoutClient.vaultAsync]), call this method to see if a user has
+     * (@see [PayPalWebCheckoutClient.vault]), call this method to see if a user has
      * successfully authorized a PayPal account for vaulting.
      *
      * @param [intent] An Android intent that holds the deep link put the merchant app
      * back into the foreground after an auth challenge.
      * @param [authState] A continuation state received from [PayPalPresentAuthChallengeResult.Success]
-     * when calling [PayPalWebCheckoutClient.vaultAsync]. This is needed to properly verify that an
+     * when calling [PayPalWebCheckoutClient.vault]. This is needed to properly verify that an
      * authorization completed successfully.
      */
     @Deprecated(
@@ -528,7 +531,7 @@ class PayPalWebCheckoutClient internal constructor(
     }
     /**
      * After a merchant app has re-entered the foreground following an auth challenge
-     * (@see [PayPalWebCheckoutClient.vaultAsync]), call this method to see if a user has
+     * (@see [PayPalWebCheckoutClient.vault]), call this method to see if a user has
      * successfully authorized a PayPal account for vaulting.
      *
      * @param [intent] An Android intent that holds the deep link put the merchant app

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -267,7 +267,7 @@ class PayPalWebCheckoutClient internal constructor(
             uri = launchUri,
             token = request.setupTokenId,
             tokenType = TokenType.VAULT_ID,
-            returnUrlScheme = urlScheme,
+            returnUrlScheme = request.fallbackUrlScheme ?: urlScheme,
             appLinkUrl = request.appLinkUrl
         )
 
@@ -320,7 +320,7 @@ class PayPalWebCheckoutClient internal constructor(
             uri = launchUri,
             token = request.setupTokenId,
             tokenType = TokenType.VAULT_ID,
-            returnUrlScheme = urlScheme,
+            returnUrlScheme = request.fallbackUrlScheme ?: urlScheme,
             appLinkUrl = request.appLinkUrl
         )
 

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -36,9 +36,9 @@ class PayPalWebCheckoutClient internal constructor(
     private val sessionStore: PayPalWebCheckoutSessionStore,
     private val deviceInspector: DeviceInspector,
     private val coreConfig: CoreConfig,
-    private val urlScheme: String?,
     private val updateClientConfigAPI: UpdateClientConfigAPI,
     private val patchCCOWithAppSwitchEligibility: PatchCCOWithAppSwitchEligibility,
+    private val urlScheme: String? = null,
 
 ) {
     private val applicationScope = CoroutineScope(SupervisorJob())

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -129,7 +129,7 @@ class PayPalWebCheckoutClient internal constructor(
             uri = launchUri,
             token = request.orderId,
             tokenType = TokenType.ORDER_ID,
-            returnUrlScheme = urlScheme,
+            returnUrlScheme = request.fallbackUrlScheme ?: urlScheme,
             appLinkUrl = request.appLinkUrl
         )
 
@@ -198,7 +198,7 @@ class PayPalWebCheckoutClient internal constructor(
             uri = launchUri,
             token = request.orderId,
             tokenType = TokenType.ORDER_ID,
-            returnUrlScheme = urlScheme,
+            returnUrlScheme = request.fallbackUrlScheme ?: urlScheme,
             appLinkUrl = request.appLinkUrl
         )
 

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.withContext
 /**
  * Use this client to approve an order with a [PayPalWebCheckoutRequest].
  */
+@Suppress("TooManyFunctions") // Necessary due to multiple method variations for backward compatibility
 class PayPalWebCheckoutClient internal constructor(
     private val analytics: PayPalWebAnalytics,
     private val payPalWebLauncher: PayPalWebLauncher,
@@ -107,8 +108,8 @@ class PayPalWebCheckoutClient internal constructor(
      * @param request [PayPalWebCheckoutRequest] for requesting an order approval
      */
     @Deprecated(
-        message = "Use start(activity, request, callback) instead.",
-        replaceWith = ReplaceWith("start(activity, request, callback)")
+        message = "Use startAsync(activity, request) or start(activity, request, callback) instead.",
+        replaceWith = ReplaceWith("startAsync(activity, request)")
     )
     fun start(
         activity: Activity,
@@ -158,7 +159,7 @@ class PayPalWebCheckoutClient internal constructor(
      *
      * @param request [PayPalWebCheckoutRequest] for requesting an order approval
      */
-    suspend fun startTemp(
+    suspend fun startAsync(
         activity: Activity,
         request: PayPalWebCheckoutRequest
     ): PayPalPresentAuthChallengeResult {
@@ -235,7 +236,7 @@ class PayPalWebCheckoutClient internal constructor(
         callback: PayPalWebStartCallback
     ) {
         applicationScope.launch {
-            val result = startTemp(activity, request)
+            val result = startAsync(activity, request)
             withContext(Dispatchers.Main) {
                 callback.onPayPalWebStartResult(result)
             }
@@ -248,8 +249,8 @@ class PayPalWebCheckoutClient internal constructor(
      * @param request [PayPalWebVaultRequest] for vaulting PayPal as a payment method
      */
     @Deprecated(
-        message = "Use vault(activity, request, callback) instead.",
-        replaceWith = ReplaceWith("vault(activity, request, callback)")
+        message = "Use vaultAsync(activity, request) or vault(activity, request, callback) instead.",
+        replaceWith = ReplaceWith("vaultAsync(activity, request)")
     )
     fun vault(
         activity: Activity,
@@ -296,7 +297,7 @@ class PayPalWebCheckoutClient internal constructor(
      *
      * @param request [PayPalWebVaultRequest] for vaulting PayPal as a payment method
      */
-    suspend fun vaultTemp(
+    suspend fun vaultAsync(
         activity: Activity,
         request: PayPalWebVaultRequest
     ): PayPalPresentAuthChallengeResult {
@@ -358,19 +359,19 @@ class PayPalWebCheckoutClient internal constructor(
         callback: PayPalWebVaultCallback
     ) {
         CoroutineScope(Dispatchers.Main).launch {
-            callback.onPayPalWebVaultResult(vaultTemp(activity, request))
+            callback.onPayPalWebVaultResult(vaultAsync(activity, request))
         }
     }
 
     /**
      * After a merchant app has re-entered the foreground following an auth challenge
-     * (@see [PayPalWebCheckoutClient.startTemp]), call this method to see if a user has
+     * (@see [PayPalWebCheckoutClient.startAsync]), call this method to see if a user has
      * successfully authorized a PayPal account as a payment source.
      *
      * @param [intent] An Android intent that holds the deep link put the merchant app
      * back into the foreground after an auth challenge.
      * @param [authState] A continuation state received from [PayPalPresentAuthChallengeResult.Success]
-     * when calling [PayPalWebCheckoutClient.startTemp]. This is needed to properly verify that an
+     * when calling [PayPalWebCheckoutClient.startAsync]. This is needed to properly verify that an
      * authorization completed successfully.
      */
     @Deprecated(
@@ -398,7 +399,7 @@ class PayPalWebCheckoutClient internal constructor(
 
     /**
      * After a merchant app has re-entered the foreground following an auth challenge
-     * (@see [PayPalWebCheckoutClient.startTemp]), call this method to see if a user has
+     * (@see [PayPalWebCheckoutClient.startAsync]), call this method to see if a user has
      * successfully authorized a PayPal account as a payment source.
      *
      * @param [intent] An Android intent that holds the deep link put the merchant app
@@ -432,13 +433,13 @@ class PayPalWebCheckoutClient internal constructor(
 
     /**
      * After a merchant app has re-entered the foreground following an auth challenge
-     * (@see [PayPalWebCheckoutClient.vaultTemp]), call this method to see if a user has
+     * (@see [PayPalWebCheckoutClient.vaultAsync]), call this method to see if a user has
      * successfully authorized a PayPal account for vaulting.
      *
      * @param [intent] An Android intent that holds the deep link put the merchant app
      * back into the foreground after an auth challenge.
      * @param [authState] A continuation state received from [PayPalPresentAuthChallengeResult.Success]
-     * when calling [PayPalWebCheckoutClient.vaultTemp]. This is needed to properly verify that an
+     * when calling [PayPalWebCheckoutClient.vaultAsync]. This is needed to properly verify that an
      * authorization completed successfully.
      */
     @Deprecated(
@@ -526,7 +527,7 @@ class PayPalWebCheckoutClient internal constructor(
     }
     /**
      * After a merchant app has re-entered the foreground following an auth challenge
-     * (@see [PayPalWebCheckoutClient.vaultTemp]), call this method to see if a user has
+     * (@see [PayPalWebCheckoutClient.vaultAsync]), call this method to see if a user has
      * successfully authorized a PayPal account for vaulting.
      *
      * @param [intent] An Android intent that holds the deep link put the merchant app

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest.kt
@@ -12,5 +12,6 @@ data class PayPalWebCheckoutRequest @JvmOverloads constructor(
     val orderId: String,
     val fundingSource: PayPalWebCheckoutFundingSource = PayPalWebCheckoutFundingSource.PAYPAL,
     val appSwitchWhenEligible: Boolean = false,
-    val appLinkUrl: String? = null
+    val appLinkUrl: String? = null,
+    val fallbackUrlScheme: String? = null
 )

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest.kt
@@ -6,9 +6,11 @@ package com.paypal.android.paypalwebpayments
  * @param orderId The ID of the order to be approved.
  * @param fundingSource specify funding (credit, paylater or default)
  * @param appSwitchWhenEligible whether to switch to the PayPal app when eligible
+ * @param appLinkUrl The app link URL to use for browser switch, or null to use default.
  */
 data class PayPalWebCheckoutRequest @JvmOverloads constructor(
     val orderId: String,
     val fundingSource: PayPalWebCheckoutFundingSource = PayPalWebCheckoutFundingSource.PAYPAL,
-    val appSwitchWhenEligible: Boolean = false
+    val appSwitchWhenEligible: Boolean = false,
+    val appLinkUrl: String? = null
 )

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest.kt
@@ -6,7 +6,8 @@ package com.paypal.android.paypalwebpayments
  * @param orderId The ID of the order to be approved.
  * @param fundingSource specify funding (credit, paylater or default)
  * @param appSwitchWhenEligible whether to switch to the PayPal app when eligible
- * @param appLinkUrl The app link URL to use for browser switch, or null to use default. Example values: "$myAppScheme://$myAppHost/$myPath", "https://$myDomain/$myPath"
+ * @param appLinkUrl The app link URL to use for browser switch, or null to use default.
+ *   Example values: "$myAppScheme://$myAppHost/$myPath", "https://$myDomain/$myPath"
  * @param fallbackUrlScheme The fallback custom URL scheme to use when app link is not configured properly.
  */
 data class PayPalWebCheckoutRequest @JvmOverloads constructor(

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest.kt
@@ -6,7 +6,8 @@ package com.paypal.android.paypalwebpayments
  * @param orderId The ID of the order to be approved.
  * @param fundingSource specify funding (credit, paylater or default)
  * @param appSwitchWhenEligible whether to switch to the PayPal app when eligible
- * @param appLinkUrl The app link URL to use for browser switch, or null to use default.
+ * @param appLinkUrl The app link URL to use for browser switch, or null to use default. Example values: "$myAppScheme://$myAppHost/$myPath", "https://$myDomain/$myPath"
+ * @param fallbackUrlScheme The fallback custom URL scheme to use when app link is not configured properly.
  */
 data class PayPalWebCheckoutRequest @JvmOverloads constructor(
     val orderId: String,

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
@@ -3,6 +3,7 @@ package com.paypal.android.paypalwebpayments
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import androidx.core.net.toUri
 import com.braintreepayments.api.BrowserSwitchClient
 import com.braintreepayments.api.BrowserSwitchFinalResult
 import com.braintreepayments.api.BrowserSwitchOptions
@@ -30,13 +31,16 @@ internal class PayPalWebLauncher(
         uri: Uri,
         token: String,
         tokenType: TokenType,
-        returnUrlScheme: String
+        returnUrlScheme: String? = null,
+        appLinkUrl: String? = null
     ): PayPalPresentAuthChallengeResult {
+        val urlScheme = if (appLinkUrl != null) null else returnUrlScheme
         val metadata = getMetadata(token, tokenType)
         val options = BrowserSwitchOptions()
             .url(uri)
             .requestCode(getRequestCode(tokenType))
-            .returnUrlScheme(returnUrlScheme)
+            .returnUrlScheme(urlScheme)
+            .appLinkUri(appLinkUrl?.toUri())
             .metadata(metadata)
         return launchBrowserSwitch(activity, options)
     }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
@@ -34,12 +34,11 @@ internal class PayPalWebLauncher(
         returnUrlScheme: String? = null,
         appLinkUrl: String? = null
     ): PayPalPresentAuthChallengeResult {
-        val urlScheme = if (appLinkUrl != null) null else returnUrlScheme
         val metadata = getMetadata(token, tokenType)
         val options = BrowserSwitchOptions()
             .url(uri)
             .requestCode(getRequestCode(tokenType))
-            .returnUrlScheme(urlScheme)
+            .returnUrlScheme(returnUrlScheme)
             .appLinkUri(appLinkUrl?.toUri())
             .metadata(metadata)
         return launchBrowserSwitch(activity, options)

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
@@ -1,7 +1,7 @@
 package com.paypal.android.paypalwebpayments
 
 /**
- * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vault].
+ * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vaultTemp].
  *
  * @property [setupTokenId] ID for the setup token associated with the vault approval
  * @property [approveVaultHref] URL for the approval web page
@@ -18,7 +18,7 @@ constructor(
 ) {
 
     /**
-     * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vault].
+     * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vaultTemp].
      *
      * @property [setupTokenId] ID for the setup token associated with the vault approval
      */

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
@@ -22,5 +22,9 @@ constructor(
      *
      * @property [setupTokenId] ID for the setup token associated with the vault approval
      */
-    constructor(setupTokenId: String) : this(setupTokenId, false)
+    constructor(
+        setupTokenId: String,
+        appSwitchWhenEligible: Boolean = false,
+        appLinkUrl: String? = null
+    ) : this(setupTokenId, appSwitchWhenEligible, appLinkUrl, null)
 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
@@ -1,7 +1,7 @@
 package com.paypal.android.paypalwebpayments
 
 /**
- * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vaultAsync].
+ * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vault].
  *
  * @property [setupTokenId] ID for the setup token associated with the vault approval
  * @property [approveVaultHref] URL for the approval web page
@@ -20,7 +20,7 @@ constructor(
 ) {
 
     /**
-     * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vaultAsync].
+     * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vault].
      *
      * @property [setupTokenId] ID for the setup token associated with the vault approval
      */

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
@@ -1,7 +1,7 @@
 package com.paypal.android.paypalwebpayments
 
 /**
- * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vaultTemp].
+ * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vaultAsync].
  *
  * @property [setupTokenId] ID for the setup token associated with the vault approval
  * @property [approveVaultHref] URL for the approval web page
@@ -18,7 +18,7 @@ constructor(
 ) {
 
     /**
-     * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vaultTemp].
+     * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vaultAsync].
      *
      * @property [setupTokenId] ID for the setup token associated with the vault approval
      */

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
@@ -6,11 +6,13 @@ package com.paypal.android.paypalwebpayments
  * @property [setupTokenId] ID for the setup token associated with the vault approval
  * @property [approveVaultHref] URL for the approval web page
  * @property [appSwitchWhenEligible] whether to switch to the PayPal app when eligible
+ * @property [appLinkUrl] The app link URL to use for returning to app
  */
 data class PayPalWebVaultRequest @Deprecated("Use PayPalWebVaultRequest(setupTokenId) instead.")
 constructor(
     val setupTokenId: String,
     val appSwitchWhenEligible: Boolean = false,
+    val appLinkUrl: String? = null,
     @Deprecated("The approveVaultHref property is no longer required and will be ignored.")
     val approveVaultHref: String? = null // NEXT_MAJOR_VERSION: - Remove this property
 ) {

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
@@ -7,12 +7,14 @@ package com.paypal.android.paypalwebpayments
  * @property [approveVaultHref] URL for the approval web page
  * @property [appSwitchWhenEligible] whether to switch to the PayPal app when eligible
  * @property [appLinkUrl] The app link URL to use for returning to app
+ * @property [fallbackUrlScheme] The fallback custom URL scheme to use when app link is not configured properly
  */
 data class PayPalWebVaultRequest @Deprecated("Use PayPalWebVaultRequest(setupTokenId) instead.")
 constructor(
     val setupTokenId: String,
     val appSwitchWhenEligible: Boolean = false,
     val appLinkUrl: String? = null,
+    val fallbackUrlScheme: String? = null,
     @Deprecated("The approveVaultHref property is no longer required and will be ignored.")
     val approveVaultHref: String? = null // NEXT_MAJOR_VERSION: - Remove this property
 ) {
@@ -25,6 +27,7 @@ constructor(
     constructor(
         setupTokenId: String,
         appSwitchWhenEligible: Boolean = false,
-        appLinkUrl: String? = null
-    ) : this(setupTokenId, appSwitchWhenEligible, appLinkUrl, null)
+        appLinkUrl: String? = null,
+        fallbackUrlScheme: String? = null
+    ) : this(setupTokenId, appSwitchWhenEligible, appLinkUrl, fallbackUrlScheme, null)
 }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -1556,7 +1556,6 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
-                returnUrlScheme = urlScheme,
                 appLinkUrl = appLinkUrl
             )
         }
@@ -1614,7 +1613,6 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-setup-token-id",
                 tokenType = TokenType.VAULT_ID,
-                returnUrlScheme = urlScheme,
                 appLinkUrl = appLinkUrl
             )
         }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -80,7 +80,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns launchResult
 
         val request = PayPalWebCheckoutRequest("fake-order-id", appLinkUrl = appLinkUrl)
-        sut.start(activity, request)
+        sut.startTemp(activity, request)
 
         // Verify launchWithUrl is called with correct parameters
         verify(exactly = 1) {
@@ -111,7 +111,7 @@ class PayPalWebCheckoutClientUnitTest {
 
         val appLinkUrl = "https://example.com/return"
         val request = PayPalWebCheckoutRequest("fake-order-id", appLinkUrl = appLinkUrl)
-        val result = sut.start(activity, request)
+        val result = sut.startTemp(activity, request)
         assertSame(launchResult, result)
     }
 
@@ -130,7 +130,7 @@ class PayPalWebCheckoutClientUnitTest {
 
         val appLinkUrl = "https://example.com/vault/return"
         val request = PayPalWebVaultRequest("fake-setup-token-id", appLinkUrl = appLinkUrl)
-        sut.vault(activity, request)
+        sut.vaultTemp(activity, request)
         verify(exactly = 1) {
             payPalWebLauncher.launchWithUrl(
                 activity = activity,
@@ -159,7 +159,7 @@ class PayPalWebCheckoutClientUnitTest {
 
         val appLinkUrl = "https://example.com/vault/return"
         val request = PayPalWebVaultRequest("fake-setup-token-id", appLinkUrl = appLinkUrl)
-        val result = sut.vault(activity, request) as PayPalPresentAuthChallengeResult.Failure
+        val result = sut.vaultTemp(activity, request) as PayPalPresentAuthChallengeResult.Failure
 
         assertSame(sdkError, result.error)
     }
@@ -225,7 +225,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns successResult
 
         val request = PayPalWebCheckoutRequest("fake-order-id")
-        sut.start(activity, request)
+            sut.startTemp(activity, request)
         val result = sut.finishStart(intent)
         assertSame(successResult, result)
     }
@@ -261,7 +261,7 @@ class PayPalWebCheckoutClientUnitTest {
                 patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
         )
         val request = PayPalWebCheckoutRequest("fake-order-id")
-            launchWithUrlClient.start(activity, request)
+            launchWithUrlClient.startTemp(activity, request)
 
             sut.restore(launchWithUrlClient.instanceState)
         val result = sut.finishStart(intent)
@@ -289,7 +289,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns failureResult
 
         val request = PayPalWebCheckoutRequest("fake-order-id")
-        sut.start(activity, request)
+            sut.startTemp(activity, request)
         val result = sut.finishStart(intent)
         assertSame(failureResult, result)
     }
@@ -315,7 +315,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns failureResult
 
         val request = PayPalWebCheckoutRequest("fake-order-id")
-            sut.start(activity, request)
+            sut.startTemp(activity, request)
         val result = sut.finishStart(intent)
         assertSame(failureResult, result)
     }
@@ -340,7 +340,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns canceledResult
 
         val request = PayPalWebCheckoutRequest("fake-order-id")
-        sut.start(activity, request)
+            sut.startTemp(activity, request)
         val result = sut.finishStart(intent)
         assertSame(canceledResult, result)
     }
@@ -375,7 +375,7 @@ class PayPalWebCheckoutClientUnitTest {
                 patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility
         )
         val request = PayPalWebCheckoutRequest("fake-order-id")
-            launchWithUrlClient.start(activity, request)
+            launchWithUrlClient.startTemp(activity, request)
 
             sut.restore(launchWithUrlClient.instanceState)
         val result = sut.finishStart(intent)
@@ -402,7 +402,7 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
         } returns successResult
 
-        sut.start(activity, PayPalWebCheckoutRequest("fake-order-id"))
+            sut.startTemp(activity, PayPalWebCheckoutRequest("fake-order-id"))
         sut.finishStart(intent)
         assertNull(sut.finishStart(intent))
     }
@@ -427,7 +427,7 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
         } returns failureResult
 
-        sut.start(activity, PayPalWebCheckoutRequest("fake-order-id"))
+            sut.startTemp(activity, PayPalWebCheckoutRequest("fake-order-id"))
         sut.finishStart(intent)
         assertNull(sut.finishStart(intent))
     }
@@ -451,7 +451,7 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
         } returns canceledResult
 
-        sut.start(activity, PayPalWebCheckoutRequest("fake-order-id"))
+            sut.startTemp(activity, PayPalWebCheckoutRequest("fake-order-id"))
         sut.finishStart(intent)
         assertNull(sut.finishStart(intent))
     }
@@ -535,7 +535,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns launchResult
 
         // When
-        val result = sut.start(activity, request)
+        val result = sut.startTemp(activity, request)
 
         // Then
         coVerify {
@@ -577,7 +577,7 @@ class PayPalWebCheckoutClientUnitTest {
             } returns launchResult
 
             // When
-            val result = sut.start(activity, request)
+            val result = sut.startTemp(activity, request)
 
             // Then
             verify {
@@ -609,7 +609,7 @@ class PayPalWebCheckoutClientUnitTest {
             } returns launchResult
 
             // When
-            val result = sut.start(activity, request)
+            val result = sut.startTemp(activity, request)
 
             // Then
             verify {
@@ -650,7 +650,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns launchResult
 
         // When
-        val result = sut.start(activity, request)
+        val result = sut.startTemp(activity, request)
 
         // Then
         coVerify { patchCCOWithAppSwitchEligibility(any(), any(), any(), any(), any()) }
@@ -685,7 +685,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns launchResult
 
         // When
-        val result = sut.start(activity, request)
+        val result = sut.startTemp(activity, request)
 
         // Then
         coVerify(exactly = 0) {
@@ -718,7 +718,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns PayPalPresentAuthChallengeResult.Success("state")
 
         // When
-        sut.start(activity, request)
+        sut.startTemp(activity, request)
 
         // Then
         coVerify {
@@ -769,7 +769,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns launchResult
 
         // When
-        val result = sut.vault(activity, request)
+        val result = sut.vaultTemp(activity, request)
 
         // Then
         coVerify {
@@ -811,7 +811,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns launchResult
 
         // When
-        val result = sut.vault(activity, request)
+        val result = sut.vaultTemp(activity, request)
 
         // Then
         coVerify {
@@ -852,7 +852,7 @@ class PayPalWebCheckoutClientUnitTest {
             } returns launchResult
 
             // When
-            val result = sut.vault(activity, request)
+            val result = sut.vaultTemp(activity, request)
 
             // Then
             verify {
@@ -889,7 +889,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns launchResult
 
         // When
-        val result = sut.vault(activity, request)
+        val result = sut.vaultTemp(activity, request)
 
         // Then
         verify {
@@ -920,7 +920,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns launchResult
 
         // When
-        val result = sut.vault(activity, request)
+        val result = sut.vaultTemp(activity, request)
 
         // Then
         coVerify(exactly = 0) {
@@ -953,7 +953,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns PayPalPresentAuthChallengeResult.Success("state")
 
         // When
-        sut.vault(activity, request)
+        sut.vaultTemp(activity, request)
 
         // Then
         coVerify {
@@ -980,7 +980,7 @@ class PayPalWebCheckoutClientUnitTest {
             } returns launchResult
 
             // When
-            val result = sut.start(activity, request)
+            val result = sut.startTemp(activity, request)
 
             // Then
             coVerify(exactly = 0) {
@@ -1010,7 +1010,7 @@ class PayPalWebCheckoutClientUnitTest {
             } returns launchResult
 
             // When
-            val result = sut.vault(activity, request)
+            val result = sut.vaultTemp(activity, request)
 
             // Then
             coVerify(exactly = 0) {
@@ -1040,7 +1040,7 @@ class PayPalWebCheckoutClientUnitTest {
             } returns launchResult
 
             // When
-            val result = sut.start(activity, request)
+            val result = sut.startTemp(activity, request)
 
             // Then
             coVerify(exactly = 0) {
@@ -1070,7 +1070,7 @@ class PayPalWebCheckoutClientUnitTest {
             } returns launchResult
 
             // When
-            val result = sut.vault(activity, request)
+            val result = sut.vaultTemp(activity, request)
 
             // Then
             coVerify(exactly = 0) {
@@ -1123,7 +1123,7 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns successResult
 
-            previousClient.vault(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            previousClient.vaultTemp(activity, PayPalWebVaultRequest("fake-setup-token-id"))
 
             sut.restore(previousClient.instanceState)
             val result = sut.finishVault(intent) as PayPalWebCheckoutFinishVaultResult.Success
@@ -1161,7 +1161,7 @@ class PayPalWebCheckoutClientUnitTest {
                 payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
             } returns successResult
 
-            previousClient.vault(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            previousClient.vaultTemp(activity, PayPalWebVaultRequest("fake-setup-token-id"))
 
         sut.restore(previousClient.instanceState)
         val result = sut.finishVault(intent) as PayPalWebCheckoutFinishVaultResult.Success
@@ -1187,7 +1187,7 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns PayPalWebCheckoutFinishVaultResult.Failure(error)
 
-        sut.vault(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            sut.vaultTemp(activity, PayPalWebVaultRequest("fake-setup-token-id"))
         val result = sut.finishVault(intent) as PayPalWebCheckoutFinishVaultResult.Failure
         assertSame(error, result.error)
     }
@@ -1211,7 +1211,7 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns PayPalWebCheckoutFinishVaultResult.Failure(error)
 
-            sut.vault(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            sut.vaultTemp(activity, PayPalWebVaultRequest("fake-setup-token-id"))
 
             sut.restore(sut.instanceState)
         val result = sut.finishVault(intent) as PayPalWebCheckoutFinishVaultResult.Failure
@@ -1236,7 +1236,7 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns PayPalWebCheckoutFinishVaultResult.Canceled
 
-        sut.vault(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            sut.vaultTemp(activity, PayPalWebVaultRequest("fake-setup-token-id"))
         val result = sut.finishVault(intent)
         assertSame(PayPalWebCheckoutFinishVaultResult.Canceled, result)
     }
@@ -1259,7 +1259,7 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns PayPalWebCheckoutFinishVaultResult.Canceled
 
-            sut.vault(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            sut.vaultTemp(activity, PayPalWebVaultRequest("fake-setup-token-id"))
 
             sut.restore(sut.instanceState)
         val result = sut.finishVault(intent)
@@ -1286,7 +1286,7 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns successResult
 
-        sut.vault(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            sut.vaultTemp(activity, PayPalWebVaultRequest("fake-setup-token-id"))
         sut.finishVault(intent)
         assertNull(sut.finishVault(intent))
     }
@@ -1310,7 +1310,7 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns PayPalWebCheckoutFinishVaultResult.Failure(error)
 
-        sut.vault(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            sut.vaultTemp(activity, PayPalWebVaultRequest("fake-setup-token-id"))
         sut.finishVault(intent)
         assertNull(sut.finishVault(intent))
     }
@@ -1333,7 +1333,7 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns PayPalWebCheckoutFinishVaultResult.Canceled
 
-        sut.vault(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            sut.vaultTemp(activity, PayPalWebVaultRequest("fake-setup-token-id"))
         sut.finishVault(intent)
         assertNull(sut.finishVault(intent))
     }
@@ -1368,7 +1368,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns launchResult
 
         // When
-        clientWithUrlScheme.start(activity, request)
+        clientWithUrlScheme.startTemp(activity, request)
 
         // Then
         verify {
@@ -1413,7 +1413,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns launchResult
 
         // When
-        clientWithUrlScheme.vault(activity, request)
+        clientWithUrlScheme.vaultTemp(activity, request)
 
         // Then
         verify {
@@ -1460,7 +1460,7 @@ class PayPalWebCheckoutClientUnitTest {
             } returns launchResult
 
             // When
-            clientWithUrlScheme.start(activity, request)
+            clientWithUrlScheme.startTemp(activity, request)
 
             // Then
             verify {
@@ -1507,7 +1507,7 @@ class PayPalWebCheckoutClientUnitTest {
             } returns launchResult
 
             // When
-            clientWithUrlScheme.vault(activity, request)
+            clientWithUrlScheme.vaultTemp(activity, request)
 
             // Then
             verify {

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -1674,6 +1674,226 @@ class PayPalWebCheckoutClientUnitTest {
         sut.vault(activity, request, callback)
     }
 
+    // Tests for fallbackUrlScheme functionality
+
+    @Test
+    fun `startAsync() uses fallbackUrlScheme when provided`() = runTest {
+        val fallbackScheme = "com.example.fallback"
+        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
+        every {
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+        } returns launchResult
+
+        val request = PayPalWebCheckoutRequest(
+            orderId = "fake-order-id",
+            fallbackUrlScheme = fallbackScheme
+        )
+        sut.startAsync(activity, request)
+
+        verify(exactly = 1) {
+            payPalWebLauncher.launchWithUrl(
+                activity = activity,
+                uri = any(),
+                token = "fake-order-id",
+                tokenType = TokenType.ORDER_ID,
+                returnUrlScheme = fallbackScheme,
+                appLinkUrl = null
+            )
+        }
+    }
+
+    @Test
+    fun `startAsync() uses default urlScheme when fallbackUrlScheme is null`() = runTest {
+        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
+        every {
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+        } returns launchResult
+
+        val request = PayPalWebCheckoutRequest(
+            orderId = "fake-order-id",
+            fallbackUrlScheme = null
+        )
+        sut.startAsync(activity, request)
+
+        verify(exactly = 1) {
+            payPalWebLauncher.launchWithUrl(
+                activity = activity,
+                uri = any(),
+                token = "fake-order-id",
+                tokenType = TokenType.ORDER_ID,
+                returnUrlScheme = null,
+                appLinkUrl = null
+            )
+        }
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `start() with deprecated method uses fallbackUrlScheme when provided`() {
+        val fallbackScheme = "com.example.fallback"
+        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
+        every {
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+        } returns launchResult
+
+        val request = PayPalWebCheckoutRequest(
+            orderId = "fake-order-id",
+            fallbackUrlScheme = fallbackScheme
+        )
+        sut.start(activity, request)
+
+        verify(exactly = 1) {
+            payPalWebLauncher.launchWithUrl(
+                activity = activity,
+                uri = any(),
+                token = "fake-order-id",
+                tokenType = TokenType.ORDER_ID,
+                returnUrlScheme = fallbackScheme,
+                appLinkUrl = null
+            )
+        }
+    }
+
+    @Test
+    fun `start() with callback uses fallbackUrlScheme when provided`() {
+        val fallbackScheme = "com.example.fallback"
+        val callback = mockk<PayPalWebStartCallback>(relaxed = true)
+        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
+        every {
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+        } returns launchResult
+
+        val request = PayPalWebCheckoutRequest(
+            orderId = "fake-order-id",
+            fallbackUrlScheme = fallbackScheme
+        )
+        sut.start(activity, request, callback)
+
+        verify(exactly = 1) {
+            payPalWebLauncher.launchWithUrl(
+                activity = activity,
+                uri = any(),
+                token = "fake-order-id",
+                tokenType = TokenType.ORDER_ID,
+                returnUrlScheme = fallbackScheme,
+                appLinkUrl = null
+            )
+        }
+    }
+
+    @Test
+    fun `vaultAsync() uses fallbackUrlScheme when provided`() = runTest {
+        val fallbackScheme = "com.example.fallback"
+        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
+        every {
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+        } returns launchResult
+
+        val request = PayPalWebVaultRequest(
+            setupTokenId = "fake-setup-token-id",
+            fallbackUrlScheme = fallbackScheme
+        )
+        sut.vaultAsync(activity, request)
+
+        verify(exactly = 1) {
+            payPalWebLauncher.launchWithUrl(
+                activity = activity,
+                uri = any(),
+                token = "fake-setup-token-id",
+                tokenType = TokenType.VAULT_ID,
+                returnUrlScheme = fallbackScheme,
+                appLinkUrl = null
+            )
+        }
+    }
+
+    @Test
+    fun `vaultAsync() uses default urlScheme when fallbackUrlScheme is null`() = runTest {
+        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
+        every {
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+        } returns launchResult
+
+        val request = PayPalWebVaultRequest(
+            setupTokenId = "fake-setup-token-id",
+            fallbackUrlScheme = null
+        )
+        sut.vaultAsync(activity, request)
+
+        verify(exactly = 1) {
+            payPalWebLauncher.launchWithUrl(
+                activity = activity,
+                uri = any(),
+                token = "fake-setup-token-id",
+                tokenType = TokenType.VAULT_ID,
+                returnUrlScheme = null,
+                appLinkUrl = null
+            )
+        }
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `vault() with deprecated method uses fallbackUrlScheme when provided`() {
+        val fallbackScheme = "com.example.fallback"
+        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
+        every {
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+        } returns launchResult
+
+        val request = PayPalWebVaultRequest(
+            setupTokenId = "fake-setup-token-id",
+            fallbackUrlScheme = fallbackScheme
+        )
+        sut.vault(activity, request)
+
+        verify(exactly = 1) {
+            payPalWebLauncher.launchWithUrl(
+                activity = activity,
+                uri = any(),
+                token = "fake-setup-token-id",
+                tokenType = TokenType.VAULT_ID,
+                returnUrlScheme = fallbackScheme,
+                appLinkUrl = null
+            )
+        }
+    }
+
+    @Test
+    fun `vault() with callback uses fallbackUrlScheme when provided`() {
+        // This test verifies the callback method can be called with fallbackUrlScheme without throwing
+        val fallbackScheme = "com.example.fallback"
+        val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
+        every {
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+        } returns PayPalPresentAuthChallengeResult.Success("auth state")
+
+        val request = PayPalWebVaultRequest(
+            setupTokenId = "fake-setup-token-id",
+            fallbackUrlScheme = fallbackScheme
+        )
+
+        // This should not throw an exception
+        sut.vault(activity, request, callback)
+    }
+
+    @Test
+    fun `vault() with callback uses default urlScheme when fallbackUrlScheme is null`() {
+        // This test verifies the callback method can be called with null fallbackUrlScheme without throwing
+        val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
+        every {
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+        } returns PayPalPresentAuthChallengeResult.Success("auth state")
+
+        val request = PayPalWebVaultRequest(
+            setupTokenId = "fake-setup-token-id",
+            fallbackUrlScheme = null
+        )
+
+        // This should not throw an exception
+        sut.vault(activity, request, callback)
+    }
+
     fun createAppSwithEligibility(launchUrl: String?) = AppSwitchEligibilityData(
         appSwitchEligible = !launchUrl.isNullOrEmpty(),
         redirectURL = launchUrl,

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
@@ -8,7 +8,8 @@ import com.braintreepayments.api.BrowserSwitchClient
 import com.braintreepayments.api.BrowserSwitchFinalResult
 import com.braintreepayments.api.BrowserSwitchOptions
 import com.braintreepayments.api.BrowserSwitchStartResult
-import com.paypal.android.corepayments.BrowserSwitchRequestCodes
+import com.paypal.android.corepayments.BrowserSwitchRequestCodes.PAYPAL_CHECKOUT
+import com.paypal.android.corepayments.BrowserSwitchRequestCodes.PAYPAL_VAULT
 import com.paypal.android.corepayments.model.TokenType
 import io.mockk.every
 import io.mockk.mockk
@@ -61,7 +62,7 @@ class PayPalWebLauncherUnitTest {
             get { metadata?.get("order_id") }.isEqualTo("fake-order-id")
             get { returnUrlScheme }.isEqualTo("com.example.app")
             get { url }.isEqualTo(Uri.parse("https://www.sandbox.paypal.com/checkoutnow"))
-            get { requestCode }.isEqualTo(BrowserSwitchRequestCodes.PAYPAL_CHECKOUT)
+            get { requestCode }.isEqualTo(PAYPAL_CHECKOUT)
         }
     }
 
@@ -87,7 +88,7 @@ class PayPalWebLauncherUnitTest {
             get { metadata?.get("order_id") }.isEqualTo("fake-order-id")
             get { returnUrlScheme }.isEqualTo("com.example.app")
             get { url }.isEqualTo(Uri.parse("https://www.paypal.com/checkoutnow"))
-            get { requestCode }.isEqualTo(BrowserSwitchRequestCodes.PAYPAL_CHECKOUT)
+            get { requestCode }.isEqualTo(PAYPAL_CHECKOUT)
         }
     }
 
@@ -113,7 +114,7 @@ class PayPalWebLauncherUnitTest {
             get { metadata?.get("order_id") }.isEqualTo("fake-order-id")
             get { returnUrlScheme }.isEqualTo("com.example.app")
             get { url }.isEqualTo(Uri.parse("https://www.paypal.com/checkoutnow"))
-            get { requestCode }.isEqualTo(BrowserSwitchRequestCodes.PAYPAL_CHECKOUT)
+            get { requestCode }.isEqualTo(PAYPAL_CHECKOUT)
         }
     }
 
@@ -139,7 +140,7 @@ class PayPalWebLauncherUnitTest {
             get { metadata?.get("order_id") }.isEqualTo("fake-order-id")
             get { returnUrlScheme }.isEqualTo("com.example.app")
             get { url }.isEqualTo(Uri.parse("https://www.paypal.com/checkoutnow"))
-            get { requestCode }.isEqualTo(BrowserSwitchRequestCodes.PAYPAL_CHECKOUT)
+            get { requestCode }.isEqualTo(PAYPAL_CHECKOUT)
         }
     }
 
@@ -185,7 +186,7 @@ class PayPalWebLauncherUnitTest {
             get { metadata?.get("setup_token_id") }.isEqualTo("fake-setup-token")
             get { returnUrlScheme }.isEqualTo("com.example.app")
             get { url }.isEqualTo(Uri.parse("https://sandbox.paypal.com/agreements/approve"))
-            get { requestCode }.isEqualTo(BrowserSwitchRequestCodes.PAYPAL_VAULT)
+            get { requestCode }.isEqualTo(PAYPAL_VAULT)
         }
     }
 
@@ -211,7 +212,7 @@ class PayPalWebLauncherUnitTest {
             get { metadata?.get("setup_token_id") }.isEqualTo("fake-setup-token")
             get { returnUrlScheme }.isEqualTo("com.example.app")
             get { url }.isEqualTo(Uri.parse("https://paypal.com/agreements/approve"))
-            get { requestCode }.isEqualTo(BrowserSwitchRequestCodes.PAYPAL_VAULT)
+            get { requestCode }.isEqualTo(PAYPAL_VAULT)
         }
     }
 
@@ -238,7 +239,7 @@ class PayPalWebLauncherUnitTest {
     @Test
     fun `completeCheckoutAuthRequest() parses successful checkout result`() {
         val browserSwitchResult = createCheckoutSuccessBrowserSwitchResult(
-            requestCode = BrowserSwitchRequestCodes.PAYPAL_CHECKOUT,
+            requestCode = PAYPAL_CHECKOUT,
             orderId = "fake-order-id",
             payerId = "fake-payer-id"
         )
@@ -258,7 +259,7 @@ class PayPalWebLauncherUnitTest {
     @Test
     fun `completeCheckoutAuthRequest() parses checkout failure when Payer Id is blank`() {
         val browserSwitchResult = createCheckoutSuccessBrowserSwitchResult(
-            requestCode = BrowserSwitchRequestCodes.PAYPAL_CHECKOUT,
+            requestCode = PAYPAL_CHECKOUT,
             orderId = "fake-order-id",
             payerId = ""
         )
@@ -277,7 +278,7 @@ class PayPalWebLauncherUnitTest {
     @Test
     fun `completeCheckoutAuthRequest() parses checkout failure when Order Id is blank`() {
         val browserSwitchResult = createCheckoutSuccessBrowserSwitchResult(
-            requestCode = BrowserSwitchRequestCodes.PAYPAL_CHECKOUT,
+            requestCode = PAYPAL_CHECKOUT,
             orderId = "",
             payerId = "fake-payer-id"
         )
@@ -296,7 +297,7 @@ class PayPalWebLauncherUnitTest {
     @Test
     fun `completeCheckoutAuthRequest() parses checkout failure when metadata is null`() {
         val browserSwitchResult = createCheckoutSuccessBrowserSwitchResult(
-            requestCode = BrowserSwitchRequestCodes.PAYPAL_CHECKOUT,
+            requestCode = PAYPAL_CHECKOUT,
             payerId = "fake-payer-id",
             metadata = null
         )
@@ -314,10 +315,7 @@ class PayPalWebLauncherUnitTest {
 
     @Test
     fun `completeCheckoutAuthRequest() parses checkout cancellation deep link url indicates failure`() {
-        val browserSwitchResult = createCheckoutCancellationBrowserSwitchResult(
-            requestCode = BrowserSwitchRequestCodes.PAYPAL_CHECKOUT,
-            orderId = "fake-order-id"
-        )
+        val browserSwitchResult = createCheckoutCancellationBrowserSwitchResult()
 
         every {
             browserSwitchClient.completeRequest(intent, "pending request")
@@ -332,7 +330,7 @@ class PayPalWebLauncherUnitTest {
     @Test
     fun `completeVaultAuthRequest() parses successful vault result`() {
         val browserSwitchResult = createVaultSuccessBrowserSwitchResult(
-            requestCode = BrowserSwitchRequestCodes.PAYPAL_VAULT,
+            requestCode = PAYPAL_VAULT,
             setupTokenId = "fake-setup-token-id",
             approvalSessionId = "fake-approval-session-id",
         )
@@ -348,11 +346,7 @@ class PayPalWebLauncherUnitTest {
 
     @Test
     fun `completeVaultAuthRequest() parses cancellation vault result when deep link path contains the word cancel`() {
-        val browserSwitchResult = createVaultCancellationBrowserSwitchResult(
-            requestCode = BrowserSwitchRequestCodes.PAYPAL_VAULT,
-            setupTokenId = "fake-setup-token-id",
-            approvalSessionId = "fake-approval-session-id",
-        )
+        val browserSwitchResult = createVaultCancellationBrowserSwitchResult()
         every {
             browserSwitchClient.completeRequest(intent, "pending request")
         } returns browserSwitchResult
@@ -365,7 +359,7 @@ class PayPalWebLauncherUnitTest {
     @Test
     fun `completeVaultAuthRequest() parses vault failure when approval session id is blank`() {
         val browserSwitchResult = createVaultSuccessBrowserSwitchResult(
-            requestCode = BrowserSwitchRequestCodes.PAYPAL_VAULT,
+            requestCode = PAYPAL_VAULT,
             setupTokenId = "fake-setup-token-id",
             approvalSessionId = "",
         )
@@ -395,13 +389,10 @@ class PayPalWebLauncherUnitTest {
         deepLinkUrl: Uri = createCheckoutDeepLinkUrl(payerId!!)
     ) = createBrowserSwitchSuccessFinalResult(requestCode, metadata, deepLinkUrl)
 
-    private fun createCheckoutCancellationBrowserSwitchResult(
-        requestCode: Int,
-        orderId: String,
-    ): BrowserSwitchFinalResult.Success {
+    private fun createCheckoutCancellationBrowserSwitchResult(): BrowserSwitchFinalResult.Success {
         val deepLinkUrl = "http://testurl.com/checkout?opType=cancel".toUri()
-        val metadata = createCheckoutMetadata(orderId)
-        return createBrowserSwitchSuccessFinalResult(requestCode, metadata, deepLinkUrl)
+        val metadata = createCheckoutMetadata("fake-order-id")
+        return createBrowserSwitchSuccessFinalResult(PAYPAL_CHECKOUT, metadata, deepLinkUrl)
     }
 
     private fun createVaultMetadata(setupTokenId: String) = JSONObject()
@@ -418,15 +409,11 @@ class PayPalWebLauncherUnitTest {
         deepLinkUrl: Uri = createVaultDeepLinkUrl(approvalSessionId!!)
     ) = createBrowserSwitchSuccessFinalResult(requestCode, metadata, deepLinkUrl)
 
-    private fun createVaultCancellationBrowserSwitchResult(
-        requestCode: Int,
-        setupTokenId: String,
-        approvalSessionId: String
-    ): BrowserSwitchFinalResult.Success {
-        val metadata = createVaultMetadata(setupTokenId)
+    private fun createVaultCancellationBrowserSwitchResult(): BrowserSwitchFinalResult.Success {
+        val metadata = createVaultMetadata("fake-setup-token-id")
         val deepLinkUrl =
-            "http://testurl.com/checkout/cancel?approval_session_id=$approvalSessionId".toUri()
-        return createBrowserSwitchSuccessFinalResult(requestCode, metadata, deepLinkUrl)
+            "http://testurl.com/checkout/cancel?approval_session_id=fake-approval-session-id".toUri()
+        return createBrowserSwitchSuccessFinalResult(PAYPAL_VAULT, metadata, deepLinkUrl)
     }
 
     private fun createBrowserSwitchSuccessFinalResult(
@@ -466,7 +453,7 @@ class PayPalWebLauncherUnitTest {
             get { metadata?.get("order_id") }.isEqualTo("order-123")
             get { returnUrlScheme }.isEqualTo("custom_url_scheme")
             get { url }.isEqualTo(Uri.parse("https://paypal.com/app-switch"))
-            get { requestCode }.isEqualTo(BrowserSwitchRequestCodes.PAYPAL_CHECKOUT)
+            get { requestCode }.isEqualTo(PAYPAL_CHECKOUT)
         }
     }
 
@@ -492,7 +479,7 @@ class PayPalWebLauncherUnitTest {
             get { metadata?.get("setup_token_id") }.isEqualTo("setup-456")
             get { returnUrlScheme }.isEqualTo("custom_url_scheme")
             get { url }.isEqualTo(Uri.parse("https://paypal.com/vault-switch"))
-            get { requestCode }.isEqualTo(BrowserSwitchRequestCodes.PAYPAL_VAULT)
+            get { requestCode }.isEqualTo(PAYPAL_VAULT)
         }
     }
 
@@ -515,5 +502,119 @@ class PayPalWebLauncherUnitTest {
             )
                     as PayPalPresentAuthChallengeResult.Failure
         assertEquals("error message from browser switch", result.error.errorDescription)
+    }
+
+    @Test
+    fun `launchWithUrl() with appLinkUrl sets appLinkUri and nullifies returnUrlScheme`() {
+        sut = PayPalWebLauncher(browserSwitchClient)
+
+        val slot = slot<BrowserSwitchOptions>()
+        every {
+            browserSwitchClient.start(activity, capture(slot))
+        } returns BrowserSwitchStartResult.Started("pending request")
+
+        val appLinkUrl = "https://example.com/return"
+        sut.launchWithUrl(
+            activity,
+            Uri.parse("https://paypal.com/checkout"),
+            "order-123",
+            TokenType.ORDER_ID,
+            "custom_url_scheme",
+            appLinkUrl
+        )
+
+        val browserSwitchOptions = slot.captured
+        expectThat(browserSwitchOptions) {
+            get { metadata?.get("order_id") }.isEqualTo("order-123")
+            get { returnUrlScheme }.isEqualTo(null) // Should be null when appLinkUrl is provided
+            get { url }.isEqualTo(Uri.parse("https://paypal.com/checkout"))
+            get { requestCode }.isEqualTo(PAYPAL_CHECKOUT)
+            get { appLinkUri }.isEqualTo(appLinkUrl.toUri())
+        }
+    }
+
+    @Test
+    fun `launchWithUrl() with null appLinkUrl uses returnUrlScheme`() {
+        sut = PayPalWebLauncher(browserSwitchClient)
+
+        val slot = slot<BrowserSwitchOptions>()
+        every {
+            browserSwitchClient.start(activity, capture(slot))
+        } returns BrowserSwitchStartResult.Started("pending request")
+
+        sut.launchWithUrl(
+            activity,
+            Uri.parse("https://paypal.com/checkout"),
+            "order-123",
+            TokenType.ORDER_ID,
+            "custom_url_scheme",
+            null
+        )
+
+        val browserSwitchOptions = slot.captured
+        expectThat(browserSwitchOptions) {
+            get { metadata?.get("order_id") }.isEqualTo("order-123")
+            get { returnUrlScheme }.isEqualTo("custom_url_scheme")
+            get { url }.isEqualTo(Uri.parse("https://paypal.com/checkout"))
+            get { requestCode }.isEqualTo(PAYPAL_CHECKOUT)
+            get { appLinkUri }.isEqualTo(null)
+        }
+    }
+
+    @Test
+    fun `launchWithUrl() with vault token and appLinkUrl works correctly`() {
+        sut = PayPalWebLauncher(browserSwitchClient)
+
+        val slot = slot<BrowserSwitchOptions>()
+        every {
+            browserSwitchClient.start(activity, capture(slot))
+        } returns BrowserSwitchStartResult.Started("pending request")
+
+        val appLinkUrl = "https://example.com/vault/return"
+        sut.launchWithUrl(
+            activity,
+            Uri.parse("https://paypal.com/vault"),
+            "setup-456",
+            TokenType.VAULT_ID,
+            "custom_url_scheme",
+            appLinkUrl
+        )
+
+        val browserSwitchOptions = slot.captured
+        expectThat(browserSwitchOptions) {
+            get { metadata?.get("setup_token_id") }.isEqualTo("setup-456")
+            get { returnUrlScheme }.isEqualTo(null) // Should be null when appLinkUrl is provided
+            get { url }.isEqualTo(Uri.parse("https://paypal.com/vault"))
+            get { requestCode }.isEqualTo(PAYPAL_VAULT)
+            get { appLinkUri }.isEqualTo(appLinkUrl.toUri())
+        }
+    }
+
+    @Test
+    fun `launchWithUrl() with default parameters maintains backward compatibility`() {
+        sut = PayPalWebLauncher(browserSwitchClient)
+
+        val slot = slot<BrowserSwitchOptions>()
+        every {
+            browserSwitchClient.start(activity, capture(slot))
+        } returns BrowserSwitchStartResult.Started("pending request")
+
+        // Call with old signature (should default appLinkUrl to null)
+        sut.launchWithUrl(
+            activity,
+            Uri.parse("https://paypal.com/checkout"),
+            "order-123",
+            TokenType.ORDER_ID,
+            "custom_url_scheme"
+        )
+
+        val browserSwitchOptions = slot.captured
+        expectThat(browserSwitchOptions) {
+            get { metadata?.get("order_id") }.isEqualTo("order-123")
+            get { returnUrlScheme }.isEqualTo("custom_url_scheme")
+            get { url }.isEqualTo(Uri.parse("https://paypal.com/checkout"))
+            get { requestCode }.isEqualTo(PAYPAL_CHECKOUT)
+            get { appLinkUri }.isEqualTo(null)
+        }
     }
 }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
@@ -505,7 +505,7 @@ class PayPalWebLauncherUnitTest {
     }
 
     @Test
-    fun `launchWithUrl() with appLinkUrl sets appLinkUri and nullifies returnUrlScheme`() {
+    fun `launchWithUrl() with appLinkUrl sets appLinkUri and returnUrlScheme`() {
         sut = PayPalWebLauncher(browserSwitchClient)
 
         val slot = slot<BrowserSwitchOptions>()
@@ -526,7 +526,7 @@ class PayPalWebLauncherUnitTest {
         val browserSwitchOptions = slot.captured
         expectThat(browserSwitchOptions) {
             get { metadata?.get("order_id") }.isEqualTo("order-123")
-            get { returnUrlScheme }.isEqualTo(null) // Should be null when appLinkUrl is provided
+            get { returnUrlScheme }.isEqualTo("custom_url_scheme") // Should use provided returnUrlScheme as fallback
             get { url }.isEqualTo(Uri.parse("https://paypal.com/checkout"))
             get { requestCode }.isEqualTo(PAYPAL_CHECKOUT)
             get { appLinkUri }.isEqualTo(appLinkUrl.toUri())
@@ -583,7 +583,7 @@ class PayPalWebLauncherUnitTest {
         val browserSwitchOptions = slot.captured
         expectThat(browserSwitchOptions) {
             get { metadata?.get("setup_token_id") }.isEqualTo("setup-456")
-            get { returnUrlScheme }.isEqualTo(null) // Should be null when appLinkUrl is provided
+            get { returnUrlScheme }.isEqualTo("custom_url_scheme") // Should use provided returnUrlScheme as fallback
             get { url }.isEqualTo(Uri.parse("https://paypal.com/vault"))
             get { requestCode }.isEqualTo(PAYPAL_VAULT)
             get { appLinkUri }.isEqualTo(appLinkUrl.toUri())


### PR DESCRIPTION
### Summary of changes
 - Restores deprecated start, vault functions
 - adds `startAsync`, `vaultAsync` suspend functions
 - added`appLinkUrl` in `PayPalWebVaultRequest` and `PayPalWebCheckoutRequest` to support universal links
 - deprecated `urlScheme` in `PayPalWebCheckoutClient`
 - when `appLinkUrl` is not null then used for navigation, if not used `urlScheme`, if both are null then result will be failure, this logic is handled in Browser Switch
 - updated changelog

 ### Checklist
 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @kgangineni 
