### PR TITLE
append path to return url in confirm-payment source

### DIFF
--- a/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
@@ -86,7 +86,7 @@ class ApproveOrderViewModel @Inject constructor(
             val returnUrl =
                 ReturnUrlFactory.createGenericReturnUrl(
                     returnToAppStrategyOption.toReturnToAppStrategy(),
-                    "returnPath"
+                    "return-path"
                 )
             CardRequest(orderId, card, returnUrl, scaOption)
         }

--- a/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/approveorder/ApproveOrderViewModel.kt
@@ -84,7 +84,10 @@ class ApproveOrderViewModel @Inject constructor(
                 securityCode = cardSecurityCode
             )
             val returnUrl =
-                ReturnUrlFactory.createGenericReturnUrl(returnToAppStrategyOption.toReturnToAppStrategy())
+                ReturnUrlFactory.createGenericReturnUrl(
+                    returnToAppStrategyOption.toReturnToAppStrategy(),
+                    "returnPath"
+                )
             CardRequest(orderId, card, returnUrl, scaOption)
         }
         cardClient.approveOrder(cardRequest) { result ->

--- a/Demo/src/main/java/com/paypal/android/utils/ReturnUrlFactory.kt
+++ b/Demo/src/main/java/com/paypal/android/utils/ReturnUrlFactory.kt
@@ -4,9 +4,10 @@ import com.paypal.android.corepayments.ReturnToAppStrategy
 
 object ReturnUrlFactory {
 
-    fun createGenericReturnUrl(strategy: ReturnToAppStrategy) = when (strategy) {
-        is ReturnToAppStrategy.AppLink -> strategy.appLinkUrl
-        is ReturnToAppStrategy.CustomUrlScheme -> "${strategy.urlScheme}://"
+    fun createGenericReturnUrl(strategy: ReturnToAppStrategy, path: String? = null) =
+        when (strategy) {
+            is ReturnToAppStrategy.AppLink -> strategy.appLinkUrl + path?.let { "/$it" }
+            is ReturnToAppStrategy.CustomUrlScheme -> "${strategy.urlScheme}://" + path.orEmpty()
     }
 
     fun createCheckoutSuccessUrl(strategy: ReturnToAppStrategy) = when (strategy) {


### PR DESCRIPTION
### Summary of changes
 - Append path to returnUrl in confirmPaymentSource, when returnUrl is `CustomUrlScheme://` call fails

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
