### PR TITLE
[PATCH] add button session id to analytics events

### DIFF
--- a/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventData.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventData.kt
@@ -60,5 +60,7 @@ internal data class TrackingEventParams(
     @SerialName("button_type")
     val buttonType: String? = null,
     @SerialName("app_switch_enabled")
-    val appSwitchEnabled: Boolean = false
+    val appSwitchEnabled: Boolean = false,
+    @SerialName("button_session_id")
+    val buttonSessionId: String? = null
 )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventsAPI.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventsAPI.kt
@@ -45,7 +45,8 @@ internal class TrackingEventsAPI constructor(
             tenantName = TENANT_NAME_PAYPAL,
             orderId = event.orderId,
             buttonType = event.buttonType,
-            appSwitchEnabled = event.appSwitchEnabled
+            appSwitchEnabled = event.appSwitchEnabled,
+            buttonSessionId = event.buttonSessionId
         )
 
         val events = TrackingEvents(eventParams = eventParams)

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
@@ -7,5 +7,6 @@ internal data class AnalyticsEventData(
     val timestamp: Long,
     val orderId: String?,
     val buttonType: String? = null,
-    val appSwitchEnabled: Boolean
+    val appSwitchEnabled: Boolean,
+    val buttonSessionId: String? = null
 )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
@@ -44,7 +44,8 @@ class AnalyticsService internal constructor(
         name: String,
         orderId: String? = null,
         buttonType: String? = null,
-        appSwitchEnabled: Boolean = false
+        appSwitchEnabled: Boolean = false,
+        buttonSessionId: String? = null
     ) {
         // TODO: send analytics event using WorkManager (supports coroutines) to avoid lint error
         // thrown because we don't use the Deferred result
@@ -58,7 +59,8 @@ class AnalyticsService internal constructor(
                     timestamp,
                     orderId = orderId,
                     buttonType = buttonType,
-                    appSwitchEnabled = appSwitchEnabled
+                    appSwitchEnabled = appSwitchEnabled,
+                    buttonSessionId = buttonSessionId
                 )
                 val response = trackingEventsAPI.sendEvent(analyticsEventData, deviceData)
                 response.error?.message?.let { errorMessage ->

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/ButtonSessionStore.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/ButtonSessionStore.kt
@@ -1,0 +1,16 @@
+package com.paypal.android.corepayments.analytics
+
+import androidx.annotation.RestrictTo
+import java.util.UUID
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object ButtonSessionStore {
+
+    @Volatile
+    var buttonSessionId: String = UUID.randomUUID().toString()
+        private set
+
+    fun resetSession() {
+        buttonSessionId = UUID.randomUUID().toString()
+    }
+}

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/analytics/ButtonSessionStoreUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/analytics/ButtonSessionStoreUnitTest.kt
@@ -1,0 +1,26 @@
+package com.paypal.android.corepayments.analytics
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ButtonSessionStoreUnitTest {
+
+    @Test
+    fun `buttonSessionId is initialized with a non-blank value`() {
+        assertFalse(ButtonSessionStore.buttonSessionId.isBlank())
+    }
+
+    @Test
+    fun `resetSession changes buttonSessionId`() {
+        val before = ButtonSessionStore.buttonSessionId
+        ButtonSessionStore.resetSession()
+        assertNotEquals(before, ButtonSessionStore.buttonSessionId)
+    }
+
+    @Test
+    fun `buttonSessionId is non-blank after resetSession`() {
+        ButtonSessionStore.resetSession()
+        assertFalse(ButtonSessionStore.buttonSessionId.isBlank())
+    }
+}

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -12,6 +12,7 @@ import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.corepayments.UpdateClientConfigAPI
 import com.paypal.android.corepayments.analytics.AnalyticsService
+import com.paypal.android.corepayments.analytics.ButtonSessionStore
 import com.paypal.android.corepayments.api.PatchCCOWithAppSwitchEligibility
 import com.paypal.android.corepayments.common.DeviceInspector
 import com.paypal.android.corepayments.model.APIResult
@@ -125,7 +126,7 @@ class PayPalWebCheckoutClient internal constructor(
     ): PayPalPresentAuthChallengeResult {
         checkoutOrderId = request.orderId
         appSwitchEnabled = false
-        analytics.notify(CheckoutEvent.STARTED, checkoutOrderId, appSwitchEnabled)
+        analytics.notify(CheckoutEvent.STARTED, checkoutOrderId, appSwitchEnabled, ButtonSessionStore.buttonSessionId)
 
         val returnToAppStrategy = resolveReturnToAppStrategy(request.returnToAppStrategy)
             ?: return PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.noReturnToAppStrategyError)
@@ -149,7 +150,8 @@ class PayPalWebCheckoutClient internal constructor(
                 analytics.notify(
                     CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
                     checkoutOrderId,
-                    appSwitchEnabled
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
                 )
 
                 // update auth state value in session store
@@ -160,7 +162,8 @@ class PayPalWebCheckoutClient internal constructor(
                 analytics.notify(
                     CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
                     checkoutOrderId,
-                    appSwitchEnabled
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
                 )
             }
         }
@@ -179,7 +182,7 @@ class PayPalWebCheckoutClient internal constructor(
     ): PayPalPresentAuthChallengeResult {
 
         checkoutOrderId = request.orderId
-        analytics.notify(CheckoutEvent.STARTED, checkoutOrderId, appSwitchEnabled)
+        analytics.notify(CheckoutEvent.STARTED, checkoutOrderId, appSwitchEnabled, ButtonSessionStore.buttonSessionId)
 
         val returnToAppStrategy = resolveReturnToAppStrategy(request.returnToAppStrategy)
             ?: return PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.noReturnToAppStrategyError)
@@ -222,7 +225,8 @@ class PayPalWebCheckoutClient internal constructor(
                 analytics.notify(
                     CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
                     checkoutOrderId,
-                    appSwitchEnabled
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
                 )
 
                 // update auth state value in session store
@@ -233,7 +237,8 @@ class PayPalWebCheckoutClient internal constructor(
                 analytics.notify(
                     CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
                     checkoutOrderId,
-                    appSwitchEnabled
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
                 )
             }
         }
@@ -275,7 +280,7 @@ class PayPalWebCheckoutClient internal constructor(
         request: PayPalWebVaultRequest
     ): PayPalPresentAuthChallengeResult {
         vaultSetupTokenId = request.setupTokenId
-        analytics.notify(VaultEvent.STARTED, vaultSetupTokenId, appSwitchEnabled)
+        analytics.notify(VaultEvent.STARTED, vaultSetupTokenId, appSwitchEnabled, ButtonSessionStore.buttonSessionId)
 
         val returnToAppStrategy = resolveReturnToAppStrategy(request.returnToAppStrategy)
             ?: return PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.noReturnToAppStrategyError)
@@ -295,7 +300,8 @@ class PayPalWebCheckoutClient internal constructor(
                 analytics.notify(
                     VaultEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
                     vaultSetupTokenId,
-                    appSwitchEnabled
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
                 )
 
                 // update auth state value in session store
@@ -306,7 +312,8 @@ class PayPalWebCheckoutClient internal constructor(
                 analytics.notify(
                     VaultEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
                     vaultSetupTokenId,
-                    appSwitchEnabled
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
                 )
             }
         }
@@ -325,7 +332,7 @@ class PayPalWebCheckoutClient internal constructor(
         request: PayPalWebVaultRequest
     ): PayPalPresentAuthChallengeResult {
         vaultSetupTokenId = request.setupTokenId
-        analytics.notify(VaultEvent.STARTED, vaultSetupTokenId, appSwitchEnabled)
+        analytics.notify(VaultEvent.STARTED, vaultSetupTokenId, appSwitchEnabled, ButtonSessionStore.buttonSessionId)
 
         val returnToAppStrategy = resolveReturnToAppStrategy(request.returnToAppStrategy)
             ?: return PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.noReturnToAppStrategyError)
@@ -352,7 +359,8 @@ class PayPalWebCheckoutClient internal constructor(
                 analytics.notify(
                     VaultEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
                     vaultSetupTokenId,
-                    appSwitchEnabled
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
                 )
 
                 // update auth state value in session store
@@ -363,7 +371,8 @@ class PayPalWebCheckoutClient internal constructor(
                 analytics.notify(
                     VaultEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
                     vaultSetupTokenId,
-                    appSwitchEnabled
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
                 )
             }
         }
@@ -407,14 +416,35 @@ class PayPalWebCheckoutClient internal constructor(
     fun finishStart(intent: Intent, authState: String): PayPalWebCheckoutFinishStartResult {
         val result = payPalWebLauncher.completeCheckoutAuthRequest(intent, authState)
         when (result) {
-            is PayPalWebCheckoutFinishStartResult.Success ->
-                analytics.notify(CheckoutEvent.SUCCEEDED, checkoutOrderId, appSwitchEnabled)
+            is PayPalWebCheckoutFinishStartResult.Success -> {
+                analytics.notify(
+                    CheckoutEvent.SUCCEEDED,
+                    checkoutOrderId,
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
+                )
+                ButtonSessionStore.resetSession()
+            }
 
-            is PayPalWebCheckoutFinishStartResult.Canceled ->
-                analytics.notify(CheckoutEvent.CANCELED, checkoutOrderId, appSwitchEnabled)
+            is PayPalWebCheckoutFinishStartResult.Canceled -> {
+                analytics.notify(
+                    CheckoutEvent.CANCELED,
+                    checkoutOrderId,
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
+                )
+                ButtonSessionStore.resetSession()
+            }
 
-            is PayPalWebCheckoutFinishStartResult.Failure ->
-                analytics.notify(CheckoutEvent.FAILED, checkoutOrderId, appSwitchEnabled)
+            is PayPalWebCheckoutFinishStartResult.Failure -> {
+                analytics.notify(
+                    CheckoutEvent.FAILED,
+                    checkoutOrderId,
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
+                )
+                ButtonSessionStore.resetSession()
+            }
 
             PayPalWebCheckoutFinishStartResult.NoResult -> {
                 // no analytics tracking required at the moment
@@ -439,27 +469,33 @@ class PayPalWebCheckoutClient internal constructor(
                     analytics.notify(
                         CheckoutEvent.SUCCEEDED,
                         checkoutOrderId,
-                        appSwitchEnabled
+                        appSwitchEnabled,
+                        ButtonSessionStore.buttonSessionId
                     )
                     sessionStore.clear()
+                    ButtonSessionStore.resetSession()
                 }
 
                 is PayPalWebCheckoutFinishStartResult.Canceled -> {
                     analytics.notify(
                         CheckoutEvent.CANCELED,
                         checkoutOrderId,
-                        appSwitchEnabled
+                        appSwitchEnabled,
+                        ButtonSessionStore.buttonSessionId
                     )
                     sessionStore.clear()
+                    ButtonSessionStore.resetSession()
                 }
 
                 is PayPalWebCheckoutFinishStartResult.Failure -> {
                     analytics.notify(
                         CheckoutEvent.FAILED,
                         checkoutOrderId,
-                        appSwitchEnabled
+                        appSwitchEnabled,
+                        ButtonSessionStore.buttonSessionId
                     )
                     sessionStore.clear()
+                    ButtonSessionStore.resetSession()
                 }
 
                 PayPalWebCheckoutFinishStartResult.NoResult -> {
@@ -489,13 +525,28 @@ class PayPalWebCheckoutClient internal constructor(
         // TODO: see if we can get setup token id from somewhere for tracking
         when (result) {
             is PayPalWebCheckoutFinishVaultResult.Success ->
-                analytics.notify(VaultEvent.SUCCEEDED, vaultSetupTokenId, appSwitchEnabled)
+                analytics.notify(
+                    VaultEvent.SUCCEEDED,
+                    vaultSetupTokenId,
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
+                )
 
             is PayPalWebCheckoutFinishVaultResult.Failure ->
-                analytics.notify(VaultEvent.FAILED, vaultSetupTokenId, appSwitchEnabled)
+                analytics.notify(
+                    VaultEvent.FAILED,
+                    vaultSetupTokenId,
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
+                )
 
             PayPalWebCheckoutFinishVaultResult.Canceled ->
-                analytics.notify(VaultEvent.CANCELED, vaultSetupTokenId, appSwitchEnabled)
+                analytics.notify(
+                    VaultEvent.CANCELED,
+                    vaultSetupTokenId,
+                    appSwitchEnabled,
+                    ButtonSessionStore.buttonSessionId
+                )
 
             PayPalWebCheckoutFinishVaultResult.NoResult -> {
                 // no analytics tracking required at the moment
@@ -580,17 +631,32 @@ class PayPalWebCheckoutClient internal constructor(
             val result = payPalWebLauncher.completeVaultAuthRequest(intent, authState)
             when (result) {
                 is PayPalWebCheckoutFinishVaultResult.Success -> {
-                    analytics.notify(VaultEvent.SUCCEEDED, vaultSetupTokenId, appSwitchEnabled)
+                    analytics.notify(
+                        VaultEvent.SUCCEEDED,
+                        vaultSetupTokenId,
+                        appSwitchEnabled,
+                        ButtonSessionStore.buttonSessionId
+                    )
                     sessionStore.clear()
                 }
 
                 is PayPalWebCheckoutFinishVaultResult.Failure -> {
-                    analytics.notify(VaultEvent.FAILED, vaultSetupTokenId, appSwitchEnabled)
+                    analytics.notify(
+                        VaultEvent.FAILED,
+                        vaultSetupTokenId,
+                        appSwitchEnabled,
+                        ButtonSessionStore.buttonSessionId
+                    )
                     sessionStore.clear()
                 }
 
                 PayPalWebCheckoutFinishVaultResult.Canceled -> {
-                    analytics.notify(VaultEvent.CANCELED, vaultSetupTokenId, appSwitchEnabled)
+                    analytics.notify(
+                        VaultEvent.CANCELED,
+                        vaultSetupTokenId,
+                        appSwitchEnabled,
+                        ButtonSessionStore.buttonSessionId
+                    )
                     sessionStore.clear()
                 }
 

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/PayPalWebAnalytics.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/PayPalWebAnalytics.kt
@@ -4,19 +4,21 @@ import com.paypal.android.corepayments.analytics.AnalyticsService
 
 internal class PayPalWebAnalytics(private val analyticsService: AnalyticsService) {
 
-    fun notify(event: CheckoutEvent, orderId: String?, appSwitchEnabled: Boolean) {
+    fun notify(event: CheckoutEvent, orderId: String?, appSwitchEnabled: Boolean, buttonSessionId: String?) {
         analyticsService.sendAnalyticsEvent(
             name = event.value,
             orderId = orderId,
-            appSwitchEnabled = appSwitchEnabled
+            appSwitchEnabled = appSwitchEnabled,
+            buttonSessionId = buttonSessionId
         )
     }
 
-    fun notify(event: VaultEvent, setupTokenId: String?, appSwitchEnabled: Boolean) {
+    fun notify(event: VaultEvent, setupTokenId: String?, appSwitchEnabled: Boolean, buttonSessionId: String?) {
         analyticsService.sendAnalyticsEvent(
             name = event.value,
             orderId = setupTokenId,
-            appSwitchEnabled = appSwitchEnabled
+            appSwitchEnabled = appSwitchEnabled,
+            buttonSessionId = buttonSessionId
         )
     }
 }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -7,6 +7,7 @@ import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.corepayments.UpdateClientConfigAPI
+import com.paypal.android.corepayments.analytics.ButtonSessionStore
 import com.paypal.android.corepayments.api.PatchCCOWithAppSwitchEligibility
 import com.paypal.android.corepayments.common.DeviceInspector
 import com.paypal.android.corepayments.model.APIResult
@@ -22,6 +23,8 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import io.mockk.verify
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertSame
@@ -92,6 +95,8 @@ class PayPalWebCheckoutClientUnitTest {
 
     @Test
     fun `startAsync() launches PayPal web checkout`() = runTest {
+        mockkObject(ButtonSessionStore)
+        every { ButtonSessionStore.buttonSessionId } returns "fake-session-id"
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
         every {
             payPalWebLauncher.launchWithUrl(
@@ -119,6 +124,15 @@ class PayPalWebCheckoutClientUnitTest {
                 returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
             )
         }
+        verify {
+            analytics.notify(
+                CheckoutEvent.STARTED,
+                "fake-order-id",
+                any(),
+                "fake-session-id"
+            )
+        }
+        unmockkObject(ButtonSessionStore)
     }
 
     @Test
@@ -200,6 +214,8 @@ class PayPalWebCheckoutClientUnitTest {
 
     @Test
     fun `finishStart() with merchant provided auth state forwards success result from auth launcher`() {
+        mockkObject(ButtonSessionStore)
+        every { ButtonSessionStore.buttonSessionId } returns "fake-session-id"
         val successResult =
             PayPalWebCheckoutFinishStartResult.Success("fake-order-id", "fake-payer-id")
         every {
@@ -208,10 +224,14 @@ class PayPalWebCheckoutClientUnitTest {
 
         val result = sut.finishStart(intent, "auth state")
         assertSame(successResult, result)
+        verify { analytics.notify(CheckoutEvent.SUCCEEDED, any(), any(), "fake-session-id") }
+        verify { ButtonSessionStore.resetSession() }
+        unmockkObject(ButtonSessionStore)
     }
 
     @Test
     fun `finishStart() with merchant provided auth state forwards error result from auth launcher`() {
+        mockkObject(ButtonSessionStore)
         val error = PayPalSDKError(123, "fake-error-description")
         val failureResult = PayPalWebCheckoutFinishStartResult.Failure(error, null)
         every {
@@ -220,10 +240,13 @@ class PayPalWebCheckoutClientUnitTest {
 
         val result = sut.finishStart(intent, "auth state")
         assertSame(failureResult, result)
+        verify { ButtonSessionStore.resetSession() }
+        unmockkObject(ButtonSessionStore)
     }
 
     @Test
     fun `finishStart() with merchant provided auth state forwards cancellation result from auth launcher`() {
+        mockkObject(ButtonSessionStore)
         val canceledResult = PayPalWebCheckoutFinishStartResult.Canceled("fake-order-id")
         every {
             payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
@@ -231,6 +254,8 @@ class PayPalWebCheckoutClientUnitTest {
 
         val result = sut.finishStart(intent, "auth state")
         assertSame(canceledResult, result)
+        verify { ButtonSessionStore.resetSession() }
+        unmockkObject(ButtonSessionStore)
     }
 
     @Test
@@ -241,6 +266,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `finishStart() with session auth state forwards success result from auth launcher`() =
         runTest {
+        mockkObject(ButtonSessionStore)
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
             every {
                 payPalWebLauncher.launchWithUrl(
@@ -265,6 +291,8 @@ class PayPalWebCheckoutClientUnitTest {
             sut.startAsync(activity, request)
         val result = sut.finishStart(intent)
         assertSame(successResult, result)
+        verify { ButtonSessionStore.resetSession() }
+        unmockkObject(ButtonSessionStore)
     }
 
     @Test
@@ -308,6 +336,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `finishStart() with session auth state forwards error result from auth launcher`() =
         runTest {
+        mockkObject(ButtonSessionStore)
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
             every {
                 payPalWebLauncher.launchWithUrl(
@@ -332,6 +361,8 @@ class PayPalWebCheckoutClientUnitTest {
             sut.startAsync(activity, request)
         val result = sut.finishStart(intent)
         assertSame(failureResult, result)
+        verify { ButtonSessionStore.resetSession() }
+        unmockkObject(ButtonSessionStore)
     }
 
     @Test
@@ -366,6 +397,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `finishStart() with session auth state forwards cancellation result from auth launcher`() =
         runTest {
+        mockkObject(ButtonSessionStore)
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
             every {
                 payPalWebLauncher.launchWithUrl(
@@ -389,6 +421,8 @@ class PayPalWebCheckoutClientUnitTest {
             sut.startAsync(activity, request)
         val result = sut.finishStart(intent)
         assertSame(canceledResult, result)
+        verify { ButtonSessionStore.resetSession() }
+        unmockkObject(ButtonSessionStore)
     }
 
     @Test
@@ -1403,7 +1437,7 @@ class PayPalWebCheckoutClientUnitTest {
         assertSame(launchResult, result)
 
         // Verify analytics was called with CheckoutEvent
-        verify { analytics.notify(any<CheckoutEvent>(), "fake-order-id", any()) }
+        verify { analytics.notify(any<CheckoutEvent>(), "fake-order-id", any(), any()) }
 
         // Verify launchWithUrl is called (the deprecated method calls it directly)
         verify(exactly = 1) {
@@ -1464,7 +1498,7 @@ class PayPalWebCheckoutClientUnitTest {
         assertSame(launchResult, result)
 
         // Verify analytics was called with VaultEvent
-        verify { analytics.notify(any<VaultEvent>(), any(), any()) }
+        verify { analytics.notify(any<VaultEvent>(), any(), any(), any()) }
 
         // Verify launchWithUrl is called (the deprecated method calls it directly)
         verify(exactly = 1) {
@@ -1813,12 +1847,13 @@ class PayPalWebCheckoutClientUnitTest {
             sut.startAsync(activity, request)
 
             // Then
-            verify { analytics.notify(CheckoutEvent.STARTED, "fake-order-id", false) }
+            verify { analytics.notify(CheckoutEvent.STARTED, "fake-order-id", false, any()) }
             verify {
                 analytics.notify(
                     CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
                     "fake-order-id",
-                    false
+                    false,
+                    any()
                 )
             }
         }
@@ -1847,7 +1882,7 @@ class PayPalWebCheckoutClientUnitTest {
         sut.finishStart(intent)
 
         // Then
-        verify { analytics.notify(CheckoutEvent.CANCELED, "fake-order-id", false) }
+        verify { analytics.notify(CheckoutEvent.CANCELED, "fake-order-id", false, any()) }
     }
 
     @Test
@@ -1875,7 +1910,7 @@ class PayPalWebCheckoutClientUnitTest {
         sut.finishStart(intent)
 
         // Then
-        verify { analytics.notify(CheckoutEvent.FAILED, "fake-order-id", false) }
+        verify { analytics.notify(CheckoutEvent.FAILED, "fake-order-id", false, any()) }
     }
 
     @Test
@@ -1897,12 +1932,13 @@ class PayPalWebCheckoutClientUnitTest {
             sut.vaultAsync(activity, request)
 
             // Then
-            verify { analytics.notify(VaultEvent.STARTED, "fake-setup-token-id", false) }
+            verify { analytics.notify(VaultEvent.STARTED, "fake-setup-token-id", false, any()) }
             verify {
                 analytics.notify(
                     VaultEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
                     "fake-setup-token-id",
-                    false
+                    false,
+                    any()
                 )
             }
         }
@@ -1924,12 +1960,13 @@ class PayPalWebCheckoutClientUnitTest {
         sut.start(activity, request)
 
         // Then
-        verify { analytics.notify(CheckoutEvent.STARTED, "fake-order-id", false) }
+        verify { analytics.notify(CheckoutEvent.STARTED, "fake-order-id", false, any()) }
         verify {
             analytics.notify(
                 CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
                 "fake-order-id",
-                false
+                false,
+                any()
             )
         }
     }
@@ -1951,12 +1988,13 @@ class PayPalWebCheckoutClientUnitTest {
         sut.vault(activity, request)
 
         // Then
-        verify { analytics.notify(VaultEvent.STARTED, "fake-setup-token-id", false) }
+        verify { analytics.notify(VaultEvent.STARTED, "fake-setup-token-id", false, any()) }
         verify {
             analytics.notify(
                 VaultEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
                 "fake-setup-token-id",
-                false
+                false,
+                any()
             )
         }
     }

--- a/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PayLaterButton.kt
+++ b/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PayLaterButton.kt
@@ -5,6 +5,7 @@ import android.content.res.TypedArray
 import android.util.AttributeSet
 import android.view.View
 import androidx.core.content.res.use
+import com.paypal.android.corepayments.analytics.ButtonSessionStore
 import com.paypal.android.ui.R
 
 
@@ -71,7 +72,8 @@ class PayLaterButton @JvmOverloads constructor(
         analyticsService.sendAnalyticsEvent(
             "payment-button:initialized",
             orderId = null,
-            buttonType = PaymentButtonFundingType.PAY_LATER.buttonType
+            buttonType = PaymentButtonFundingType.PAY_LATER.buttonType,
+            buttonSessionId = ButtonSessionStore.buttonSessionId
         )
     }
 

--- a/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PayPalButton.kt
+++ b/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PayPalButton.kt
@@ -5,6 +5,7 @@ import android.content.res.TypedArray
 import android.util.AttributeSet
 import android.view.View
 import androidx.core.content.res.use
+import com.paypal.android.corepayments.analytics.ButtonSessionStore
 import com.paypal.android.paymentbuttons.error.createFormattedIllegalArgumentException
 import com.paypal.android.ui.R
 
@@ -73,7 +74,8 @@ open class PayPalButton @JvmOverloads constructor(
         analyticsService.sendAnalyticsEvent(
             "payment-button:initialized",
             orderId = null,
-            buttonType = PaymentButtonFundingType.PAYPAL.buttonType
+            buttonType = PaymentButtonFundingType.PAYPAL.buttonType,
+            buttonSessionId = ButtonSessionStore.buttonSessionId
         )
     }
 

--- a/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PayPalCreditButton.kt
+++ b/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PayPalCreditButton.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.TypedArray
 import android.util.AttributeSet
 import androidx.core.content.res.use
+import com.paypal.android.corepayments.analytics.ButtonSessionStore
 import com.paypal.android.paymentbuttons.error.createFormattedIllegalArgumentException
 import com.paypal.android.ui.R
 import com.paypal.android.paymentbuttons.PayPalCreditButtonColor.BLACK
@@ -56,7 +57,8 @@ class PayPalCreditButton @JvmOverloads constructor(
         analyticsService.sendAnalyticsEvent(
             "payment-button:initialized",
             orderId = null,
-            buttonType = PaymentButtonFundingType.PAYPAL_CREDIT.buttonType
+            buttonType = PaymentButtonFundingType.PAYPAL_CREDIT.buttonType,
+            buttonSessionId = ButtonSessionStore.buttonSessionId
         )
     }
 

--- a/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
+++ b/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
@@ -20,6 +20,7 @@ import com.google.android.material.shape.ShapeAppearanceModel
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.analytics.AnalyticsService
+import com.paypal.android.corepayments.analytics.ButtonSessionStore
 import com.paypal.android.ui.R
 
 @Suppress("TooManyFunctions")
@@ -234,7 +235,8 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
             analyticsService.sendAnalyticsEvent(
                 "payment-button:tapped",
                 orderId = null,
-                buttonType = fundingType.buttonType
+                buttonType = fundingType.buttonType,
+                buttonSessionId = ButtonSessionStore.buttonSessionId
             )
         }
     }


### PR DESCRIPTION
<!--
PR Title format: (<scope>): <short summary>

Scopes and version bumps:
  MINOR — new public API, class, method, or capability
  PATCH — bug fix, behavioral correction, crash fix
  MAJOR  — removes/renames API, changes signature, drops support
  NOVERSION — none, changes to demo app, doesn't impact SDK functionality, refactor, docs, tests, chore, CI
-->

## Summary
- Analytics pipeline now includes `buttonSessionId` in all checkout and vault tracking events
- `PayPalWebCheckoutClient` resets button session on checkout/vault terminal states (success, failure, cancel)
- `PayPalButton`, `PayLaterButton`, `PayPalCreditButton`, `PaymentButton` send `buttonSessionId` on init and tap events

### API / Contract Changes

## New

None

## Modified



## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe migration steps below)

## Migration:

### Checklist

- [ ] Added a changelog entry