### PR TITLE
Fix issue of null in return url when fallback custom url scheme is used

### DIFF
--- a/CorePayments/api/CorePayments.api
+++ b/CorePayments/api/CorePayments.api
@@ -105,6 +105,31 @@ public final class com/paypal/android/corepayments/PayPalSDKError : java/lang/Ex
 	public final fun getErrorDescription ()Ljava/lang/String;
 }
 
+public abstract class com/paypal/android/corepayments/ReturnToAppStrategy {
+}
+
+public final class com/paypal/android/corepayments/ReturnToAppStrategy$AppLink : com/paypal/android/corepayments/ReturnToAppStrategy {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/paypal/android/corepayments/ReturnToAppStrategy$AppLink;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/ReturnToAppStrategy$AppLink;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/ReturnToAppStrategy$AppLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppLinkUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/paypal/android/corepayments/ReturnToAppStrategy$CustomUrlScheme : com/paypal/android/corepayments/ReturnToAppStrategy {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/paypal/android/corepayments/ReturnToAppStrategy$CustomUrlScheme;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/ReturnToAppStrategy$CustomUrlScheme;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/ReturnToAppStrategy$CustomUrlScheme;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUrlScheme ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/paypal/android/corepayments/UpdateClientConfigAPI$Defaults {
 	public static final field INSTANCE Lcom/paypal/android/corepayments/UpdateClientConfigAPI$Defaults;
 	public static final field INTEGRATION_ARTIFACT Ljava/lang/String;

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/ReturnToAppStrategy.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/ReturnToAppStrategy.kt
@@ -1,5 +1,7 @@
 package com.paypal.android.corepayments
 
+import androidx.annotation.RestrictTo
+
 /**
  * Strategy for returning to the app after browser-based checkout flows.
  *
@@ -22,3 +24,14 @@ sealed class ReturnToAppStrategy {
      */
     data class CustomUrlScheme(val urlScheme: String) : ReturnToAppStrategy()
 }
+
+/**
+ * Builds return URL from return to app strategy.
+ */
+val ReturnToAppStrategy.returnUrl: String
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    get() = when (this) {
+        is ReturnToAppStrategy.AppLink -> this.appLinkUrl
+        is ReturnToAppStrategy.CustomUrlScheme ->
+            "${this.urlScheme}://x-callback-url/paypal-sdk/paypal-checkout"
+    }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/ReturnToAppStrategy.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/ReturnToAppStrategy.kt
@@ -1,0 +1,24 @@
+package com.paypal.android.corepayments
+
+/**
+ * Strategy for returning to the app after browser-based checkout flows.
+ *
+ * Use [AppLink] for Android App Links (https:// URLs) or [CustomUrlScheme] for custom URL schemes.
+ */
+sealed class ReturnToAppStrategy {
+    /**
+     * Return to app using Android App Links.
+     *
+     * @property appLinkUrl The app link URL to use for browser switch.
+     *   Example: "https://example.com/path"
+     */
+    data class AppLink(val appLinkUrl: String) : ReturnToAppStrategy()
+
+    /**
+     * Return to app using a custom URL scheme.
+     *
+     * @property urlScheme The custom URL scheme to use for browser switch.
+     *   Example: "myapp"
+     */
+    data class CustomUrlScheme(val urlScheme: String) : ReturnToAppStrategy()
+}

--- a/Demo/src/main/java/com/paypal/android/models/OrderRequest.kt
+++ b/Demo/src/main/java/com/paypal/android/models/OrderRequest.kt
@@ -1,13 +1,14 @@
 package com.paypal.android.models
 
 import com.paypal.android.api.model.OrderIntent
-import com.paypal.android.uishared.enums.DeepLinkStrategy
+import com.paypal.android.uishared.enums.ReturnToAppStrategyOption
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 @Serializable
 data class OrderRequest(
     val intent: OrderIntent,
     val shouldVaultOnSuccess: Boolean,
     val appSwitchWhenEligible: Boolean,
-    val deepLinkStrategy: DeepLinkStrategy
+    @Transient val returnToAppStrategy: ReturnToAppStrategyOption = ReturnToAppStrategyOption.APP_LINKS
 )

--- a/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderUiState.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderUiState.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Immutable
 import com.paypal.android.api.model.Order
 import com.paypal.android.api.model.OrderIntent
 import com.paypal.android.cardpayments.threedsecure.SCA
-import com.paypal.android.uishared.enums.DeepLinkStrategy
+import com.paypal.android.uishared.enums.ReturnToAppStrategyOption
 import com.paypal.android.uishared.enums.StoreInVaultOption
 import com.paypal.android.uishared.state.ActionState
 
@@ -19,7 +19,7 @@ data class ApproveOrderUiState(
     val cardSecurityCode: String = "",
     val intentOption: OrderIntent = OrderIntent.AUTHORIZE,
     val shouldVaultOption: StoreInVaultOption = StoreInVaultOption.NO,
-    val deepLinkStrategy: DeepLinkStrategy = DeepLinkStrategy.APP_LINKS
+    val returnToAppStrategyOption: ReturnToAppStrategyOption = ReturnToAppStrategyOption.APP_LINKS
 ) {
     val isCreateOrderSuccessful: Boolean
         get() = createOrderState is ActionState.Success

--- a/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderView.kt
@@ -96,8 +96,8 @@ private fun Step1_CreateOrder(uiState: ApproveOrderUiState, viewModel: ApproveOr
         EnumOptionList(
             title = stringResource(id = R.string.deep_link_strategy_title),
             stringArrayResId = R.array.deep_link_strategy_options,
-            onSelectedOptionChange = { value -> viewModel.deepLinkStrategy = value },
-            selectedOption = uiState.deepLinkStrategy
+            onSelectedOptionChange = { value -> viewModel.returnToAppStrategy = value },
+            selectedOption = uiState.returnToAppStrategyOption
         )
         ActionButtonColumn(
             defaultTitle = "CREATE ORDER",

--- a/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
@@ -21,7 +21,7 @@ import com.paypal.android.fraudprotection.PayPalDataCollector
 import com.paypal.android.fraudprotection.PayPalDataCollectorRequest
 import com.paypal.android.models.OrderRequest
 import com.paypal.android.models.TestCard
-import com.paypal.android.uishared.enums.DeepLinkStrategy
+import com.paypal.android.uishared.enums.ReturnToAppStrategyOption
 import com.paypal.android.uishared.enums.StoreInVaultOption
 import com.paypal.android.uishared.state.ActionState
 import com.paypal.android.usecase.CompleteOrderUseCase
@@ -54,7 +54,7 @@ class ApproveOrderViewModel @Inject constructor(
             createOrderState = ActionState.Loading
             val orderRequest = uiState.value.run {
                 val shouldVault = shouldVaultOption == StoreInVaultOption.ON_SUCCESS
-                OrderRequest(intentOption, shouldVault, false, deepLinkStrategy = deepLinkStrategy)
+                OrderRequest(intentOption, shouldVault, false)
             }
             createOrderState = createOrderUseCase(orderRequest).mapToActionState()
         }
@@ -83,7 +83,8 @@ class ApproveOrderViewModel @Inject constructor(
                 expirationYear = dateString.formattedYear,
                 securityCode = cardSecurityCode
             )
-            val returnUrl = ReturnUrlFactory.createGenericReturnUrl(deepLinkStrategy)
+            val returnUrl =
+                ReturnUrlFactory.createGenericReturnUrl(returnToAppStrategyOption.toReturnToAppStrategy())
             CardRequest(orderId, card, returnUrl, scaOption)
         }
         cardClient.approveOrder(cardRequest) { result ->
@@ -191,10 +192,10 @@ class ApproveOrderViewModel @Inject constructor(
             _uiState.update { it.copy(shouldVaultOption = value) }
         }
 
-    var deepLinkStrategy: DeepLinkStrategy
-        get() = _uiState.value.deepLinkStrategy
+    var returnToAppStrategy: ReturnToAppStrategyOption
+        get() = _uiState.value.returnToAppStrategyOption
         set(value) {
-            _uiState.update { it.copy(deepLinkStrategy = value) }
+            _uiState.update { it.copy(returnToAppStrategyOption = value) }
         }
 
     fun prefillCard(testCard: TestCard) {

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutView.kt
@@ -92,7 +92,7 @@ private fun Step1_CreateOrder(uiState: PayPalUiState, viewModel: PayPalCheckoutV
         EnumOptionList(
             title = stringResource(id = R.string.return_to_app_strategy_title),
             stringArrayResId = R.array.deep_link_strategy_options,
-            onSelectedOptionChange = { value -> viewModel.returnToAppStrategy = value },
+            onSelectedOptionChange = { value -> viewModel.returnToAppStrategyOption = value },
             selectedOption = uiState.returnToAppStrategyOption
         )
         ActionButtonColumn(

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutView.kt
@@ -90,10 +90,10 @@ private fun Step1_CreateOrder(uiState: PayPalUiState, viewModel: PayPalCheckoutV
             onOrderIntentChange = { value -> viewModel.intentOption = value },
         )
         EnumOptionList(
-            title = stringResource(id = R.string.deep_link_strategy_title),
+            title = stringResource(id = R.string.return_to_app_strategy_title),
             stringArrayResId = R.array.deep_link_strategy_options,
-            onSelectedOptionChange = { value -> viewModel.deepLinkStrategy = value },
-            selectedOption = uiState.deepLinkStrategy
+            onSelectedOptionChange = { value -> viewModel.returnToAppStrategy = value },
+            selectedOption = uiState.returnToAppStrategyOption
         )
         ActionButtonColumn(
             defaultTitle = "CREATE ORDER",

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
@@ -61,7 +61,7 @@ class PayPalCheckoutViewModel @Inject constructor(
             _uiState.update { it.copy(appSwitchWhenEligible = value) }
         }
 
-    var returnToAppStrategy: ReturnToAppStrategyOption
+    var returnToAppStrategyOption: ReturnToAppStrategyOption
         get() = _uiState.value.returnToAppStrategyOption
         set(value) {
             _uiState.update { it.copy(returnToAppStrategyOption = value) }
@@ -125,7 +125,7 @@ class PayPalCheckoutViewModel @Inject constructor(
             orderId,
             fundingSource,
             appSwitchWhenEligible,
-            returnToAppStrategy.toReturnToAppStrategy()
+            returnToAppStrategyOption.toReturnToAppStrategy()
         )
 
         paypalClient.start(activity, checkoutRequest) { startResult ->

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
@@ -6,8 +6,6 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.paypal.android.DemoConstants.APP_CUSTOM_URL_SCHEME
-import com.paypal.android.DemoConstants.APP_URL
 import com.paypal.android.api.model.Order
 import com.paypal.android.api.model.OrderIntent
 import com.paypal.android.api.services.SDKSampleServerAPI
@@ -20,7 +18,7 @@ import com.paypal.android.paypalwebpayments.PayPalWebCheckoutClient
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFinishStartResult
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFundingSource
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutRequest
-import com.paypal.android.uishared.enums.DeepLinkStrategy
+import com.paypal.android.uishared.enums.ReturnToAppStrategyOption
 import com.paypal.android.uishared.state.ActionState
 import com.paypal.android.usecase.CompleteOrderUseCase
 import com.paypal.android.usecase.CreateOrderUseCase
@@ -63,10 +61,10 @@ class PayPalCheckoutViewModel @Inject constructor(
             _uiState.update { it.copy(appSwitchWhenEligible = value) }
         }
 
-    var deepLinkStrategy
-        get() = _uiState.value.deepLinkStrategy
+    var returnToAppStrategy: ReturnToAppStrategyOption
+        get() = _uiState.value.returnToAppStrategyOption
         set(value) {
-            _uiState.update { it.copy(deepLinkStrategy = value) }
+            _uiState.update { it.copy(returnToAppStrategyOption = value) }
         }
 
     private var createOrderState
@@ -104,7 +102,7 @@ class PayPalCheckoutViewModel @Inject constructor(
                     intent = intentOption,
                     shouldVaultOnSuccess = false,
                     appSwitchWhenEligible = appSwitchWhenEligible,
-                    deepLinkStrategy = deepLinkStrategy
+                    returnToAppStrategy = returnToAppStrategyOption
                 )
             }
             createOrderState = createOrderUseCase(orderRequest).mapToActionState()
@@ -127,8 +125,7 @@ class PayPalCheckoutViewModel @Inject constructor(
             orderId,
             fundingSource,
             appSwitchWhenEligible,
-            if (deepLinkStrategy == DeepLinkStrategy.APP_LINKS) APP_URL else null,
-            APP_CUSTOM_URL_SCHEME
+            returnToAppStrategy.toReturnToAppStrategy()
         )
 
         paypalClient.start(activity, checkoutRequest) { startResult ->

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
@@ -20,6 +20,7 @@ import com.paypal.android.paypalwebpayments.PayPalWebCheckoutClient
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFinishStartResult
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFundingSource
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutRequest
+import com.paypal.android.uishared.enums.DeepLinkStrategy
 import com.paypal.android.uishared.state.ActionState
 import com.paypal.android.usecase.CompleteOrderUseCase
 import com.paypal.android.usecase.CreateOrderUseCase
@@ -126,7 +127,7 @@ class PayPalCheckoutViewModel @Inject constructor(
             orderId,
             fundingSource,
             appSwitchWhenEligible,
-            APP_URL,
+            if (deepLinkStrategy == DeepLinkStrategy.APP_LINKS) APP_URL else null,
             APP_CUSTOM_URL_SCHEME
         )
 

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalUiState.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalUiState.kt
@@ -4,7 +4,7 @@ import com.paypal.android.api.model.Order
 import com.paypal.android.api.model.OrderIntent
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFinishStartResult
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFundingSource
-import com.paypal.android.uishared.enums.DeepLinkStrategy
+import com.paypal.android.uishared.enums.ReturnToAppStrategyOption
 import com.paypal.android.uishared.state.ActionState
 
 data class PayPalUiState(
@@ -14,7 +14,7 @@ data class PayPalUiState(
     val completeOrderState: ActionState<Order, Exception> = ActionState.Idle,
     val fundingSource: PayPalWebCheckoutFundingSource = PayPalWebCheckoutFundingSource.PAYPAL,
     val appSwitchWhenEligible: Boolean = false,
-    val deepLinkStrategy: DeepLinkStrategy = DeepLinkStrategy.APP_LINKS,
+    val returnToAppStrategyOption: ReturnToAppStrategyOption = ReturnToAppStrategyOption.APP_LINKS,
 ) {
     val isCreateOrderSuccessful: Boolean
         get() = createOrderState is ActionState.Success

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultUiState.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultUiState.kt
@@ -3,7 +3,7 @@ package com.paypal.android.ui.paypalwebvault
 import com.paypal.android.api.model.PayPalPaymentToken
 import com.paypal.android.api.model.PayPalSetupToken
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFinishVaultResult
-import com.paypal.android.uishared.enums.DeepLinkStrategy
+import com.paypal.android.uishared.enums.ReturnToAppStrategyOption
 import com.paypal.android.uishared.state.ActionState
 
 data class PayPalVaultUiState(
@@ -11,7 +11,7 @@ data class PayPalVaultUiState(
     val vaultPayPalState: ActionState<PayPalWebCheckoutFinishVaultResult.Success, Exception> = ActionState.Idle,
     val createPaymentTokenState: ActionState<PayPalPaymentToken, Exception> = ActionState.Idle,
     val appSwitchWhenEligible: Boolean = false,
-    val deepLinkStrategy: DeepLinkStrategy = DeepLinkStrategy.APP_LINKS
+    val returnToAppStrategy: ReturnToAppStrategyOption = ReturnToAppStrategyOption.APP_LINKS
 ) {
     val isCreateSetupTokenSuccessful: Boolean
         get() = createSetupTokenState is ActionState.Success

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultView.kt
@@ -87,10 +87,10 @@ private fun Step1_CreateSetupToken(
             modifier = Modifier.fillMaxWidth()
         )
         EnumOptionList(
-            title = stringResource(id = R.string.deep_link_strategy_title),
+            title = stringResource(id = R.string.return_to_app_strategy_title),
             stringArrayResId = R.array.deep_link_strategy_options,
-            onSelectedOptionChange = { value -> viewModel.deepLinkStrategy = value },
-            selectedOption = uiState.deepLinkStrategy
+            onSelectedOptionChange = { value -> viewModel.returnToAppStrategy = value },
+            selectedOption = uiState.returnToAppStrategy
         )
         ActionButtonColumn(
             defaultTitle = "CREATE SETUP TOKEN",

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
@@ -14,6 +14,7 @@ import com.paypal.android.paypalwebpayments.PayPalPresentAuthChallengeResult
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutClient
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFinishVaultResult
 import com.paypal.android.paypalwebpayments.PayPalWebVaultRequest
+import com.paypal.android.uishared.enums.DeepLinkStrategy
 import com.paypal.android.uishared.state.ActionState
 import com.paypal.android.usecase.CreatePayPalPaymentTokenUseCase
 import com.paypal.android.usecase.CreatePayPalSetupTokenUseCase
@@ -89,7 +90,7 @@ class PayPalVaultViewModel @Inject constructor(
                 val request = PayPalWebVaultRequest(
                     setupTokenId,
                     appSwitchWhenEligible,
-                    APP_URL,
+                    if (deepLinkStrategy == DeepLinkStrategy.APP_LINKS) APP_URL else null,
                     APP_CUSTOM_URL_SCHEME
                 )
                 vaultSetupTokenWithRequest(activity, request)

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
@@ -5,8 +5,6 @@ import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.paypal.android.DemoConstants.APP_CUSTOM_URL_SCHEME
-import com.paypal.android.DemoConstants.APP_URL
 import com.paypal.android.api.model.PayPalSetupToken
 import com.paypal.android.api.services.SDKSampleServerAPI
 import com.paypal.android.corepayments.CoreConfig
@@ -14,7 +12,7 @@ import com.paypal.android.paypalwebpayments.PayPalPresentAuthChallengeResult
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutClient
 import com.paypal.android.paypalwebpayments.PayPalWebCheckoutFinishVaultResult
 import com.paypal.android.paypalwebpayments.PayPalWebVaultRequest
-import com.paypal.android.uishared.enums.DeepLinkStrategy
+import com.paypal.android.uishared.enums.ReturnToAppStrategyOption
 import com.paypal.android.uishared.state.ActionState
 import com.paypal.android.usecase.CreatePayPalPaymentTokenUseCase
 import com.paypal.android.usecase.CreatePayPalSetupTokenUseCase
@@ -62,10 +60,10 @@ class PayPalVaultViewModel @Inject constructor(
             _uiState.update { it.copy(appSwitchWhenEligible = value) }
         }
 
-    var deepLinkStrategy
-        get() = _uiState.value.deepLinkStrategy
+    var returnToAppStrategy: ReturnToAppStrategyOption
+        get() = _uiState.value.returnToAppStrategy
         set(value) {
-            _uiState.update { it.copy(deepLinkStrategy = value) }
+            _uiState.update { it.copy(returnToAppStrategy = value) }
         }
 
     fun createSetupToken() {
@@ -73,7 +71,7 @@ class PayPalVaultViewModel @Inject constructor(
             createSetupTokenState = ActionState.Loading
             createSetupTokenState = createPayPalSetupTokenUseCase(
                 appSwitchWhenEligible,
-                deepLinkStrategy
+                returnToAppStrategy.toReturnToAppStrategy()
             ).mapToActionState()
         }
     }
@@ -83,6 +81,7 @@ class PayPalVaultViewModel @Inject constructor(
 
     fun vaultSetupToken(activity: ComponentActivity) {
         val setupTokenId = createdSetupToken?.id
+
         if (setupTokenId == null) {
             vaultPayPalState = ActionState.Failure(Exception("Create a setup token to continue."))
         } else {
@@ -90,8 +89,7 @@ class PayPalVaultViewModel @Inject constructor(
                 val request = PayPalWebVaultRequest(
                     setupTokenId,
                     appSwitchWhenEligible,
-                    if (deepLinkStrategy == DeepLinkStrategy.APP_LINKS) APP_URL else null,
-                    APP_CUSTOM_URL_SCHEME
+                    returnToAppStrategy.toReturnToAppStrategy()
                 )
                 vaultSetupTokenWithRequest(activity, request)
             }

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardUiState.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardUiState.kt
@@ -2,9 +2,9 @@ package com.paypal.android.ui.vaultcard
 
 import com.paypal.android.api.model.CardPaymentToken
 import com.paypal.android.api.model.CardSetupToken
-import com.paypal.android.ui.approveorder.SetupTokenInfo
 import com.paypal.android.cardpayments.threedsecure.SCA
-import com.paypal.android.uishared.enums.DeepLinkStrategy
+import com.paypal.android.ui.approveorder.SetupTokenInfo
+import com.paypal.android.uishared.enums.ReturnToAppStrategyOption
 import com.paypal.android.uishared.state.ActionState
 
 data class VaultCardUiState(
@@ -15,7 +15,7 @@ data class VaultCardUiState(
     val cardExpirationDate: String = "",
     val cardSecurityCode: String = "",
     val scaOption: SCA = SCA.SCA_WHEN_REQUIRED,
-    val deepLinkStrategy: DeepLinkStrategy = DeepLinkStrategy.APP_LINKS,
+    val returnToAppStrategy: ReturnToAppStrategyOption = ReturnToAppStrategyOption.APP_LINKS,
 ) {
     val isCreateSetupTokenSuccessful: Boolean
         get() = createSetupTokenState is ActionState.Success

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardView.kt
@@ -95,8 +95,8 @@ private fun Step_CreateSetupToken(
         EnumOptionList(
             title = stringResource(id = R.string.deep_link_strategy_title),
             stringArrayResId = R.array.deep_link_strategy_options,
-            onSelectedOptionChange = { value -> viewModel.deepLinkStrategy = value },
-            selectedOption = uiState.deepLinkStrategy
+            onSelectedOptionChange = { value -> viewModel.returnToAppStrategy = value },
+            selectedOption = uiState.returnToAppStrategy
         )
         ActionButtonColumn(
             defaultTitle = "CREATE SETUP TOKEN",

--- a/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/vaultcard/VaultCardViewModel.kt
@@ -19,7 +19,7 @@ import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.models.TestCard
 import com.paypal.android.ui.approveorder.DateString
 import com.paypal.android.ui.approveorder.SetupTokenInfo
-import com.paypal.android.uishared.enums.DeepLinkStrategy
+import com.paypal.android.uishared.enums.ReturnToAppStrategyOption
 import com.paypal.android.uishared.state.ActionState
 import com.paypal.android.usecase.CreateCardPaymentTokenUseCase
 import com.paypal.android.usecase.CreateCardSetupTokenUseCase
@@ -90,10 +90,10 @@ class VaultCardViewModel @Inject constructor(
             _uiState.update { it.copy(scaOption = value) }
         }
 
-    var deepLinkStrategy: DeepLinkStrategy
-        get() = _uiState.value.deepLinkStrategy
+    var returnToAppStrategy: ReturnToAppStrategyOption
+        get() = _uiState.value.returnToAppStrategy
         set(value) {
-            _uiState.update { it.copy(deepLinkStrategy = value) }
+            _uiState.update { it.copy(returnToAppStrategy = value) }
         }
 
     fun prefillCard(testCard: TestCard) {
@@ -111,9 +111,12 @@ class VaultCardViewModel @Inject constructor(
         viewModelScope.launch {
             createSetupTokenState = ActionState.Loading
             val sca = _uiState.value.scaOption
-            val deepLinkStrategy = _uiState.value.deepLinkStrategy
+            val returnToAppStrategy = _uiState.value.returnToAppStrategy
             createSetupTokenState =
-                createSetupTokenUseCase(sca, deepLinkStrategy).mapToActionState()
+                createSetupTokenUseCase(
+                    sca,
+                    returnToAppStrategy.toReturnToAppStrategy()
+                ).mapToActionState()
         }
     }
 
@@ -132,7 +135,8 @@ class VaultCardViewModel @Inject constructor(
     private fun updateSetupTokenWithId(activity: ComponentActivity, setupTokenId: String) {
         updateSetupTokenState = ActionState.Loading
         val card = parseCard(_uiState.value)
-        val returnUrl = ReturnUrlFactory.createGenericReturnUrl(deepLinkStrategy)
+        val returnUrl =
+            ReturnUrlFactory.createGenericReturnUrl(returnToAppStrategy.toReturnToAppStrategy())
         val cardVaultRequest = CardVaultRequest(setupTokenId, card, returnUrl)
         cardClient.vault(cardVaultRequest) { result ->
             when (result) {

--- a/Demo/src/main/java/com/paypal/android/uishared/enums/DeepLinkStrategy.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/enums/DeepLinkStrategy.kt
@@ -1,5 +1,0 @@
-package com.paypal.android.uishared.enums
-
-enum class DeepLinkStrategy {
-    CUSTOM_URL_SCHEME, APP_LINKS
-}

--- a/Demo/src/main/java/com/paypal/android/uishared/enums/ReturnToAppStrategyOption.kt
+++ b/Demo/src/main/java/com/paypal/android/uishared/enums/ReturnToAppStrategyOption.kt
@@ -1,0 +1,14 @@
+package com.paypal.android.uishared.enums
+
+import com.paypal.android.DemoConstants
+import com.paypal.android.corepayments.ReturnToAppStrategy
+
+enum class ReturnToAppStrategyOption {
+    APP_LINKS,
+    CUSTOM_URL_SCHEME;
+
+    fun toReturnToAppStrategy(): ReturnToAppStrategy = when (this) {
+        APP_LINKS -> ReturnToAppStrategy.AppLink(DemoConstants.APP_URL)
+        CUSTOM_URL_SCHEME -> ReturnToAppStrategy.CustomUrlScheme(DemoConstants.APP_CUSTOM_URL_SCHEME)
+    }
+}

--- a/Demo/src/main/java/com/paypal/android/usecase/CreateCardSetupTokenUseCase.kt
+++ b/Demo/src/main/java/com/paypal/android/usecase/CreateCardSetupTokenUseCase.kt
@@ -8,7 +8,7 @@ import com.paypal.android.api.model.serialization.ExperienceContext
 import com.paypal.android.api.services.SDKSampleServerAPI
 import com.paypal.android.api.services.SDKSampleServerResult
 import com.paypal.android.cardpayments.threedsecure.SCA
-import com.paypal.android.uishared.enums.DeepLinkStrategy
+import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.utils.ReturnUrlFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -20,7 +20,7 @@ class CreateCardSetupTokenUseCase @Inject constructor(
 
     suspend operator fun invoke(
         sca: SCA,
-        deepLinkStrategy: DeepLinkStrategy
+        returnToAppStrategy: ReturnToAppStrategy
     ): SDKSampleServerResult<CardSetupToken, Exception> =
         withContext(Dispatchers.IO) {
             // create a payment token with an empty card attribute; the merchant app will
@@ -30,8 +30,8 @@ class CreateCardSetupTokenUseCase @Inject constructor(
                     card = CardDetails(
                         verificationMethod = sca.name,
                         experienceContext = ExperienceContext(
-                            returnUrl = ReturnUrlFactory.createVaultSuccessUrl(deepLinkStrategy),
-                            cancelUrl = ReturnUrlFactory.createVaultCancelUrl(deepLinkStrategy)
+                            returnUrl = ReturnUrlFactory.createVaultSuccessUrl(returnToAppStrategy),
+                            cancelUrl = ReturnUrlFactory.createVaultCancelUrl(returnToAppStrategy)
                         )
                     )
                 )

--- a/Demo/src/main/java/com/paypal/android/usecase/CreateOrderUseCase.kt
+++ b/Demo/src/main/java/com/paypal/android/usecase/CreateOrderUseCase.kt
@@ -26,13 +26,15 @@ class CreateOrderUseCase @Inject constructor(
     suspend operator fun invoke(request: OrderRequest): SDKSampleServerResult<Order, Exception> {
         val paymentSource = when {
             request.appSwitchWhenEligible -> {
-                val deepLinkStrategy = request.deepLinkStrategy
-                val appUrl = ReturnUrlFactory.createGenericReturnUrl(deepLinkStrategy)
+                val returnToAppStrategy = request.returnToAppStrategy.toReturnToAppStrategy()
+                val appUrl = ReturnUrlFactory.createGenericReturnUrl(returnToAppStrategy)
                 OrderPaymentSource(
                     paypal = PayPalPaymentSource(
                         experienceContext = PayPalOrderExperienceContext(
-                            returnUrl = ReturnUrlFactory.createCheckoutSuccessUrl(deepLinkStrategy),
-                            cancelUrl = ReturnUrlFactory.createCheckoutCancelUrl(deepLinkStrategy),
+                            returnUrl = ReturnUrlFactory.createCheckoutSuccessUrl(
+                                returnToAppStrategy
+                            ),
+                            cancelUrl = ReturnUrlFactory.createCheckoutCancelUrl(returnToAppStrategy),
                             nativeApp = NativeApp(appUrl = appUrl)
                         )
                     )

--- a/Demo/src/main/java/com/paypal/android/usecase/CreatePayPalSetupTokenUseCase.kt
+++ b/Demo/src/main/java/com/paypal/android/usecase/CreatePayPalSetupTokenUseCase.kt
@@ -8,7 +8,7 @@ import com.paypal.android.api.model.serialization.PayPalSetupRequestBody
 import com.paypal.android.api.model.serialization.PayPalSource
 import com.paypal.android.api.services.SDKSampleServerAPI
 import com.paypal.android.api.services.SDKSampleServerResult
-import com.paypal.android.uishared.enums.DeepLinkStrategy
+import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.utils.ReturnUrlFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -20,14 +20,14 @@ class CreatePayPalSetupTokenUseCase @Inject constructor(
 
     suspend operator fun invoke(
         appSwitchEnabled: Boolean,
-        deepLinkStrategy: DeepLinkStrategy
+        returnToAppStrategy: ReturnToAppStrategy
     ): SDKSampleServerResult<PayPalSetupToken, Exception> =
         withContext(Dispatchers.IO) {
-            val appUrl = ReturnUrlFactory.createGenericReturnUrl(deepLinkStrategy)
+            val appUrl = ReturnUrlFactory.createGenericReturnUrl(returnToAppStrategy)
             val experienceContext = PayPalExperienceContext(
                 vaultInstruction = "ON_PAYER_APPROVAL",
-                returnUrl = ReturnUrlFactory.createCheckoutSuccessUrl(deepLinkStrategy),
-                cancelUrl = ReturnUrlFactory.createCheckoutCancelUrl(deepLinkStrategy),
+                returnUrl = ReturnUrlFactory.createCheckoutSuccessUrl(returnToAppStrategy),
+                cancelUrl = ReturnUrlFactory.createCheckoutCancelUrl(returnToAppStrategy),
                 nativeApp = PayPalNativeApp(appUrl = appUrl)
             )
 

--- a/Demo/src/main/java/com/paypal/android/utils/ReturnUrlFactory.kt
+++ b/Demo/src/main/java/com/paypal/android/utils/ReturnUrlFactory.kt
@@ -1,33 +1,31 @@
 package com.paypal.android.utils
 
-import com.paypal.android.DemoConstants.APP_CUSTOM_URL_SCHEME
-import com.paypal.android.DemoConstants.APP_URL
-import com.paypal.android.uishared.enums.DeepLinkStrategy
+import com.paypal.android.corepayments.ReturnToAppStrategy
 
 object ReturnUrlFactory {
 
-    fun createGenericReturnUrl(deepLinkStrategy: DeepLinkStrategy) = when (deepLinkStrategy) {
-        DeepLinkStrategy.APP_LINKS -> APP_URL
-        DeepLinkStrategy.CUSTOM_URL_SCHEME -> "$APP_CUSTOM_URL_SCHEME://"
+    fun createGenericReturnUrl(strategy: ReturnToAppStrategy) = when (strategy) {
+        is ReturnToAppStrategy.AppLink -> strategy.appLinkUrl
+        is ReturnToAppStrategy.CustomUrlScheme -> "${strategy.urlScheme}://"
     }
 
-    fun createCheckoutSuccessUrl(deepLinkStrategy: DeepLinkStrategy) = when (deepLinkStrategy) {
-        DeepLinkStrategy.APP_LINKS -> "$APP_URL/success"
-        DeepLinkStrategy.CUSTOM_URL_SCHEME -> "$APP_CUSTOM_URL_SCHEME://success"
+    fun createCheckoutSuccessUrl(strategy: ReturnToAppStrategy) = when (strategy) {
+        is ReturnToAppStrategy.AppLink -> "${strategy.appLinkUrl}/success"
+        is ReturnToAppStrategy.CustomUrlScheme -> "${strategy.urlScheme}://success"
     }
 
-    fun createCheckoutCancelUrl(deepLinkStrategy: DeepLinkStrategy) = when (deepLinkStrategy) {
-        DeepLinkStrategy.APP_LINKS -> "$APP_URL/cancel"
-        DeepLinkStrategy.CUSTOM_URL_SCHEME -> "$APP_CUSTOM_URL_SCHEME://cancel"
+    fun createCheckoutCancelUrl(strategy: ReturnToAppStrategy) = when (strategy) {
+        is ReturnToAppStrategy.AppLink -> "${strategy.appLinkUrl}/cancel"
+        is ReturnToAppStrategy.CustomUrlScheme -> "${strategy.urlScheme}://cancel"
     }
 
-    fun createVaultSuccessUrl(deepLinkStrategy: DeepLinkStrategy) = when (deepLinkStrategy) {
-        DeepLinkStrategy.APP_LINKS -> "$APP_URL/vault/success"
-        DeepLinkStrategy.CUSTOM_URL_SCHEME -> "$APP_CUSTOM_URL_SCHEME://vault/success"
+    fun createVaultSuccessUrl(strategy: ReturnToAppStrategy) = when (strategy) {
+        is ReturnToAppStrategy.AppLink -> "${strategy.appLinkUrl}/vault/success"
+        is ReturnToAppStrategy.CustomUrlScheme -> "${strategy.urlScheme}://vault/success"
     }
 
-    fun createVaultCancelUrl(deepLinkStrategy: DeepLinkStrategy) = when (deepLinkStrategy) {
-        DeepLinkStrategy.APP_LINKS -> "$APP_URL/vault/success"
-        DeepLinkStrategy.CUSTOM_URL_SCHEME -> "$APP_CUSTOM_URL_SCHEME://vault/success"
+    fun createVaultCancelUrl(strategy: ReturnToAppStrategy) = when (strategy) {
+        is ReturnToAppStrategy.AppLink -> "${strategy.appLinkUrl}/vault/success"
+        is ReturnToAppStrategy.CustomUrlScheme -> "${strategy.urlScheme}://vault/success"
     }
 }

--- a/Demo/src/main/res/values/strings.xml
+++ b/Demo/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     </string-array>
 
     <string name="deep_link_strategy_title">DEEP LINK STRATEGY</string>
+    <string name="return_to_app_strategy_title">RETURN TO APP STRATEGY</string>
     <string-array name="deep_link_strategy_options">
         <item>APP_LINKS</item>
         <item>CUSTOM_URL_SCHEME</item>

--- a/PayPalWebPayments/api/PayPalWebPayments.api
+++ b/PayPalWebPayments/api/PayPalWebPayments.api
@@ -117,22 +117,19 @@ public final class com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;)V
 	public fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;Z)V
-	public fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLcom/paypal/android/corepayments/ReturnToAppStrategy;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLcom/paypal/android/corepayments/ReturnToAppStrategy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;
 	public final fun component3 ()Z
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;Ljava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;
-	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;
+	public final fun component4 ()Lcom/paypal/android/corepayments/ReturnToAppStrategy;
+	public final fun copy (Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLcom/paypal/android/corepayments/ReturnToAppStrategy;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;
+	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;ZLcom/paypal/android/corepayments/ReturnToAppStrategy;ILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAppLinkUrl ()Ljava/lang/String;
 	public final fun getAppSwitchWhenEligible ()Z
-	public final fun getFallbackUrlScheme ()Ljava/lang/String;
 	public final fun getFundingSource ()Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFundingSource;
 	public final fun getOrderId ()Ljava/lang/String;
+	public final fun getReturnToAppStrategy ()Lcom/paypal/android/corepayments/ReturnToAppStrategy;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -146,22 +143,20 @@ public abstract interface class com/paypal/android/paypalwebpayments/PayPalWebVa
 }
 
 public final class com/paypal/android/paypalwebpayments/PayPalWebVaultRequest {
-	public fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZLcom/paypal/android/corepayments/ReturnToAppStrategy;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLcom/paypal/android/corepayments/ReturnToAppStrategy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZLcom/paypal/android/corepayments/ReturnToAppStrategy;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLcom/paypal/android/corepayments/ReturnToAppStrategy;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Z
-	public final fun component3 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/paypal/android/corepayments/ReturnToAppStrategy;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;
-	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;
+	public final fun copy (Ljava/lang/String;ZLcom/paypal/android/corepayments/ReturnToAppStrategy;Ljava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;
+	public static synthetic fun copy$default (Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;Ljava/lang/String;ZLcom/paypal/android/corepayments/ReturnToAppStrategy;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAppLinkUrl ()Ljava/lang/String;
 	public final fun getAppSwitchWhenEligible ()Z
 	public final fun getApproveVaultHref ()Ljava/lang/String;
-	public final fun getFallbackUrlScheme ()Ljava/lang/String;
+	public final fun getReturnToAppStrategy ()Lcom/paypal/android/corepayments/ReturnToAppStrategy;
 	public final fun getSetupTokenId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -472,9 +472,11 @@ class PayPalWebCheckoutClient internal constructor(
     }
 
     private fun redirectUrlWithCustomScheme(scheme: String?): String? {
-        return if (scheme != null)
+        return if (scheme != null) {
             "$scheme://x-callback-url/paypal-sdk/paypal-checkout"
-        else urlScheme?.let { "$it://x-callback-url/paypal-sdk/paypal-checkout" }
+        } else {
+            urlScheme?.let { "$it://x-callback-url/paypal-sdk/paypal-checkout" }
+        }
     }
 
     private fun buildPayPalCheckoutUri(

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -122,7 +122,8 @@ class PayPalWebCheckoutClient internal constructor(
         val launchUri = buildPayPalCheckoutUri(
             orderId = request.orderId,
             funding = request.fundingSource,
-            redirectUrl = request.appLinkUrl ?: redirectUriPayPalCheckout
+            redirectUrl = request.appLinkUrl
+                ?: redirectUrlWithCustomScheme(request.fallbackUrlScheme)
         )
 
         val result = payPalWebLauncher.launchWithUrl(
@@ -186,7 +187,7 @@ class PayPalWebCheckoutClient internal constructor(
                     fallbackUri = buildPayPalCheckoutUri(
                         orderId = request.orderId,
                         funding = request.fundingSource,
-                        request.appLinkUrl ?: redirectUriPayPalCheckout
+                        request.appLinkUrl ?: redirectUrlWithCustomScheme(request.fallbackUrlScheme)
                     )
                 )
             }
@@ -470,8 +471,11 @@ class PayPalWebCheckoutClient internal constructor(
         return result
     }
 
-    private val redirectUriPayPalCheckout
-        get() = urlScheme?.let { "$urlScheme://x-callback-url/paypal-sdk/paypal-checkout" }
+    private fun redirectUrlWithCustomScheme(scheme: String?): String? {
+        return if (scheme != null)
+            "$scheme://x-callback-url/paypal-sdk/paypal-checkout"
+        else urlScheme?.let { "$it://x-callback-url/paypal-sdk/paypal-checkout" }
+    }
 
     private fun buildPayPalCheckoutUri(
         orderId: String?,

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -165,7 +165,6 @@ class PayPalWebCheckoutClient internal constructor(
      *
      * @param request [PayPalWebCheckoutRequest] for requesting an order approval
      */
-    @Suppress("LongMethod")
     @VisibleForTesting
     internal suspend fun startAsync(
         activity: Activity,
@@ -598,5 +597,4 @@ class PayPalWebCheckoutClient internal constructor(
             is ReturnToAppStrategy.CustomUrlScheme ->
                 "${this.urlScheme}://x-callback-url/paypal-sdk/paypal-checkout"
         }
-
 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -471,6 +471,16 @@ class PayPalWebCheckoutClient internal constructor(
         return result
     }
 
+    /**
+     * Construct a redirect URL with the provided custom scheme if null then use deprecated
+     * urlScheme from constructor. Deprecated urlScheme is still supported for backward
+     * compatibility, but providing a custom scheme in the request is now the recommended approach.
+     * Deprecated urlScheme will eventually be removed in a future major version,
+     * so providing a custom scheme in the request is recommended for forward compatibility.
+     * This check is needed for now to cover all possible scenarios of how the client might be
+     * used, but can be removed once urlScheme is fully deprecated and removed.
+     * This URL will be used to return to the app after the PayPal web flow is completed.
+     */
     private fun redirectUrlWithCustomScheme(scheme: String?): String? {
         return if (scheme != null) {
             "$scheme://x-callback-url/paypal-sdk/paypal-checkout"

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest.kt
@@ -1,19 +1,18 @@
 package com.paypal.android.paypalwebpayments
 
+import com.paypal.android.corepayments.ReturnToAppStrategy
+
 /**
  * Creates an instance of a PayPalRequest.
  *
  * @param orderId The ID of the order to be approved.
  * @param fundingSource specify funding (credit, paylater or default)
  * @param appSwitchWhenEligible whether to switch to the PayPal app when eligible
- * @param appLinkUrl The app link URL to use for browser switch, or null to use default.
- *   Example values: "$myAppScheme://$myAppHost/$myPath", "https://$myDomain/$myPath"
- * @param fallbackUrlScheme The fallback custom URL scheme to use when app link is not configured properly.
+ * @param returnToAppStrategy Strategy for returning to the app after checkout flow
  */
 data class PayPalWebCheckoutRequest @JvmOverloads constructor(
     val orderId: String,
     val fundingSource: PayPalWebCheckoutFundingSource = PayPalWebCheckoutFundingSource.PAYPAL,
     val appSwitchWhenEligible: Boolean = false,
-    val appLinkUrl: String? = null,
-    val fallbackUrlScheme: String? = null
+    val returnToAppStrategy: ReturnToAppStrategy? = null
 )

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import com.paypal.android.corepayments.BrowserSwitchRequestCodes
 import com.paypal.android.corepayments.CaptureDeepLinkResult
 import com.paypal.android.corepayments.DeepLink
+import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.corepayments.browserswitch.BrowserSwitchClient
 import com.paypal.android.corepayments.browserswitch.BrowserSwitchOptions
 import com.paypal.android.corepayments.browserswitch.BrowserSwitchPendingState
@@ -35,15 +36,14 @@ internal class PayPalWebLauncher(
         uri: Uri,
         token: String,
         tokenType: TokenType,
-        returnUrlScheme: String? = null,
-        appLinkUrl: String? = null
+        returnToAppStrategy: ReturnToAppStrategy,
     ): PayPalPresentAuthChallengeResult {
         val metadata = getMetadata(token, tokenType)
         val options = BrowserSwitchOptions(
             targetUri = uri,
             requestCode = getRequestCode(tokenType),
-            returnUrlScheme = returnUrlScheme,
-            appLinkUrl = appLinkUrl,
+            returnUrlScheme = (returnToAppStrategy as? ReturnToAppStrategy.CustomUrlScheme)?.urlScheme,
+            appLinkUrl = (returnToAppStrategy as? ReturnToAppStrategy.AppLink)?.appLinkUrl,
             metadata = metadata
         )
         return launchBrowserSwitch(activity, options)

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebVaultRequest.kt
@@ -1,20 +1,20 @@
 package com.paypal.android.paypalwebpayments
 
+import com.paypal.android.corepayments.ReturnToAppStrategy
+
 /**
  * Request to vault a PayPal payment method using [PayPalWebCheckoutClient.vault].
  *
  * @property [setupTokenId] ID for the setup token associated with the vault approval
- * @property [approveVaultHref] URL for the approval web page
  * @property [appSwitchWhenEligible] whether to switch to the PayPal app when eligible
- * @property [appLinkUrl] The app link URL to use for returning to app
- * @property [fallbackUrlScheme] The fallback custom URL scheme to use when app link is not configured properly
+ * @property [returnToAppStrategy] Strategy for returning to the app after checkout flow
+ * @property [approveVaultHref] URL for the approval web page
  */
 data class PayPalWebVaultRequest @Deprecated("Use PayPalWebVaultRequest(setupTokenId) instead.")
 constructor(
     val setupTokenId: String,
     val appSwitchWhenEligible: Boolean = false,
-    val appLinkUrl: String? = null,
-    val fallbackUrlScheme: String? = null,
+    val returnToAppStrategy: ReturnToAppStrategy? = null,
     @Deprecated("The approveVaultHref property is no longer required and will be ignored.")
     val approveVaultHref: String? = null // NEXT_MAJOR_VERSION: - Remove this property
 ) {
@@ -27,7 +27,6 @@ constructor(
     constructor(
         setupTokenId: String,
         appSwitchWhenEligible: Boolean = false,
-        appLinkUrl: String? = null,
-        fallbackUrlScheme: String? = null
-    ) : this(setupTokenId, appSwitchWhenEligible, appLinkUrl, fallbackUrlScheme, null)
+        returnToAppStrategy: ReturnToAppStrategy? = null
+    ) : this(setupTokenId, appSwitchWhenEligible, returnToAppStrategy, null)
 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/errors/PayPalWebCheckoutError.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/errors/PayPalWebCheckoutError.kt
@@ -21,4 +21,10 @@ internal object PayPalWebCheckoutError {
         code = PayPalWebCheckoutErrorCode.BROWSER_SWITCH.ordinal,
         errorDescription = cause.message ?: "Unable to Browser Switch"
     )
+
+    // 3. ReturnToAppStrategy or urlScheme is required
+    val noReturnToAppStrategyError = PayPalSDKError(
+        code = PayPalWebCheckoutErrorCode.NO_RETURN_TO_APP_STRATEGY.ordinal,
+        errorDescription = "ReturnToAppStrategy or urlScheme is required. "
+    )
 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/errors/PayPalWebCheckoutErrorCode.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/errors/PayPalWebCheckoutErrorCode.kt
@@ -3,5 +3,6 @@ package com.paypal.android.paypalwebpayments.errors
 internal enum class PayPalWebCheckoutErrorCode {
     UNKNOWN,
     MALFORMED_RESULT,
-    BROWSER_SWITCH
+    BROWSER_SWITCH,
+    NO_RETURN_TO_APP_STRATEGY
 }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -260,7 +260,10 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
         } returns successResult
 
-        val request = PayPalWebCheckoutRequest("fake-order-id")
+            val request = PayPalWebCheckoutRequest(
+                "fake-order-id",
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             sut.startAsync(activity, request)
         val result = sut.finishStart(intent)
         assertSame(successResult, result)
@@ -324,7 +327,10 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
         } returns failureResult
 
-        val request = PayPalWebCheckoutRequest("fake-order-id")
+            val request = PayPalWebCheckoutRequest(
+                "fake-order-id",
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             sut.startAsync(activity, request)
         val result = sut.finishStart(intent)
         assertSame(failureResult, result)
@@ -350,7 +356,10 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
         } returns failureResult
 
-        val request = PayPalWebCheckoutRequest("fake-order-id")
+            val request = PayPalWebCheckoutRequest(
+                "fake-order-id",
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             sut.startAsync(activity, request)
         val result = sut.finishStart(intent)
         assertSame(failureResult, result)
@@ -375,7 +384,10 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
         } returns canceledResult
 
-        val request = PayPalWebCheckoutRequest("fake-order-id")
+            val request = PayPalWebCheckoutRequest(
+                "fake-order-id",
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             sut.startAsync(activity, request)
         val result = sut.finishStart(intent)
         assertSame(canceledResult, result)
@@ -600,7 +612,11 @@ class PayPalWebCheckoutClientUnitTest {
         runTest {
             // Given
             every { deviceInspector.isPayPalInstalled } returns true
-            val request = PayPalWebCheckoutRequest("fake-order-id", appSwitchWhenEligible = true)
+            val request = PayPalWebCheckoutRequest(
+                "fake-order-id",
+                appSwitchWhenEligible = true,
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             val appSwitchResponse = createAppSwitchEligibilityResponse(null)
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
@@ -633,7 +649,11 @@ class PayPalWebCheckoutClientUnitTest {
         runTest {
             // Given
             every { deviceInspector.isPayPalInstalled } returns true
-            val request = PayPalWebCheckoutRequest("fake-order-id", appSwitchWhenEligible = true)
+            val request = PayPalWebCheckoutRequest(
+                "fake-order-id",
+                appSwitchWhenEligible = true,
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             val appSwitchResponse = createAppSwitchEligibilityResponse("")
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
@@ -697,7 +717,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(any())
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
             )
         }
         assertSame(launchResult, result)
@@ -706,7 +726,11 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `start() skips app switch check when appSwitchWhenEligible is false`() = runTest {
         // Given
-        val request = PayPalWebCheckoutRequest("fake-order-id", appSwitchWhenEligible = false)
+        val request = PayPalWebCheckoutRequest(
+            "fake-order-id",
+            appSwitchWhenEligible = false,
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
         every {
@@ -742,7 +766,11 @@ class PayPalWebCheckoutClientUnitTest {
     fun `start() uses correct token type in app switch request`() = runTest {
         // Given
         every { deviceInspector.isPayPalInstalled } returns true
-        val request = PayPalWebCheckoutRequest("test-order-123", appSwitchWhenEligible = true)
+        val request = PayPalWebCheckoutRequest(
+            "test-order-123",
+            appSwitchWhenEligible = true,
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         val appSwitchResponse = createAppSwitchEligibilityResponse("https://test.com")
 
         coEvery {
@@ -799,7 +827,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = fakeAppSwitchUrl.toUri(),
                 token = "fake-setup-token-id",
                 tokenType = TokenType.VAULT_ID,
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(any())
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
             )
         } returns launchResult
 
@@ -832,7 +860,11 @@ class PayPalWebCheckoutClientUnitTest {
     fun `vault() falls back to web vault when app switch is enabled but URL is null`() = runTest {
         // Given
         every { deviceInspector.isPayPalInstalled } returns true
-        val request = PayPalWebVaultRequest("fake-setup-token-id", appSwitchWhenEligible = true)
+        val request = PayPalWebVaultRequest(
+            "fake-setup-token-id",
+            appSwitchWhenEligible = true,
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         val appSwitchResponse = createAppSwitchEligibilityResponse(null)
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
@@ -874,7 +906,11 @@ class PayPalWebCheckoutClientUnitTest {
         runTest {
             // Given
             every { deviceInspector.isPayPalInstalled } returns true
-            val request = PayPalWebVaultRequest("fake-setup-token-id", appSwitchWhenEligible = true)
+            val request = PayPalWebVaultRequest(
+                "fake-setup-token-id",
+                appSwitchWhenEligible = true,
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             val appSwitchResponse = createAppSwitchEligibilityResponse("")
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
@@ -906,7 +942,11 @@ class PayPalWebCheckoutClientUnitTest {
     fun `vault() falls back to web vault when app switch request fails`() = runTest {
         // Given
         every { deviceInspector.isPayPalInstalled } returns true
-        val request = PayPalWebVaultRequest("fake-setup-token-id", appSwitchWhenEligible = true)
+        val request = PayPalWebVaultRequest(
+            "fake-setup-token-id",
+            appSwitchWhenEligible = true,
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
         coEvery {
@@ -942,7 +982,11 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `vault() skips app switch check when appSwitchWhenEligible is false`() = runTest {
         // Given
-        val request = PayPalWebVaultRequest("fake-setup-token-id", appSwitchWhenEligible = false)
+        val request = PayPalWebVaultRequest(
+            "fake-setup-token-id",
+            appSwitchWhenEligible = false,
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
         every {
@@ -978,7 +1022,11 @@ class PayPalWebCheckoutClientUnitTest {
     fun `vault() uses correct token type in app switch request`() = runTest {
         // Given
         every { deviceInspector.isPayPalInstalled } returns true
-        val request = PayPalWebVaultRequest("test-setup-123", appSwitchWhenEligible = true)
+        val request = PayPalWebVaultRequest(
+            "test-setup-123",
+            appSwitchWhenEligible = true,
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         val appSwitchResponse = createAppSwitchEligibilityResponse("https://test.com")
 
         coEvery {
@@ -1009,7 +1057,11 @@ class PayPalWebCheckoutClientUnitTest {
         runTest {
             // Given
             every { deviceInspector.isPayPalInstalled } returns false
-            val request = PayPalWebCheckoutRequest("fake-order-id", appSwitchWhenEligible = true)
+            val request = PayPalWebCheckoutRequest(
+                "fake-order-id",
+                appSwitchWhenEligible = true,
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
             every {
@@ -1040,7 +1092,11 @@ class PayPalWebCheckoutClientUnitTest {
         runTest {
             // Given
             every { deviceInspector.isPayPalInstalled } returns false
-            val request = PayPalWebVaultRequest("fake-setup-token-id", appSwitchWhenEligible = true)
+            val request = PayPalWebVaultRequest(
+                "fake-setup-token-id",
+                appSwitchWhenEligible = true,
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
             every {
@@ -1071,7 +1127,11 @@ class PayPalWebCheckoutClientUnitTest {
         runTest {
             // Given
             every { deviceInspector.isPayPalInstalled } returns true
-            val request = PayPalWebCheckoutRequest("fake-order-id", appSwitchWhenEligible = false)
+            val request = PayPalWebCheckoutRequest(
+                "fake-order-id",
+                appSwitchWhenEligible = false,
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
             every {
@@ -1102,7 +1162,11 @@ class PayPalWebCheckoutClientUnitTest {
         runTest {
             // Given
             every { deviceInspector.isPayPalInstalled } returns true
-            val request = PayPalWebVaultRequest("fake-setup-token-id", appSwitchWhenEligible = false)
+            val request = PayPalWebVaultRequest(
+                "fake-setup-token-id",
+                appSwitchWhenEligible = false,
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
             every {
@@ -1164,7 +1228,13 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns successResult
 
-            previousClient.vaultAsync(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            previousClient.vaultAsync(
+                activity,
+                PayPalWebVaultRequest(
+                    "fake-setup-token-id",
+                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+                )
+            )
 
             sut.restore(previousClient.instanceState)
             val result = sut.finishVault(intent) as PayPalWebCheckoutFinishVaultResult.Success
@@ -1202,7 +1272,13 @@ class PayPalWebCheckoutClientUnitTest {
                 payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
             } returns successResult
 
-            previousClient.vaultAsync(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            previousClient.vaultAsync(
+                activity,
+                PayPalWebVaultRequest(
+                    "fake-setup-token-id",
+                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+                )
+            )
 
         sut.restore(previousClient.instanceState)
         val result = sut.finishVault(intent) as PayPalWebCheckoutFinishVaultResult.Success
@@ -1228,7 +1304,13 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns PayPalWebCheckoutFinishVaultResult.Failure(error)
 
-            sut.vaultAsync(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            sut.vaultAsync(
+                activity,
+                PayPalWebVaultRequest(
+                    "fake-setup-token-id",
+                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+                )
+            )
         val result = sut.finishVault(intent) as PayPalWebCheckoutFinishVaultResult.Failure
         assertSame(error, result.error)
     }
@@ -1252,7 +1334,13 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns PayPalWebCheckoutFinishVaultResult.Failure(error)
 
-            sut.vaultAsync(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            sut.vaultAsync(
+                activity,
+                PayPalWebVaultRequest(
+                    "fake-setup-token-id",
+                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+                )
+            )
 
             sut.restore(sut.instanceState)
         val result = sut.finishVault(intent) as PayPalWebCheckoutFinishVaultResult.Failure
@@ -1277,7 +1365,13 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns PayPalWebCheckoutFinishVaultResult.Canceled
 
-            sut.vaultAsync(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            sut.vaultAsync(
+                activity,
+                PayPalWebVaultRequest(
+                    "fake-setup-token-id",
+                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+                )
+            )
         val result = sut.finishVault(intent)
         assertSame(PayPalWebCheckoutFinishVaultResult.Canceled, result)
     }
@@ -1300,7 +1394,13 @@ class PayPalWebCheckoutClientUnitTest {
             payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
         } returns PayPalWebCheckoutFinishVaultResult.Canceled
 
-            sut.vaultAsync(activity, PayPalWebVaultRequest("fake-setup-token-id"))
+            sut.vaultAsync(
+                activity,
+                PayPalWebVaultRequest(
+                    "fake-setup-token-id",
+                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+                )
+            )
 
             sut.restore(sut.instanceState)
         val result = sut.finishVault(intent)
@@ -1754,6 +1854,18 @@ class PayPalWebCheckoutClientUnitTest {
 
     @Test
     fun `startAsync() uses default urlScheme when returnToAppStrategy is null`() = runTest {
+        // Create a client with urlScheme
+        val clientWithUrlScheme = PayPalWebCheckoutClient(
+            analytics = analytics,
+            payPalWebLauncher = payPalWebLauncher,
+            sessionStore = PayPalWebCheckoutSessionStore(),
+            updateClientConfigAPI = updateClientConfigAPI,
+            patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
+            deviceInspector = deviceInspector,
+            coreConfig = coreConfig,
+            urlScheme = urlScheme
+        )
+
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
         every {
             payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
@@ -1763,7 +1875,7 @@ class PayPalWebCheckoutClientUnitTest {
             orderId = "fake-order-id",
             returnToAppStrategy = null
         )
-        sut.startAsync(activity, request)
+        clientWithUrlScheme.startAsync(activity, request)
 
         verify(exactly = 1) {
             payPalWebLauncher.launchWithUrl(
@@ -1771,7 +1883,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
-                returnToAppStrategy = any()
+                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(urlScheme)
             )
         }
     }
@@ -1854,6 +1966,18 @@ class PayPalWebCheckoutClientUnitTest {
 
     @Test
     fun `vaultAsync() uses default urlScheme when returnToAppStrategy is null`() = runTest {
+        // Create a client with urlScheme
+        val clientWithUrlScheme = PayPalWebCheckoutClient(
+            analytics = analytics,
+            payPalWebLauncher = payPalWebLauncher,
+            sessionStore = PayPalWebCheckoutSessionStore(),
+            updateClientConfigAPI = updateClientConfigAPI,
+            patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
+            deviceInspector = deviceInspector,
+            coreConfig = coreConfig,
+            urlScheme = urlScheme
+        )
+
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
         every {
             payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
@@ -1863,7 +1987,7 @@ class PayPalWebCheckoutClientUnitTest {
             setupTokenId = "fake-setup-token-id",
             returnToAppStrategy = null
         )
-        sut.vaultAsync(activity, request)
+        clientWithUrlScheme.vaultAsync(activity, request)
 
         verify(exactly = 1) {
             payPalWebLauncher.launchWithUrl(
@@ -1871,7 +1995,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-setup-token-id",
                 tokenType = TokenType.VAULT_ID,
-                returnToAppStrategy = any()
+                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(urlScheme)
             )
         }
     }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -1950,5 +1950,4 @@ class PayPalWebCheckoutClientUnitTest {
             ineligibleReason = null
         )
     }
-
 }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.FragmentActivity
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.PayPalSDKError
+import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.corepayments.UpdateClientConfigAPI
 import com.paypal.android.corepayments.api.PatchCCOWithAppSwitchEligibility
 import com.paypal.android.corepayments.common.DeviceInspector
@@ -100,12 +101,14 @@ class PayPalWebCheckoutClientUnitTest {
                 any(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } returns launchResult
 
-        val request = PayPalWebCheckoutRequest("fake-order-id", appLinkUrl = appLinkUrl)
+        val request = PayPalWebCheckoutRequest(
+            "fake-order-id",
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         sut.startAsync(activity, request)
 
         // Verify launchWithUrl is called with correct parameters
@@ -115,7 +118,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
-                appLinkUrl = appLinkUrl
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
             )
         }
     }
@@ -130,13 +133,15 @@ class PayPalWebCheckoutClientUnitTest {
                 any(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } returns launchResult
 
         val appLinkUrl = "https://example.com/return"
-        val request = PayPalWebCheckoutRequest("fake-order-id", appLinkUrl = appLinkUrl)
+        val request = PayPalWebCheckoutRequest(
+            "fake-order-id",
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         val result = sut.startAsync(activity, request)
         assertSame(launchResult, result)
     }
@@ -155,7 +160,10 @@ class PayPalWebCheckoutClientUnitTest {
         } returns launchResult
 
         val appLinkUrl = "https://example.com/vault/return"
-        val request = PayPalWebVaultRequest("fake-setup-token-id", appLinkUrl = appLinkUrl)
+        val request = PayPalWebVaultRequest(
+            "fake-setup-token-id",
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         sut.vaultAsync(activity, request)
         verify(exactly = 1) {
             payPalWebLauncher.launchWithUrl(
@@ -163,7 +171,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-setup-token-id",
                 tokenType = TokenType.VAULT_ID,
-                appLinkUrl = appLinkUrl
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
             )
         }
     }
@@ -178,13 +186,15 @@ class PayPalWebCheckoutClientUnitTest {
                 any(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } returns launchResult
 
         val appLinkUrl = "https://example.com/vault/return"
-        val request = PayPalWebVaultRequest("fake-setup-token-id", appLinkUrl = appLinkUrl)
+        val request = PayPalWebVaultRequest(
+            "fake-setup-token-id",
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         val result = sut.vaultAsync(activity, request) as PayPalPresentAuthChallengeResult.Failure
 
         assertSame(sdkError, result.error)
@@ -535,7 +545,7 @@ class PayPalWebCheckoutClientUnitTest {
         val request = PayPalWebCheckoutRequest(
             "fake-order-id",
             appSwitchWhenEligible = true,
-            appLinkUrl = appLinkUrl
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
         )
         val appSwitchResponse = createAppSwitchEligibilityResponse(fakeAppSwitchUrl)
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
@@ -556,7 +566,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = any(),
                 tokenType = any(),
-                appLinkUrl = any()
+                returnToAppStrategy = any()
             )
         } returns launchResult
 
@@ -579,7 +589,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
-                appLinkUrl = appLinkUrl
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
             )
         }
         assertSame(launchResult, result)
@@ -611,7 +621,8 @@ class PayPalWebCheckoutClientUnitTest {
                     activity = activity,
                     uri = any(),
                     token = "fake-order-id",
-                    tokenType = TokenType.ORDER_ID
+                    tokenType = TokenType.ORDER_ID,
+                    returnToAppStrategy = any()
                 )
             }
             assertSame(launchResult, result)
@@ -644,6 +655,7 @@ class PayPalWebCheckoutClientUnitTest {
                     uri = any(),
                     token = "fake-order-id",
                     tokenType = TokenType.ORDER_ID,
+                    returnToAppStrategy = any()
                 )
             }
             assertSame(launchResult, result)
@@ -656,7 +668,7 @@ class PayPalWebCheckoutClientUnitTest {
         val request = PayPalWebCheckoutRequest(
             orderId = "fake-order-id",
             appSwitchWhenEligible = true,
-            appLinkUrl = appLinkUrl
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
         )
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
@@ -670,8 +682,7 @@ class PayPalWebCheckoutClientUnitTest {
                 any(),
                 any(),
                 any(),
-                any(),
-                appLinkUrl
+                any()
             )
         } returns launchResult
 
@@ -686,8 +697,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
-                returnUrlScheme = null,
-                appLinkUrl = any()
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(any())
             )
         }
         assertSame(launchResult, result)
@@ -701,7 +711,6 @@ class PayPalWebCheckoutClientUnitTest {
 
         every {
             payPalWebLauncher.launchWithUrl(
-                any(),
                 any(),
                 any(),
                 any(),
@@ -723,6 +732,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
+                returnToAppStrategy = any()
             )
         }
         assertSame(launchResult, result)
@@ -767,7 +777,7 @@ class PayPalWebCheckoutClientUnitTest {
         val request = PayPalWebVaultRequest(
             "fake-setup-token-id",
             appSwitchWhenEligible = true,
-            appLinkUrl = appLinkUrl
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
         )
         val appSwitchResponse =
             createAppSwitchEligibilityResponse(fakeAppSwitchUrl)
@@ -789,8 +799,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = fakeAppSwitchUrl.toUri(),
                 token = "fake-setup-token-id",
                 tokenType = TokenType.VAULT_ID,
-                returnUrlScheme = null,
-                appLinkUrl = any()
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(any())
             )
         } returns launchResult
 
@@ -813,8 +822,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-setup-token-id",
                 tokenType = TokenType.VAULT_ID,
-                returnUrlScheme = null,
-                appLinkUrl = appLinkUrl
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
             )
         }
         assertSame(launchResult, result)
@@ -833,7 +841,7 @@ class PayPalWebCheckoutClientUnitTest {
         } returns APIResult.Success(appSwitchResponse)
 
         every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
         } returns launchResult
 
         // When
@@ -854,7 +862,8 @@ class PayPalWebCheckoutClientUnitTest {
                 activity = activity,
                 uri = any(),
                 token = "fake-setup-token-id",
-                tokenType = TokenType.VAULT_ID
+                tokenType = TokenType.VAULT_ID,
+                returnToAppStrategy = any()
             )
         }
         assertSame(launchResult, result)
@@ -886,7 +895,8 @@ class PayPalWebCheckoutClientUnitTest {
                     activity = activity,
                     uri = any(),
                     token = "fake-setup-token-id",
-                    tokenType = TokenType.VAULT_ID
+                    tokenType = TokenType.VAULT_ID,
+                    returnToAppStrategy = any()
                 )
             }
             assertSame(launchResult, result)
@@ -909,7 +919,6 @@ class PayPalWebCheckoutClientUnitTest {
                 any(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } returns launchResult
@@ -923,7 +932,8 @@ class PayPalWebCheckoutClientUnitTest {
                 activity = activity,
                 uri = any(),
                 token = "fake-setup-token-id",
-                tokenType = TokenType.VAULT_ID
+                tokenType = TokenType.VAULT_ID,
+                returnToAppStrategy = any()
             )
         }
         assertSame(launchResult, result)
@@ -957,7 +967,8 @@ class PayPalWebCheckoutClientUnitTest {
                 activity = activity,
                 uri = any(),
                 token = "fake-setup-token-id",
-                tokenType = TokenType.VAULT_ID
+                tokenType = TokenType.VAULT_ID,
+                returnToAppStrategy = any()
             )
         }
         assertSame(launchResult, result)
@@ -1002,7 +1013,7 @@ class PayPalWebCheckoutClientUnitTest {
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
             every {
-                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
             } returns launchResult
 
             // When
@@ -1017,7 +1028,8 @@ class PayPalWebCheckoutClientUnitTest {
                     activity = activity,
                     uri = any(),
                     token = "fake-order-id",
-                    tokenType = TokenType.ORDER_ID
+                    tokenType = TokenType.ORDER_ID,
+                    returnToAppStrategy = any()
                 )
             }
             assertSame(launchResult, result)
@@ -1047,7 +1059,8 @@ class PayPalWebCheckoutClientUnitTest {
                     activity = activity,
                     uri = any(),
                     token = "fake-setup-token-id",
-                    tokenType = TokenType.VAULT_ID
+                    tokenType = TokenType.VAULT_ID,
+                    returnToAppStrategy = any()
                 )
             }
             assertSame(launchResult, result)
@@ -1077,7 +1090,8 @@ class PayPalWebCheckoutClientUnitTest {
                     activity = activity,
                     uri = any(),
                     token = "fake-order-id",
-                    tokenType = TokenType.ORDER_ID
+                    tokenType = TokenType.ORDER_ID,
+                    returnToAppStrategy = any()
                 )
             }
             assertSame(launchResult, result)
@@ -1107,7 +1121,8 @@ class PayPalWebCheckoutClientUnitTest {
                     activity = activity,
                     uri = any(),
                     token = "fake-setup-token-id",
-                    tokenType = TokenType.VAULT_ID
+                    tokenType = TokenType.VAULT_ID,
+                    returnToAppStrategy = any()
                 )
             }
             assertSame(launchResult, result)
@@ -1388,7 +1403,6 @@ class PayPalWebCheckoutClientUnitTest {
                 any(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } returns launchResult
@@ -1403,8 +1417,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
-                returnUrlScheme = urlScheme,
-                appLinkUrl = null
+                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(urlScheme)
             )
         }
     }
@@ -1433,7 +1446,6 @@ class PayPalWebCheckoutClientUnitTest {
                 any(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } returns launchResult
@@ -1448,15 +1460,14 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-setup-token-id",
                 tokenType = TokenType.VAULT_ID,
-                returnUrlScheme = urlScheme,
-                appLinkUrl = null
+                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(urlScheme)
             )
         }
     }
 
     @Test
     @Suppress("DEPRECATION")
-    fun `start() with deprecated urlScheme constructor and appLinkUrl in request prioritizes appLinkUrl`() =
+    fun `start() with deprecated urlScheme constructor and AppLink in request prioritizes AppLink`() =
         runTest {
             val mockLauncher = mockk<PayPalWebLauncher>(relaxed = true)
             val clientWithUrlScheme = PayPalWebCheckoutClient(
@@ -1471,12 +1482,14 @@ class PayPalWebCheckoutClientUnitTest {
             )
 
             val appLinkUrl = "https://example.com/return"
-            val request = PayPalWebCheckoutRequest("fake-order-id", appLinkUrl = appLinkUrl)
+            val request = PayPalWebCheckoutRequest(
+                "fake-order-id",
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
             every {
                 mockLauncher.launchWithUrl(
-                    any(),
                     any(),
                     any(),
                     any(),
@@ -1495,15 +1508,14 @@ class PayPalWebCheckoutClientUnitTest {
                     uri = any(),
                     token = "fake-order-id",
                     tokenType = TokenType.ORDER_ID,
-                    returnUrlScheme = urlScheme,
-                    appLinkUrl = appLinkUrl
+                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
                 )
             }
         }
 
     @Test
     @Suppress("DEPRECATION")
-    fun `vault() with deprecated urlScheme constructor and appLinkUrl in request prioritizes appLinkUrl`() =
+    fun `vault() with deprecated urlScheme constructor and AppLink in request prioritizes AppLink`() =
         runTest {
             val mockLauncher = mockk<PayPalWebLauncher>(relaxed = true)
             val clientWithUrlScheme = PayPalWebCheckoutClient(
@@ -1518,12 +1530,14 @@ class PayPalWebCheckoutClientUnitTest {
             )
 
             val appLinkUrl = "https://example.com/vault/return"
-            val request = PayPalWebVaultRequest("fake-setup-token-id", appLinkUrl = appLinkUrl)
+            val request = PayPalWebVaultRequest(
+                "fake-setup-token-id",
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+            )
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
 
             every {
                 mockLauncher.launchWithUrl(
-                    any(),
                     any(),
                     any(),
                     any(),
@@ -1542,8 +1556,7 @@ class PayPalWebCheckoutClientUnitTest {
                     uri = any(),
                     token = "fake-setup-token-id",
                     tokenType = TokenType.VAULT_ID,
-                    returnUrlScheme = urlScheme,
-                    appLinkUrl = appLinkUrl
+                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
                 )
             }
         }
@@ -1559,12 +1572,14 @@ class PayPalWebCheckoutClientUnitTest {
                 any(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } returns launchResult
 
-        val request = PayPalWebCheckoutRequest("fake-order-id", appLinkUrl = appLinkUrl)
+        val request = PayPalWebCheckoutRequest(
+            "fake-order-id",
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         val result = sut.start(activity, request)
 
         // Verify it returns the launch result
@@ -1580,7 +1595,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
-                appLinkUrl = appLinkUrl
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
             )
         }
     }
@@ -1595,12 +1610,14 @@ class PayPalWebCheckoutClientUnitTest {
                 any(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } returns launchResult
 
-        val request = PayPalWebCheckoutRequest("fake-order-id", appLinkUrl = appLinkUrl)
+        val request = PayPalWebCheckoutRequest(
+            "fake-order-id",
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         val result = sut.start(activity, request) as PayPalPresentAuthChallengeResult.Failure
 
         assertSame(sdkError, result.error)
@@ -1615,13 +1632,15 @@ class PayPalWebCheckoutClientUnitTest {
                 any(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } returns launchResult
 
         val appLinkUrl = "https://example.com/vault/return"
-        val request = PayPalWebVaultRequest("fake-setup-token-id", appLinkUrl = appLinkUrl)
+        val request = PayPalWebVaultRequest(
+            "fake-setup-token-id",
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         val result = sut.vault(activity, request)
 
         // Verify it returns the launch result
@@ -1637,7 +1656,7 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-setup-token-id",
                 tokenType = TokenType.VAULT_ID,
-                appLinkUrl = appLinkUrl
+                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
             )
         }
     }
@@ -1652,13 +1671,15 @@ class PayPalWebCheckoutClientUnitTest {
                 any(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } returns launchResult
 
         val appLinkUrl = "https://example.com/vault/return"
-        val request = PayPalWebVaultRequest("fake-setup-token-id", appLinkUrl = appLinkUrl)
+        val request = PayPalWebVaultRequest(
+            "fake-setup-token-id",
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
         val result = sut.vault(activity, request) as PayPalPresentAuthChallengeResult.Failure
 
         assertSame(sdkError, result.error)
@@ -1672,11 +1693,14 @@ class PayPalWebCheckoutClientUnitTest {
     fun `start() with callback method exists and can be called`() {
         // This test just verifies the callback method can be called without throwing
         val callback = mockk<PayPalWebStartCallback>(relaxed = true)
-        val request = PayPalWebCheckoutRequest("fake-order-id", appLinkUrl = appLinkUrl)
+        val request = PayPalWebCheckoutRequest(
+            "fake-order-id",
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
 
         // Mock the async dependencies to avoid side effects
         every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
         } returns PayPalPresentAuthChallengeResult.Success("auth state")
 
         // This should not throw an exception
@@ -1687,30 +1711,33 @@ class PayPalWebCheckoutClientUnitTest {
     fun `vault() with callback method exists and can be called`() {
         // This test just verifies the callback method can be called without throwing
         val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
-        val request = PayPalWebVaultRequest("fake-setup-token-id", appLinkUrl = appLinkUrl)
+        val request = PayPalWebVaultRequest(
+            "fake-setup-token-id",
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
 
         // Mock the async dependencies to avoid side effects
         every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
         } returns PayPalPresentAuthChallengeResult.Success("auth state")
 
         // This should not throw an exception
         sut.vault(activity, request, callback)
     }
 
-    // Tests for fallbackUrlScheme functionality
+    // Tests for returnToAppStrategy functionality
 
     @Test
-    fun `startAsync() uses fallbackUrlScheme when provided`() = runTest {
+    fun `startAsync() uses CustomUrlScheme when provided`() = runTest {
         val fallbackScheme = "com.example.fallback"
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
         every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
         } returns launchResult
 
         val request = PayPalWebCheckoutRequest(
             orderId = "fake-order-id",
-            fallbackUrlScheme = fallbackScheme
+            returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
         )
         sut.startAsync(activity, request)
 
@@ -1720,22 +1747,21 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
-                returnUrlScheme = fallbackScheme,
-                appLinkUrl = null
+                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
             )
         }
     }
 
     @Test
-    fun `startAsync() uses default urlScheme when fallbackUrlScheme is null`() = runTest {
+    fun `startAsync() uses default urlScheme when returnToAppStrategy is null`() = runTest {
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
         every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
         } returns launchResult
 
         val request = PayPalWebCheckoutRequest(
             orderId = "fake-order-id",
-            fallbackUrlScheme = null
+            returnToAppStrategy = null
         )
         sut.startAsync(activity, request)
 
@@ -1745,24 +1771,23 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
-                returnUrlScheme = null,
-                appLinkUrl = null
+                returnToAppStrategy = any()
             )
         }
     }
 
     @Test
     @Suppress("DEPRECATION")
-    fun `start() with deprecated method uses fallbackUrlScheme when provided`() {
+    fun `start() with deprecated method uses CustomUrlScheme when provided`() {
         val fallbackScheme = "com.example.fallback"
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
         every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
         } returns launchResult
 
         val request = PayPalWebCheckoutRequest(
             orderId = "fake-order-id",
-            fallbackUrlScheme = fallbackScheme
+            returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
         )
         sut.start(activity, request)
 
@@ -1772,23 +1797,22 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
-                returnUrlScheme = fallbackScheme,
-                appLinkUrl = null
+                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
             )
         }
     }
 
     @Test
-    fun `startAsync() with fallbackUrlScheme uses fallbackUrlScheme when provided`() = runTest {
+    fun `startAsync() with CustomUrlScheme uses CustomUrlScheme when provided`() = runTest {
         val fallbackScheme = "com.example.fallback"
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
         every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
         } returns launchResult
 
         val request = PayPalWebCheckoutRequest(
             orderId = "fake-order-id",
-            fallbackUrlScheme = fallbackScheme
+            returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
         )
         sut.startAsync(activity, request)
 
@@ -1798,23 +1822,22 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-order-id",
                 tokenType = TokenType.ORDER_ID,
-                returnUrlScheme = fallbackScheme,
-                appLinkUrl = null
+                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
             )
         }
     }
 
     @Test
-    fun `vaultAsync() uses fallbackUrlScheme when provided`() = runTest {
+    fun `vaultAsync() uses CustomUrlScheme when provided`() = runTest {
         val fallbackScheme = "com.example.fallback"
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
         every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
         } returns launchResult
 
         val request = PayPalWebVaultRequest(
             setupTokenId = "fake-setup-token-id",
-            fallbackUrlScheme = fallbackScheme
+            returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
         )
         sut.vaultAsync(activity, request)
 
@@ -1824,22 +1847,21 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-setup-token-id",
                 tokenType = TokenType.VAULT_ID,
-                returnUrlScheme = fallbackScheme,
-                appLinkUrl = null
+                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
             )
         }
     }
 
     @Test
-    fun `vaultAsync() uses default urlScheme when fallbackUrlScheme is null`() = runTest {
+    fun `vaultAsync() uses default urlScheme when returnToAppStrategy is null`() = runTest {
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
         every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
         } returns launchResult
 
         val request = PayPalWebVaultRequest(
             setupTokenId = "fake-setup-token-id",
-            fallbackUrlScheme = null
+            returnToAppStrategy = null
         )
         sut.vaultAsync(activity, request)
 
@@ -1849,24 +1871,23 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-setup-token-id",
                 tokenType = TokenType.VAULT_ID,
-                returnUrlScheme = null,
-                appLinkUrl = null
+                returnToAppStrategy = any()
             )
         }
     }
 
     @Test
     @Suppress("DEPRECATION")
-    fun `vault() with deprecated method uses fallbackUrlScheme when provided`() {
+    fun `vault() with deprecated method uses CustomUrlScheme when provided`() {
         val fallbackScheme = "com.example.fallback"
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
         every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
         } returns launchResult
 
         val request = PayPalWebVaultRequest(
             setupTokenId = "fake-setup-token-id",
-            fallbackUrlScheme = fallbackScheme
+            returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
         )
         sut.vault(activity, request)
 
@@ -1876,24 +1897,23 @@ class PayPalWebCheckoutClientUnitTest {
                 uri = any(),
                 token = "fake-setup-token-id",
                 tokenType = TokenType.VAULT_ID,
-                returnUrlScheme = fallbackScheme,
-                appLinkUrl = null
+                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
             )
         }
     }
 
     @Test
-    fun `vault() with callback uses fallbackUrlScheme when provided`() {
-        // This test verifies the callback method can be called with fallbackUrlScheme without throwing
+    fun `vault() with callback uses CustomUrlScheme when provided`() {
+        // This test verifies the callback method can be called with CustomUrlScheme without throwing
         val fallbackScheme = "com.example.fallback"
         val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
         every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
         } returns PayPalPresentAuthChallengeResult.Success("auth state")
 
         val request = PayPalWebVaultRequest(
             setupTokenId = "fake-setup-token-id",
-            fallbackUrlScheme = fallbackScheme
+            returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
         )
 
         // This should not throw an exception
@@ -1901,16 +1921,16 @@ class PayPalWebCheckoutClientUnitTest {
     }
 
     @Test
-    fun `vault() with callback uses default urlScheme when fallbackUrlScheme is null`() {
-        // This test verifies the callback method can be called with null fallbackUrlScheme without throwing
+    fun `vault() with callback uses default urlScheme when returnToAppStrategy is null`() {
+        // This test verifies the callback method can be called with null returnToAppStrategy without throwing
         val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
         every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
         } returns PayPalPresentAuthChallengeResult.Success("auth state")
 
         val request = PayPalWebVaultRequest(
             setupTokenId = "fake-setup-token-id",
-            fallbackUrlScheme = null
+            returnToAppStrategy = null
         )
 
         // This should not throw an exception
@@ -1931,246 +1951,4 @@ class PayPalWebCheckoutClientUnitTest {
         )
     }
 
-    // MARK: - Tests for redirect URI with appLinkUrl and fallbackUrlScheme
-
-    @Test
-    fun `startAsync() uses appLinkUrl in redirect_uri when appLinkUrl is provided`() = runTest {
-        val testAppLinkUrl = "https://example.com/return"
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebCheckoutRequest(
-            orderId = "fake-order-id",
-            appLinkUrl = testAppLinkUrl
-        )
-        sut.startAsync(activity, request)
-
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                activity = activity,
-                uri = match { uri ->
-                    uri.getQueryParameter("redirect_uri") == testAppLinkUrl
-                },
-                token = "fake-order-id",
-                tokenType = TokenType.ORDER_ID,
-                returnUrlScheme = null,
-                appLinkUrl = testAppLinkUrl
-            )
-        }
-    }
-
-    @Test
-    fun `startAsync() uses fallbackUrlScheme in redirect_uri when fallbackUrlScheme is provided`() =
-        runTest {
-            val fallbackScheme = "com.example.fallback"
-            val expectedRedirectUri = "$fallbackScheme://x-callback-url/paypal-sdk/paypal-checkout"
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-            every {
-                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
-            } returns launchResult
-
-            val request = PayPalWebCheckoutRequest(
-                orderId = "fake-order-id",
-                fallbackUrlScheme = fallbackScheme
-            )
-            sut.startAsync(activity, request)
-
-            verify(exactly = 1) {
-                payPalWebLauncher.launchWithUrl(
-                    activity = activity,
-                    uri = match { uri ->
-                        uri.getQueryParameter("redirect_uri") == expectedRedirectUri
-                    },
-                    token = "fake-order-id",
-                    tokenType = TokenType.ORDER_ID,
-                    returnUrlScheme = fallbackScheme,
-                    appLinkUrl = null
-                )
-            }
-        }
-
-    @Test
-    fun `startAsync() prioritizes appLinkUrl over fallbackUrlScheme in redirect_uri`() = runTest {
-        val testAppLinkUrl = "https://example.com/return"
-        val fallbackScheme = "com.example.fallback"
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebCheckoutRequest(
-            orderId = "fake-order-id",
-            appLinkUrl = testAppLinkUrl,
-            fallbackUrlScheme = fallbackScheme
-        )
-        sut.startAsync(activity, request)
-
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                activity = activity,
-                uri = match { uri ->
-                    uri.getQueryParameter("redirect_uri") == testAppLinkUrl
-                },
-                token = "fake-order-id",
-                tokenType = TokenType.ORDER_ID,
-                returnUrlScheme = fallbackScheme,
-                appLinkUrl = testAppLinkUrl
-            )
-        }
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `startAsync() with urlScheme uses urlScheme in redirect_uri when no appLinkUrl or fallbackUrlScheme`() =
-        runTest {
-            val testUrlScheme = "com.example.app"
-            val expectedRedirectUri = "$testUrlScheme://x-callback-url/paypal-sdk/paypal-checkout"
-            val mockLauncher = mockk<PayPalWebLauncher>(relaxed = true)
-            val clientWithUrlScheme = PayPalWebCheckoutClient(
-                analytics = analytics,
-                payPalWebLauncher = mockLauncher,
-                sessionStore = PayPalWebCheckoutSessionStore(),
-                updateClientConfigAPI = updateClientConfigAPI,
-                patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
-                deviceInspector = deviceInspector,
-                coreConfig = coreConfig,
-                urlScheme = testUrlScheme
-            )
-
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                mockLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
-            } returns launchResult
-
-            val request = PayPalWebCheckoutRequest(
-                orderId = "fake-order-id",
-                appLinkUrl = null,
-                fallbackUrlScheme = null
-            )
-            clientWithUrlScheme.startAsync(activity, request)
-
-            verify(exactly = 1) {
-                mockLauncher.launchWithUrl(
-                    activity = activity,
-                    uri = match { uri ->
-                        uri.getQueryParameter("redirect_uri") == expectedRedirectUri
-                    },
-                    token = "fake-order-id",
-                    tokenType = TokenType.ORDER_ID,
-                    returnUrlScheme = testUrlScheme,
-                    appLinkUrl = null
-                )
-            }
-        }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `startAsync() with urlScheme prioritizes fallbackUrlScheme over urlScheme in redirect_uri`() =
-        runTest {
-            val testUrlScheme = "com.example.app"
-            val fallbackScheme = "com.example.fallback"
-            val expectedRedirectUri = "$fallbackScheme://x-callback-url/paypal-sdk/paypal-checkout"
-            val mockLauncher = mockk<PayPalWebLauncher>(relaxed = true)
-            val clientWithUrlScheme = PayPalWebCheckoutClient(
-                analytics = analytics,
-                payPalWebLauncher = mockLauncher,
-                sessionStore = PayPalWebCheckoutSessionStore(),
-                updateClientConfigAPI = updateClientConfigAPI,
-                patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
-                deviceInspector = deviceInspector,
-                coreConfig = coreConfig,
-                urlScheme = testUrlScheme
-            )
-
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                mockLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
-            } returns launchResult
-
-            val request = PayPalWebCheckoutRequest(
-                orderId = "fake-order-id",
-                appLinkUrl = null,
-                fallbackUrlScheme = fallbackScheme
-            )
-            clientWithUrlScheme.startAsync(activity, request)
-
-            verify(exactly = 1) {
-                mockLauncher.launchWithUrl(
-                    activity = activity,
-                    uri = match { uri ->
-                        uri.getQueryParameter("redirect_uri") == expectedRedirectUri
-                    },
-                    token = "fake-order-id",
-                    tokenType = TokenType.ORDER_ID,
-                    returnUrlScheme = fallbackScheme,
-                    appLinkUrl = null
-                )
-            }
-        }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `deprecated start() uses appLinkUrl in redirect_uri when appLinkUrl is provided`() {
-        val testAppLinkUrl = "https://example.com/return"
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebCheckoutRequest(
-            orderId = "fake-order-id",
-            appLinkUrl = testAppLinkUrl
-        )
-        sut.start(activity, request)
-
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                activity = activity,
-                uri = match { uri ->
-                    uri.getQueryParameter("redirect_uri") == testAppLinkUrl
-                },
-                token = "fake-order-id",
-                tokenType = TokenType.ORDER_ID,
-                returnUrlScheme = null,
-                appLinkUrl = testAppLinkUrl
-            )
-        }
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `deprecated start() uses fallbackUrlScheme in redirect_uri when fallbackUrlScheme is provided`() {
-        val fallbackScheme = "com.example.fallback"
-        val expectedRedirectUri = "$fallbackScheme://x-callback-url/paypal-sdk/paypal-checkout"
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebCheckoutRequest(
-            orderId = "fake-order-id",
-            fallbackUrlScheme = fallbackScheme
-        )
-        sut.start(activity, request)
-
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                activity = activity,
-                uri = match { uri ->
-                    uri.getQueryParameter("redirect_uri") == expectedRedirectUri
-                },
-                token = "fake-order-id",
-                tokenType = TokenType.ORDER_ID,
-                returnUrlScheme = fallbackScheme,
-                appLinkUrl = null
-            )
-        }
-    }
 }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
@@ -6,6 +6,7 @@ import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import com.paypal.android.corepayments.BrowserSwitchRequestCodes.PAYPAL_CHECKOUT
 import com.paypal.android.corepayments.BrowserSwitchRequestCodes.PAYPAL_VAULT
+import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.corepayments.browserswitch.BrowserSwitchClient
 import com.paypal.android.corepayments.browserswitch.BrowserSwitchOptions
 import com.paypal.android.corepayments.browserswitch.BrowserSwitchPendingState
@@ -54,7 +55,7 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://www.sandbox.paypal.com/checkoutnow"),
             "fake-order-id",
             TokenType.ORDER_ID,
-            "com.example.app"
+            ReturnToAppStrategy.CustomUrlScheme("com.example.app")
         )
 
         val browserSwitchOptions = slot.captured
@@ -80,7 +81,7 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://www.paypal.com/checkoutnow"),
             "fake-order-id",
             TokenType.ORDER_ID,
-            "com.example.app"
+            ReturnToAppStrategy.CustomUrlScheme("com.example.app")
         )
 
         val browserSwitchOptions = slot.captured
@@ -106,7 +107,7 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://www.paypal.com/checkoutnow"),
             "fake-order-id",
             TokenType.ORDER_ID,
-            "com.example.app"
+            ReturnToAppStrategy.CustomUrlScheme("com.example.app")
         )
 
         val browserSwitchOptions = slot.captured
@@ -132,7 +133,7 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://www.paypal.com/checkoutnow"),
             "fake-order-id",
             TokenType.ORDER_ID,
-            "com.example.app"
+            ReturnToAppStrategy.CustomUrlScheme("com.example.app")
         )
 
         val browserSwitchOptions = slot.captured
@@ -158,7 +159,7 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://www.sandbox.paypal.com/checkoutnow"),
             "fake-order-id",
             TokenType.ORDER_ID,
-            "com.example.app"
+            ReturnToAppStrategy.CustomUrlScheme("com.example.app")
         )
                 as PayPalPresentAuthChallengeResult.Failure
         assertEquals("error message from browser switch", result.error.errorDescription)
@@ -178,7 +179,7 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://sandbox.paypal.com/agreements/approve"),
             "fake-setup-token",
             TokenType.VAULT_ID,
-            "com.example.app"
+            ReturnToAppStrategy.CustomUrlScheme("com.example.app")
         )
 
         val browserSwitchOptions = slot.captured
@@ -204,7 +205,7 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://paypal.com/agreements/approve"),
             "fake-setup-token",
             TokenType.VAULT_ID,
-            "com.example.app"
+            ReturnToAppStrategy.CustomUrlScheme("com.example.app")
         )
 
         val browserSwitchOptions = slot.captured
@@ -230,7 +231,7 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://www.sandbox.paypal.com/checkoutnow"),
             "fake-order-id",
             TokenType.ORDER_ID,
-            "com.example.app"
+            ReturnToAppStrategy.CustomUrlScheme("com.example.app")
         )
                 as PayPalPresentAuthChallengeResult.Failure
         assertEquals("error message from browser switch", result.error.errorDescription)
@@ -416,7 +417,7 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://paypal.com/app-switch"),
             "order-123",
             TokenType.ORDER_ID,
-            "custom_url_scheme"
+            ReturnToAppStrategy.CustomUrlScheme("custom_url_scheme")
         )
 
         val browserSwitchOptions = slot.captured
@@ -442,7 +443,7 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://paypal.com/vault-switch"),
             "setup-456",
             TokenType.VAULT_ID,
-            "custom_url_scheme"
+            ReturnToAppStrategy.CustomUrlScheme("custom_url_scheme")
         )
 
         val browserSwitchOptions = slot.captured
@@ -469,14 +470,14 @@ class PayPalWebLauncherUnitTest {
                 Uri.parse("https://test.com"),
                 "token-123",
                 TokenType.ORDER_ID,
-                "custom_url_scheme"
+                ReturnToAppStrategy.CustomUrlScheme("custom_url_scheme")
             )
                     as PayPalPresentAuthChallengeResult.Failure
         assertEquals("error message from browser switch", result.error.errorDescription)
     }
 
     @Test
-    fun `launchWithUrl() with appLinkUrl sets appLinkUri and returnUrlScheme`() {
+    fun `launchWithUrl() with AppLink sets appLinkUri and returnUrlScheme`() {
         sut = PayPalWebLauncher(browserSwitchClient)
 
         val slot = slot<BrowserSwitchOptions>()
@@ -490,14 +491,13 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://paypal.com/checkout"),
             "order-123",
             TokenType.ORDER_ID,
-            "custom_url_scheme",
-            appLinkUrl
+            ReturnToAppStrategy.AppLink(appLinkUrl)
         )
 
         val browserSwitchOptions = slot.captured
         expectThat(browserSwitchOptions) {
             get { metadata?.get("order_id") }.isEqualTo("order-123")
-            get { returnUrlScheme }.isEqualTo("custom_url_scheme") // Should use provided returnUrlScheme as fallback
+            get { returnUrlScheme }.isEqualTo(null)
             get { targetUri }.isEqualTo(Uri.parse("https://paypal.com/checkout"))
             get { requestCode }.isEqualTo(PAYPAL_CHECKOUT)
             get { this.appLinkUrl }.isEqualTo(appLinkUrl)
@@ -505,7 +505,7 @@ class PayPalWebLauncherUnitTest {
     }
 
     @Test
-    fun `launchWithUrl() with null appLinkUrl uses returnUrlScheme`() {
+    fun `launchWithUrl() with null AppLink uses returnUrlScheme`() {
         sut = PayPalWebLauncher(browserSwitchClient)
 
         val slot = slot<BrowserSwitchOptions>()
@@ -518,8 +518,7 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://paypal.com/checkout"),
             "order-123",
             TokenType.ORDER_ID,
-            "custom_url_scheme",
-            null
+            ReturnToAppStrategy.CustomUrlScheme("custom_url_scheme")
         )
 
         val browserSwitchOptions = slot.captured
@@ -533,7 +532,7 @@ class PayPalWebLauncherUnitTest {
     }
 
     @Test
-    fun `launchWithUrl() with vault token and appLinkUrl works correctly`() {
+    fun `launchWithUrl() with vault token and AppLink works correctly`() {
         sut = PayPalWebLauncher(browserSwitchClient)
 
         val slot = slot<BrowserSwitchOptions>()
@@ -547,14 +546,13 @@ class PayPalWebLauncherUnitTest {
             Uri.parse("https://paypal.com/vault"),
             "setup-456",
             TokenType.VAULT_ID,
-            "custom_url_scheme",
-            appLinkUrl
+            ReturnToAppStrategy.AppLink(appLinkUrl)
         )
 
         val browserSwitchOptions = slot.captured
         expectThat(browserSwitchOptions) {
             get { metadata?.get("setup_token_id") }.isEqualTo("setup-456")
-            get { returnUrlScheme }.isEqualTo("custom_url_scheme") // Should use provided returnUrlScheme as fallback
+            get { returnUrlScheme }.isEqualTo(null)
             get { targetUri }.isEqualTo(Uri.parse("https://paypal.com/vault"))
             get { requestCode }.isEqualTo(PAYPAL_VAULT)
             get { this.appLinkUrl }.isEqualTo(appLinkUrl)
@@ -570,13 +568,13 @@ class PayPalWebLauncherUnitTest {
             browserSwitchClient.start(activity, capture(slot))
         } returns BrowserSwitchStartResult.Success
 
-        // Call with old signature (should default appLinkUrl to null)
+        // Call with CustomUrlScheme
         sut.launchWithUrl(
             activity,
             Uri.parse("https://paypal.com/checkout"),
             "order-123",
             TokenType.ORDER_ID,
-            "custom_url_scheme"
+            ReturnToAppStrategy.CustomUrlScheme("custom_url_scheme")
         )
 
         val browserSwitchOptions = slot.captured


### PR DESCRIPTION
### Summary of changes
 - When appLinkUrl and deprecated param for urlScheme are not passed, then instead of constructing url using fallbackUrlScheme, null is passed in return url, this PR fixes issue

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
