### PR TITLE
[1.x] Fix PayPalWebCheckoutClient False Failure Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   * Explicitly declare Java 17 version as the target JVM toolchain
 * CardPayments
   * Skip deep link URL parsing in `CardClient` for `approveOrder()` and `vault()` 3DS authentication flows
+* PayPalWebPayments
+  * Fix issue with `PayPalWebCheckoutClient.start()` that caused explicit user cancelation to return a `Failure` event, instead of `Canceled`
+  * Fix issue with `PayPalWebCheckoutClient.vault()` that caused explicit user cancelation ro return a `Success` event, instead of `Canceled`
 
 ## 1.7.1 (2024-10-29)
 * Gradle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # PayPal Android SDK Release Notes
 
 ## unreleased
+
 * Gradle
   * Update Kotlin version to `1.9.24`
   * Update Android Gradle Plugin (AGP) to version `8.7.1`

--- a/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthLauncher.kt
+++ b/CardPayments/src/main/java/com/paypal/android/cardpayments/CardAuthLauncher.kt
@@ -15,8 +15,8 @@ internal class CardAuthLauncher(
 
     companion object {
         private const val METADATA_KEY_REQUEST_TYPE = "request_type"
-        private const val REQUEST_TYPE_APPROVE_ORDER = "approve_order"
-        private const val REQUEST_TYPE_VAULT = "vault"
+        private const val REQUEST_TYPE_APPROVE_ORDER = "card_approve_order"
+        private const val REQUEST_TYPE_VAULT = "card_vault"
 
         private const val METADATA_KEY_ORDER_ID = "order_id"
         private const val METADATA_KEY_SETUP_TOKEN_ID = "setup_token_id"

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/CardAuthLauncherUnitTest.kt
@@ -35,11 +35,11 @@ class CardAuthLauncherUnitTest {
     private val card = Card("4111111111111111", "01", "25", "123")
 
     private val approveOrderMetadata = JSONObject()
-        .put("request_type", "approve_order")
+        .put("request_type", "card_approve_order")
         .put("order_id", "fake-order-id")
 
     private val vaultMetadata = JSONObject()
-        .put("request_type", "vault")
+        .put("request_type", "card_vault")
         .put("setup_token_id", "fake-setup-token-id")
 
     @Before
@@ -78,7 +78,7 @@ class CardAuthLauncherUnitTest {
 
         val browserSwitchOptions = slot.captured
         val metadata = browserSwitchOptions.metadata
-        assertEquals("approve_order", metadata?.getString("request_type"))
+        assertEquals("card_approve_order", metadata?.getString("request_type"))
         assertEquals("fake-order-id", metadata?.getString("order_id"))
         assertEquals("merchant.app", browserSwitchOptions.returnUrlScheme)
         assertEquals(Uri.parse("https://fake.com/destination"), browserSwitchOptions.url)
@@ -99,7 +99,7 @@ class CardAuthLauncherUnitTest {
 
         val browserSwitchOptions = slot.captured
         val metadata = browserSwitchOptions.metadata
-        assertEquals("vault", metadata?.getString("request_type"))
+        assertEquals("card_vault", metadata?.getString("request_type"))
         assertEquals("fake-setup-token-id", metadata?.getString("setup_token_id"))
         assertEquals("merchant.app", browserSwitchOptions.returnUrlScheme)
         assertEquals(Uri.parse("https://fake.com/destination"), browserSwitchOptions.url)

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
@@ -27,8 +27,8 @@ internal class PayPalWebLauncher(
         private const val METADATA_KEY_ORDER_ID = "order_id"
         private const val METADATA_KEY_SETUP_TOKEN_ID = "setup_token_id"
 
-        private const val REQUEST_TYPE_CHECKOUT = "checkout"
-        private const val REQUEST_TYPE_VAULT = "vault"
+        private const val REQUEST_TYPE_CHECKOUT = "paypal_checkout"
+        private const val REQUEST_TYPE_VAULT = "paypal_vault"
 
         private const val URL_PARAM_APPROVAL_SESSION_ID = "approval_session_id"
     }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
@@ -169,8 +169,11 @@ internal class PayPalWebLauncher(
         return if (deepLinkUrl == null || requestMetadata == null) {
             PayPalWebStatus.VaultError(PayPalWebCheckoutError.unknownError)
         } else {
+            val isCancelUrl = deepLinkUrl.path?.contains("cancel") ?: false
             val approvalSessionId = deepLinkUrl.getQueryParameter(URL_PARAM_APPROVAL_SESSION_ID)
-            if (approvalSessionId.isNullOrEmpty()) {
+            if (isCancelUrl) {
+                PayPalWebStatus.VaultCanceled
+            } else if (approvalSessionId.isNullOrEmpty()) {
                 PayPalWebStatus.VaultError(PayPalWebCheckoutError.malformedResultError)
             } else {
                 val result = PayPalWebVaultResult(approvalSessionId)

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
@@ -25,6 +25,7 @@ internal class PayPalWebLauncher(
     companion object {
         private const val METADATA_KEY_REQUEST_TYPE = "request_type"
         private const val METADATA_KEY_ORDER_ID = "order_id"
+        private const val METADATA_KEY_OP_TYPE = "opType"
         private const val METADATA_KEY_SETUP_TOKEN_ID = "setup_token_id"
 
         private const val REQUEST_TYPE_CHECKOUT = "paypal_checkout"
@@ -143,7 +144,10 @@ internal class PayPalWebLauncher(
         } else {
             val payerId = deepLinkUrl.getQueryParameter("PayerID")
             val orderId = metadata.optString(METADATA_KEY_ORDER_ID)
-            if (orderId.isNullOrBlank() || payerId.isNullOrBlank()) {
+            val opType = deepLinkUrl.getQueryParameter(METADATA_KEY_OP_TYPE)
+            if (opType == "cancel") {
+                PayPalWebStatus.CheckoutCanceled(orderId)
+            } else if (orderId.isNullOrBlank() || payerId.isNullOrBlank()) {
                 PayPalWebStatus.CheckoutError(PayPalWebCheckoutError.malformedResultError, orderId)
             } else {
                 PayPalWebStatus.CheckoutSuccess(PayPalWebCheckoutResult(orderId, payerId))

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
@@ -62,7 +62,7 @@ class PayPalWebLauncherUnitTest {
         val browserSwitchOptions = slot.captured
         expectThat(browserSwitchOptions) {
             get { metadata?.get("order_id") }.isEqualTo("fake-order-id")
-            get { metadata?.get("request_type") }.isEqualTo("checkout")
+            get { metadata?.get("request_type") }.isEqualTo("paypal_checkout")
             get { returnUrlScheme }.isEqualTo("custom_url_scheme")
             get { url }.isEqualTo(Uri.parse(expectedUrl))
         }
@@ -88,7 +88,7 @@ class PayPalWebLauncherUnitTest {
         val browserSwitchOptions = slot.captured
         expectThat(browserSwitchOptions) {
             get { metadata?.get("order_id") }.isEqualTo("fake-order-id")
-            get { metadata?.get("request_type") }.isEqualTo("checkout")
+            get { metadata?.get("request_type") }.isEqualTo("paypal_checkout")
             get { returnUrlScheme }.isEqualTo("custom_url_scheme")
             get { url }.isEqualTo(Uri.parse(expectedUrl))
         }
@@ -114,7 +114,7 @@ class PayPalWebLauncherUnitTest {
         val browserSwitchOptions = slot.captured
         expectThat(browserSwitchOptions) {
             get { metadata?.get("order_id") }.isEqualTo("fake-order-id")
-            get { metadata?.get("request_type") }.isEqualTo("checkout")
+            get { metadata?.get("request_type") }.isEqualTo("paypal_checkout")
             get { returnUrlScheme }.isEqualTo("custom_url_scheme")
             get { url }.isEqualTo(Uri.parse(expectedUrl))
         }
@@ -140,7 +140,7 @@ class PayPalWebLauncherUnitTest {
         val browserSwitchOptions = slot.captured
         expectThat(browserSwitchOptions) {
             get { metadata?.get("order_id") }.isEqualTo("fake-order-id")
-            get { metadata?.get("request_type") }.isEqualTo("checkout")
+            get { metadata?.get("request_type") }.isEqualTo("paypal_checkout")
             get { returnUrlScheme }.isEqualTo("custom_url_scheme")
             get { url }.isEqualTo(Uri.parse(expectedUrl))
         }
@@ -176,7 +176,7 @@ class PayPalWebLauncherUnitTest {
         val browserSwitchOptions = slot.captured
         expectThat(browserSwitchOptions) {
             get { metadata?.get("setup_token_id") }.isEqualTo("fake-setup-token")
-            get { metadata?.get("request_type") }.isEqualTo("vault")
+            get { metadata?.get("request_type") }.isEqualTo("paypal_vault")
             get { returnUrlScheme }.isEqualTo("custom_url_scheme")
             get { url }.isEqualTo(Uri.parse(expectedUrl))
         }
@@ -198,7 +198,7 @@ class PayPalWebLauncherUnitTest {
         val browserSwitchOptions = slot.captured
         expectThat(browserSwitchOptions) {
             get { metadata?.get("setup_token_id") }.isEqualTo("fake-setup-token")
-            get { metadata?.get("request_type") }.isEqualTo("vault")
+            get { metadata?.get("request_type") }.isEqualTo("paypal_vault")
             get { returnUrlScheme }.isEqualTo("custom_url_scheme")
             get { url }.isEqualTo(Uri.parse(expectedUrl))
         }
@@ -376,7 +376,7 @@ class PayPalWebLauncherUnitTest {
 
     private fun createVaultMetadata(setupTokenId: String) = JSONObject()
         .put("setup_token_id", setupTokenId)
-        .put("request_type", "vault")
+        .put("request_type", "paypal_vault")
 
     private fun createVaultDeepLinkUrl(approvalSessionId: String) =
         Uri.parse("http://testurl.com/checkout?approval_session_id=$approvalSessionId")

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
@@ -360,6 +360,19 @@ class PayPalWebLauncherUnitTest {
     }
 
     @Test
+    fun `deliverBrowserSwitchResult() parses vault cancellation when deep link url indicates failure`() {
+        val browserSwitchResult = createVaultCancellationBrowserSwitchResult(
+            setupTokenId = "fake-setup-token-id",
+            approvalSessionId = "fake-approval-session-id",
+        )
+        every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+        sut = PayPalWebLauncher("custom_url_scheme", liveConfig, browserSwitchClient)
+        val status = sut.deliverBrowserSwitchResult(activity)
+        assertTrue(status is PayPalWebStatus.VaultCanceled)
+    }
+
+    @Test
     fun `deliverBrowserSwitchResult() parses vault cancelations`() {
         val browserSwitchResult = createVaultCanceledBrowserSwitchResult("fake-setup-token-id")
         every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
@@ -408,6 +421,16 @@ class PayPalWebLauncherUnitTest {
         metadata: JSONObject? = setupTokenId?.let { createVaultMetadata(it) },
         deepLinkUrl: Uri? = approvalSessionId?.let { createVaultDeepLinkUrl(it) }
     ) = createBrowserSwitchResult(BrowserSwitchStatus.SUCCESS, metadata, deepLinkUrl)
+
+    private fun createVaultCancellationBrowserSwitchResult(
+        setupTokenId: String,
+        approvalSessionId: String
+    ): BrowserSwitchResult {
+        val metadata = createVaultMetadata(setupTokenId)
+        val deepLinkUrl =
+            "http://testurl.com/checkout/cancel?approval_session_id=$approvalSessionId".toUri()
+        return createBrowserSwitchResult(BrowserSwitchStatus.SUCCESS, metadata, deepLinkUrl)
+    }
 
     private fun createVaultCanceledBrowserSwitchResult(setupTokenId: String) =
         createBrowserSwitchResult(

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
@@ -1,6 +1,7 @@
 package com.paypal.android.paypalwebpayments
 
 import android.net.Uri
+import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import com.braintreepayments.api.BrowserSwitchClient
 import com.braintreepayments.api.BrowserSwitchException
@@ -290,6 +291,20 @@ class PayPalWebLauncherUnitTest {
     }
 
     @Test
+    fun `deliverBrowserSwitchResult() parses checkout cancellation when deep link url indicates failure`() {
+        val browserSwitchResult =
+            createCheckoutCancellationBrowserSwitchResult(orderId = "fake-order-id")
+        every { browserSwitchClient.deliverResult(activity) } returns browserSwitchResult
+
+        sut = PayPalWebLauncher("custom_url_scheme", liveConfig, browserSwitchClient)
+        val status = sut.deliverBrowserSwitchResult(activity)
+        assertTrue(status is PayPalWebStatus.CheckoutCanceled)
+
+        val actualOrderId = (status as? PayPalWebStatus.CheckoutCanceled)?.orderId
+        assertEquals("fake-order-id", actualOrderId)
+    }
+
+    @Test
     fun `deliverBrowserSwitchResult() parses checkout cancelations`() {
         val browserSwitchResult = createCheckoutCanceledBrowserSwitchResult("fake-order-id")
         createBrowserSwitchResult(BrowserSwitchStatus.CANCELED)
@@ -367,6 +382,12 @@ class PayPalWebLauncherUnitTest {
         metadata: JSONObject? = orderId?.let { createCheckoutMetadata(it) },
         deepLinkUrl: Uri? = payerId?.let { createCheckoutDeepLinkUrl(it) }
     ) = createBrowserSwitchResult(BrowserSwitchStatus.SUCCESS, metadata, deepLinkUrl)
+
+    private fun createCheckoutCancellationBrowserSwitchResult(orderId: String): BrowserSwitchResult {
+        val deepLinkUrl = "http://testurl.com/checkout?opType=cancel".toUri()
+        val metadata = createCheckoutMetadata(orderId)
+        return createBrowserSwitchResult(BrowserSwitchStatus.SUCCESS, metadata, deepLinkUrl)
+    }
 
     private fun createCheckoutCanceledBrowserSwitchResult(orderId: String) =
         createBrowserSwitchResult(


### PR DESCRIPTION
### Summary of changes

* PayPalWebPayments
  * Fix issue with `PayPalWebCheckoutClient.start()` that caused explicit user cancelation to return a `Failure` event, instead of `Canceled`
  * Fix issue with `PayPalWebCheckoutClient.vault()` that caused explicit user cancelation ro return a `Success` event, instead of `Canceled`
  * Rename the following browser switch metadata values to avoid collisions with other payment clients:
    * `REQUEST_TYPE_CHECKOUT`
    * `REQUEST_TYPE_VAULT`
* CardPayments
  * Rename the following browser switch metadata values to avoid collisions with other payment clients:
    * `REQUEST_TYPE_APPROVE_ORDER`
    * `REQUEST_TYPE_VAULT`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
