### PR TITLE
Add latency analytics events for app switch integration

### DIFF
--- a/CorePayments/api/CorePayments.api
+++ b/CorePayments/api/CorePayments.api
@@ -158,19 +158,28 @@ public final class com/paypal/android/corepayments/UpdateClientConfigResponse$Co
 }
 
 public final class com/paypal/android/corepayments/UpdateClientConfigResult$Failure : com/paypal/android/corepayments/UpdateClientConfigResult {
-	public fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;)V
+	public fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;)V
+	public synthetic fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/paypal/android/corepayments/PayPalSDKError;
-	public final fun copy (Lcom/paypal/android/corepayments/PayPalSDKError;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Failure;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/UpdateClientConfigResult$Failure;Lcom/paypal/android/corepayments/PayPalSDKError;ILjava/lang/Object;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Failure;
+	public final fun component2 ()Lcom/paypal/android/corepayments/HttpRequestTiming;
+	public final fun copy (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Failure;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/UpdateClientConfigResult$Failure;Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Failure;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Lcom/paypal/android/corepayments/PayPalSDKError;
+	public fun getTiming ()Lcom/paypal/android/corepayments/HttpRequestTiming;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/paypal/android/corepayments/UpdateClientConfigResult$Success : com/paypal/android/corepayments/UpdateClientConfigResult {
-	public static final field INSTANCE Lcom/paypal/android/corepayments/UpdateClientConfigResult$Success;
+	public fun <init> ()V
+	public fun <init> (Lcom/paypal/android/corepayments/HttpRequestTiming;)V
+	public synthetic fun <init> (Lcom/paypal/android/corepayments/HttpRequestTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/paypal/android/corepayments/HttpRequestTiming;
+	public final fun copy (Lcom/paypal/android/corepayments/HttpRequestTiming;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Success;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/UpdateClientConfigResult$Success;Lcom/paypal/android/corepayments/HttpRequestTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Success;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getTiming ()Lcom/paypal/android/corepayments/HttpRequestTiming;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -263,48 +272,59 @@ public final class com/paypal/android/corepayments/graphql/GraphQLResponse$Compa
 }
 
 public final class com/paypal/android/corepayments/graphql/GraphQLResult$Failure : com/paypal/android/corepayments/graphql/GraphQLResult {
-	public fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;)V
+	public fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;)V
+	public synthetic fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/paypal/android/corepayments/PayPalSDKError;
-	public final fun copy (Lcom/paypal/android/corepayments/PayPalSDKError;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Failure;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResult$Failure;Lcom/paypal/android/corepayments/PayPalSDKError;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Failure;
+	public final fun component2 ()Lcom/paypal/android/corepayments/HttpRequestTiming;
+	public final fun copy (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Failure;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResult$Failure;Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Failure;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Lcom/paypal/android/corepayments/PayPalSDKError;
+	public fun getTiming ()Lcom/paypal/android/corepayments/HttpRequestTiming;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/paypal/android/corepayments/graphql/GraphQLResult$Success : com/paypal/android/corepayments/graphql/GraphQLResult {
-	public fun <init> (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;Lcom/paypal/android/corepayments/HttpRequestTiming;)V
+	public synthetic fun <init> (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;Lcom/paypal/android/corepayments/HttpRequestTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;
+	public final fun component3 ()Lcom/paypal/android/corepayments/HttpRequestTiming;
+	public final fun copy (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;Lcom/paypal/android/corepayments/HttpRequestTiming;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;Lcom/paypal/android/corepayments/HttpRequestTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCorrelationId ()Ljava/lang/String;
 	public final fun getResponse ()Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
+	public fun getTiming ()Lcom/paypal/android/corepayments/HttpRequestTiming;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/paypal/android/corepayments/model/APIResult$Failure : com/paypal/android/corepayments/model/APIResult {
-	public fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;)V
+	public fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;)V
+	public synthetic fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/paypal/android/corepayments/PayPalSDKError;
-	public final fun copy (Lcom/paypal/android/corepayments/PayPalSDKError;)Lcom/paypal/android/corepayments/model/APIResult$Failure;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/model/APIResult$Failure;Lcom/paypal/android/corepayments/PayPalSDKError;ILjava/lang/Object;)Lcom/paypal/android/corepayments/model/APIResult$Failure;
+	public final fun component2 ()Lcom/paypal/android/corepayments/HttpRequestTiming;
+	public final fun copy (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;)Lcom/paypal/android/corepayments/model/APIResult$Failure;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/model/APIResult$Failure;Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/model/APIResult$Failure;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Lcom/paypal/android/corepayments/PayPalSDKError;
+	public fun getTiming ()Lcom/paypal/android/corepayments/HttpRequestTiming;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/paypal/android/corepayments/model/APIResult$Success : com/paypal/android/corepayments/model/APIResult {
-	public fun <init> (Ljava/lang/Object;)V
+	public fun <init> (Ljava/lang/Object;Lcom/paypal/android/corepayments/HttpRequestTiming;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lcom/paypal/android/corepayments/HttpRequestTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/Object;)Lcom/paypal/android/corepayments/model/APIResult$Success;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/model/APIResult$Success;Ljava/lang/Object;ILjava/lang/Object;)Lcom/paypal/android/corepayments/model/APIResult$Success;
+	public final fun component2 ()Lcom/paypal/android/corepayments/HttpRequestTiming;
+	public final fun copy (Ljava/lang/Object;Lcom/paypal/android/corepayments/HttpRequestTiming;)Lcom/paypal/android/corepayments/model/APIResult$Success;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/model/APIResult$Success;Ljava/lang/Object;Lcom/paypal/android/corepayments/HttpRequestTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/model/APIResult$Success;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Ljava/lang/Object;
+	public fun getTiming ()Lcom/paypal/android/corepayments/HttpRequestTiming;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/CorePayments/api/CorePayments.api
+++ b/CorePayments/api/CorePayments.api
@@ -158,28 +158,28 @@ public final class com/paypal/android/corepayments/UpdateClientConfigResponse$Co
 }
 
 public final class com/paypal/android/corepayments/UpdateClientConfigResult$Failure : com/paypal/android/corepayments/UpdateClientConfigResult {
-	public fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;)V
-	public synthetic fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRoundTripTiming;)V
+	public synthetic fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRoundTripTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/paypal/android/corepayments/PayPalSDKError;
-	public final fun component2 ()Lcom/paypal/android/corepayments/HttpRequestTiming;
-	public final fun copy (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Failure;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/UpdateClientConfigResult$Failure;Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Failure;
+	public final fun component2 ()Lcom/paypal/android/corepayments/HttpRoundTripTiming;
+	public final fun copy (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRoundTripTiming;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Failure;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/UpdateClientConfigResult$Failure;Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRoundTripTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Failure;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Lcom/paypal/android/corepayments/PayPalSDKError;
-	public fun getTiming ()Lcom/paypal/android/corepayments/HttpRequestTiming;
+	public fun getRoundTripTiming ()Lcom/paypal/android/corepayments/HttpRoundTripTiming;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/paypal/android/corepayments/UpdateClientConfigResult$Success : com/paypal/android/corepayments/UpdateClientConfigResult {
 	public fun <init> ()V
-	public fun <init> (Lcom/paypal/android/corepayments/HttpRequestTiming;)V
-	public synthetic fun <init> (Lcom/paypal/android/corepayments/HttpRequestTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/paypal/android/corepayments/HttpRequestTiming;
-	public final fun copy (Lcom/paypal/android/corepayments/HttpRequestTiming;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Success;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/UpdateClientConfigResult$Success;Lcom/paypal/android/corepayments/HttpRequestTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Success;
+	public fun <init> (Lcom/paypal/android/corepayments/HttpRoundTripTiming;)V
+	public synthetic fun <init> (Lcom/paypal/android/corepayments/HttpRoundTripTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/paypal/android/corepayments/HttpRoundTripTiming;
+	public final fun copy (Lcom/paypal/android/corepayments/HttpRoundTripTiming;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Success;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/UpdateClientConfigResult$Success;Lcom/paypal/android/corepayments/HttpRoundTripTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/UpdateClientConfigResult$Success;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getTiming ()Lcom/paypal/android/corepayments/HttpRequestTiming;
+	public fun getRoundTripTiming ()Lcom/paypal/android/corepayments/HttpRoundTripTiming;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -272,59 +272,59 @@ public final class com/paypal/android/corepayments/graphql/GraphQLResponse$Compa
 }
 
 public final class com/paypal/android/corepayments/graphql/GraphQLResult$Failure : com/paypal/android/corepayments/graphql/GraphQLResult {
-	public fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;)V
-	public synthetic fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRoundTripTiming;)V
+	public synthetic fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRoundTripTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/paypal/android/corepayments/PayPalSDKError;
-	public final fun component2 ()Lcom/paypal/android/corepayments/HttpRequestTiming;
-	public final fun copy (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Failure;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResult$Failure;Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Failure;
+	public final fun component2 ()Lcom/paypal/android/corepayments/HttpRoundTripTiming;
+	public final fun copy (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRoundTripTiming;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Failure;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResult$Failure;Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRoundTripTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Failure;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Lcom/paypal/android/corepayments/PayPalSDKError;
-	public fun getTiming ()Lcom/paypal/android/corepayments/HttpRequestTiming;
+	public fun getRoundTripTiming ()Lcom/paypal/android/corepayments/HttpRoundTripTiming;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/paypal/android/corepayments/graphql/GraphQLResult$Success : com/paypal/android/corepayments/graphql/GraphQLResult {
-	public fun <init> (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;Lcom/paypal/android/corepayments/HttpRequestTiming;)V
-	public synthetic fun <init> (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;Lcom/paypal/android/corepayments/HttpRequestTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;Lcom/paypal/android/corepayments/HttpRoundTripTiming;)V
+	public synthetic fun <init> (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;Lcom/paypal/android/corepayments/HttpRoundTripTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lcom/paypal/android/corepayments/HttpRequestTiming;
-	public final fun copy (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;Lcom/paypal/android/corepayments/HttpRequestTiming;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;Lcom/paypal/android/corepayments/HttpRequestTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;
+	public final fun component3 ()Lcom/paypal/android/corepayments/HttpRoundTripTiming;
+	public final fun copy (Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;Lcom/paypal/android/corepayments/HttpRoundTripTiming;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;Lcom/paypal/android/corepayments/graphql/GraphQLResponse;Ljava/lang/String;Lcom/paypal/android/corepayments/HttpRoundTripTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/graphql/GraphQLResult$Success;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCorrelationId ()Ljava/lang/String;
 	public final fun getResponse ()Lcom/paypal/android/corepayments/graphql/GraphQLResponse;
-	public fun getTiming ()Lcom/paypal/android/corepayments/HttpRequestTiming;
+	public fun getRoundTripTiming ()Lcom/paypal/android/corepayments/HttpRoundTripTiming;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/paypal/android/corepayments/model/APIResult$Failure : com/paypal/android/corepayments/model/APIResult {
-	public fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;)V
-	public synthetic fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRoundTripTiming;)V
+	public synthetic fun <init> (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRoundTripTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/paypal/android/corepayments/PayPalSDKError;
-	public final fun component2 ()Lcom/paypal/android/corepayments/HttpRequestTiming;
-	public final fun copy (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;)Lcom/paypal/android/corepayments/model/APIResult$Failure;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/model/APIResult$Failure;Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRequestTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/model/APIResult$Failure;
+	public final fun component2 ()Lcom/paypal/android/corepayments/HttpRoundTripTiming;
+	public final fun copy (Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRoundTripTiming;)Lcom/paypal/android/corepayments/model/APIResult$Failure;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/model/APIResult$Failure;Lcom/paypal/android/corepayments/PayPalSDKError;Lcom/paypal/android/corepayments/HttpRoundTripTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/model/APIResult$Failure;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Lcom/paypal/android/corepayments/PayPalSDKError;
-	public fun getTiming ()Lcom/paypal/android/corepayments/HttpRequestTiming;
+	public fun getRoundTripTiming ()Lcom/paypal/android/corepayments/HttpRoundTripTiming;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/paypal/android/corepayments/model/APIResult$Success : com/paypal/android/corepayments/model/APIResult {
-	public fun <init> (Ljava/lang/Object;Lcom/paypal/android/corepayments/HttpRequestTiming;)V
-	public synthetic fun <init> (Ljava/lang/Object;Lcom/paypal/android/corepayments/HttpRequestTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Object;Lcom/paypal/android/corepayments/HttpRoundTripTiming;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lcom/paypal/android/corepayments/HttpRoundTripTiming;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
-	public final fun component2 ()Lcom/paypal/android/corepayments/HttpRequestTiming;
-	public final fun copy (Ljava/lang/Object;Lcom/paypal/android/corepayments/HttpRequestTiming;)Lcom/paypal/android/corepayments/model/APIResult$Success;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/model/APIResult$Success;Ljava/lang/Object;Lcom/paypal/android/corepayments/HttpRequestTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/model/APIResult$Success;
+	public final fun component2 ()Lcom/paypal/android/corepayments/HttpRoundTripTiming;
+	public final fun copy (Ljava/lang/Object;Lcom/paypal/android/corepayments/HttpRoundTripTiming;)Lcom/paypal/android/corepayments/model/APIResult$Success;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/model/APIResult$Success;Ljava/lang/Object;Lcom/paypal/android/corepayments/HttpRoundTripTiming;ILjava/lang/Object;)Lcom/paypal/android/corepayments/model/APIResult$Success;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Ljava/lang/Object;
-	public fun getTiming ()Lcom/paypal/android/corepayments/HttpRequestTiming;
+	public fun getRoundTripTiming ()Lcom/paypal/android/corepayments/HttpRoundTripTiming;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/Http.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/Http.kt
@@ -20,6 +20,7 @@ internal class Http(
 
     suspend fun send(httpRequest: HttpRequest): HttpResponse =
         withContext(dispatcher) {
+            val startTime = System.currentTimeMillis()
             runCatching {
                 val url = httpRequest.url
                 val connection = url.openConnection() as HttpURLConnection
@@ -45,13 +46,21 @@ internal class Http(
 
                 connection.connect()
                 httpResponseParser.parse(connection)
+            }.map { response ->
+                response.copy(
+                    timing = HttpRequestTiming(startTime = startTime, endTime = System.currentTimeMillis())
+                )
             }.recover {
                 val status = when (it) {
                     is UnknownHostException -> HttpResponse.STATUS_UNKNOWN_HOST
                     is IllegalStateException -> HttpResponse.SERVER_ERROR
                     else -> HttpResponse.STATUS_UNDETERMINED
                 }
-                HttpResponse(status = status, error = it)
+                HttpResponse(
+                    status = status,
+                    error = it,
+                    timing = HttpRequestTiming(startTime = startTime, endTime = System.currentTimeMillis())
+                )
             }.getOrNull()!!
         }
 }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/Http.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/Http.kt
@@ -48,7 +48,7 @@ internal class Http(
                 httpResponseParser.parse(connection)
             }.map { response ->
                 response.copy(
-                    timing = HttpRequestTiming(startTime = startTime, endTime = System.currentTimeMillis())
+                    roundTripTiming = HttpRoundTripTiming(startTime = startTime, endTime = System.currentTimeMillis())
                 )
             }.recover {
                 val status = when (it) {
@@ -59,7 +59,7 @@ internal class Http(
                 HttpResponse(
                     status = status,
                     error = it,
-                    timing = HttpRequestTiming(startTime = startTime, endTime = System.currentTimeMillis())
+                    roundTripTiming = HttpRoundTripTiming(startTime = startTime, endTime = System.currentTimeMillis())
                 )
             }.getOrNull()!!
         }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/HttpRequestTiming.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/HttpRequestTiming.kt
@@ -1,0 +1,19 @@
+package com.paypal.android.corepayments
+
+import androidx.annotation.RestrictTo
+
+/**
+ * Captures the wall-clock duration of a single HTTP round trip.
+ *
+ * [startTime] is recorded immediately before the request is sent and [endTime]
+ * immediately after the response (or error) is received. Both are epoch
+ * milliseconds ([System.currentTimeMillis]). Used to emit API request latency
+ * analytics without any downstream calculation — the raw epochs are reported.
+ *
+ * @suppress
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class HttpRequestTiming(
+    val startTime: Long,
+    val endTime: Long
+)

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/HttpResponse.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/HttpResponse.kt
@@ -11,7 +11,8 @@ data class HttpResponse(
     val status: Int,
     val headers: Map<String, String> = emptyMap(),
     val body: String? = null,
-    val error: Throwable? = null
+    val error: Throwable? = null,
+    val timing: HttpRequestTiming? = null
 ) {
     companion object {
         const val STATUS_UNDETERMINED = -1

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/HttpResponse.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/HttpResponse.kt
@@ -12,7 +12,7 @@ data class HttpResponse(
     val headers: Map<String, String> = emptyMap(),
     val body: String? = null,
     val error: Throwable? = null,
-    val timing: HttpRequestTiming? = null
+    val roundTripTiming: HttpRoundTripTiming? = null
 ) {
     companion object {
         const val STATUS_UNDETERMINED = -1

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/HttpRoundTripTiming.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/HttpRoundTripTiming.kt
@@ -13,7 +13,7 @@ import androidx.annotation.RestrictTo
  * @suppress
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-data class HttpRequestTiming(
+data class HttpRoundTripTiming(
     val startTime: Long,
     val endTime: Long
 )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventData.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventData.kt
@@ -72,5 +72,13 @@ internal data class TrackingEventParams(
     @SerialName("is_cached_session")
     val isCachedSession: Boolean? = null,
     @SerialName("is_vault_request")
-    val isVaultRequest: Boolean? = null
+    val isVaultRequest: Boolean? = null,
+    @SerialName("end_time")
+    val endTime: String? = null,
+    @SerialName("endpoint")
+    val endpoint: String? = null,
+    @SerialName("presentation_type")
+    val presentationType: String? = null,
+    @SerialName("flow")
+    val flow: String? = null
 )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventsAPI.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventsAPI.kt
@@ -51,7 +51,11 @@ internal class TrackingEventsAPI constructor(
             errorDescription = event.errorDescription,
             startTime = event.startTime?.toString(),
             isCachedSession = event.isCachedSession,
-            isVaultRequest = event.isVaultRequest
+            isVaultRequest = event.isVaultRequest,
+            endTime = event.endTime?.toString(),
+            endpoint = event.endpoint,
+            presentationType = event.presentationType,
+            flow = event.flow
         )
 
         val events = TrackingEvents(eventParams = eventParams)

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/UpdateClientConfigAPI.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/UpdateClientConfigAPI.kt
@@ -47,18 +47,23 @@ class UpdateClientConfigAPI(
                     graphQLClient.send<UpdateClientConfigResponse, UpdateClientConfigVariables>(
                         graphQLRequest = graphQLRequest
                     )
+                val timing = graphQLResponse.timing
                 when (graphQLResponse) {
                     is GraphQLResult.Success -> {
                         val correlationId = graphQLResponse.correlationId
                         graphQLResponse.response.data?.let {
-                            UpdateClientConfigResult.Success
+                            UpdateClientConfigResult.Success(timing = timing)
                         } ?: UpdateClientConfigResult.Failure(
-                            APIClientError.noResponseData(correlationId)
+                            error = APIClientError.noResponseData(correlationId),
+                            timing = timing
                         )
                     }
 
                     is GraphQLResult.Failure -> {
-                        UpdateClientConfigResult.Failure(graphQLResponse.error)
+                        UpdateClientConfigResult.Failure(
+                            error = graphQLResponse.error,
+                            timing = timing
+                        )
                     }
                 }
             }
@@ -115,6 +120,13 @@ data class UpdateClientConfigResponse(
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 sealed class UpdateClientConfigResult {
-    data object Success : UpdateClientConfigResult()
-    data class Failure(val error: PayPalSDKError) : UpdateClientConfigResult()
+
+    /** Round-trip timing of the underlying GraphQL request, when available. */
+    abstract val timing: HttpRequestTiming?
+
+    data class Success(override val timing: HttpRequestTiming? = null) : UpdateClientConfigResult()
+    data class Failure(
+        val error: PayPalSDKError,
+        override val timing: HttpRequestTiming? = null
+    ) : UpdateClientConfigResult()
 }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/UpdateClientConfigAPI.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/UpdateClientConfigAPI.kt
@@ -47,22 +47,22 @@ class UpdateClientConfigAPI(
                     graphQLClient.send<UpdateClientConfigResponse, UpdateClientConfigVariables>(
                         graphQLRequest = graphQLRequest
                     )
-                val timing = graphQLResponse.timing
+                val roundTripTiming = graphQLResponse.roundTripTiming
                 when (graphQLResponse) {
                     is GraphQLResult.Success -> {
                         val correlationId = graphQLResponse.correlationId
                         graphQLResponse.response.data?.let {
-                            UpdateClientConfigResult.Success(timing = timing)
+                            UpdateClientConfigResult.Success(roundTripTiming = roundTripTiming)
                         } ?: UpdateClientConfigResult.Failure(
                             error = APIClientError.noResponseData(correlationId),
-                            timing = timing
+                            roundTripTiming = roundTripTiming
                         )
                     }
 
                     is GraphQLResult.Failure -> {
                         UpdateClientConfigResult.Failure(
                             error = graphQLResponse.error,
-                            timing = timing
+                            roundTripTiming = roundTripTiming
                         )
                     }
                 }
@@ -122,11 +122,11 @@ data class UpdateClientConfigResponse(
 sealed class UpdateClientConfigResult {
 
     /** Round-trip timing of the underlying GraphQL request, when available. */
-    abstract val timing: HttpRequestTiming?
+    abstract val roundTripTiming: HttpRoundTripTiming?
 
-    data class Success(override val timing: HttpRequestTiming? = null) : UpdateClientConfigResult()
+    data class Success(override val roundTripTiming: HttpRoundTripTiming? = null) : UpdateClientConfigResult()
     data class Failure(
         val error: PayPalSDKError,
-        override val timing: HttpRequestTiming? = null
+        override val roundTripTiming: HttpRoundTripTiming? = null
     ) : UpdateClientConfigResult()
 }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
@@ -13,5 +13,9 @@ internal data class AnalyticsEventData(
     val errorDescription: String? = null,
     val startTime: Long? = null,
     val isCachedSession: Boolean? = null,
-    val isVaultRequest: Boolean? = null
+    val isVaultRequest: Boolean? = null,
+    val endTime: Long? = null,
+    val endpoint: String? = null,
+    val presentationType: String? = null,
+    val flow: String? = null
 )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
@@ -40,6 +40,7 @@ class AnalyticsService internal constructor(
                 CoroutineScope(dispatcher)
             )
 
+    @Suppress("LongParameterList")
     fun sendAnalyticsEvent(
         name: String,
         orderId: String? = null,
@@ -50,7 +51,11 @@ class AnalyticsService internal constructor(
         errorDescription: String? = null,
         startTime: Long? = null,
         isCachedSession: Boolean? = null,
-        isVaultRequest: Boolean? = null
+        isVaultRequest: Boolean? = null,
+        endTime: Long? = null,
+        endpoint: String? = null,
+        presentationType: String? = null,
+        flow: String? = null
     ) {
         // TODO: send analytics event using WorkManager (supports coroutines) to avoid lint error
         // thrown because we don't use the Deferred result
@@ -70,7 +75,11 @@ class AnalyticsService internal constructor(
                     errorDescription = errorDescription,
                     startTime = startTime,
                     isCachedSession = isCachedSession,
-                    isVaultRequest = isVaultRequest
+                    isVaultRequest = isVaultRequest,
+                    endTime = endTime,
+                    endpoint = endpoint,
+                    presentationType = presentationType,
+                    flow = flow
                 )
                 val response = trackingEventsAPI.sendEvent(analyticsEventData, deviceData)
                 response.error?.message?.let { errorMessage ->

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPI.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPI.kt
@@ -134,7 +134,7 @@ class CreateShopperSessionWithAppSwitchEligibilityAPI internal constructor(
                 graphQLRequest,
                 additionalHeaders = mapOf(Headers.AUTHORIZATION to "Bearer $lsat")
             )
-            val timing = graphQLResult.timing
+            val roundTripTiming = graphQLResult.roundTripTiming
             when (graphQLResult) {
                 is GraphQLResult.Success -> {
                     val data = graphQLResult.response.data
@@ -143,18 +143,18 @@ class CreateShopperSessionWithAppSwitchEligibilityAPI internal constructor(
                     if (data == null) {
                         APIResult.Failure(
                             error = APIClientError.noResponseData(graphQLResult.correlationId),
-                            timing = timing
+                            roundTripTiming = roundTripTiming
                         )
                     } else {
                         APIResult.Success(
                             data = data.toResponse(),
-                            timing = timing
+                            roundTripTiming = roundTripTiming
                         )
                     }
                 }
                 is GraphQLResult.Failure -> APIResult.Failure(
                     error = graphQLResult.error,
-                    timing = timing
+                    roundTripTiming = roundTripTiming
                 )
             }
         }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPI.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPI.kt
@@ -134,18 +134,28 @@ class CreateShopperSessionWithAppSwitchEligibilityAPI internal constructor(
                 graphQLRequest,
                 additionalHeaders = mapOf(Headers.AUTHORIZATION to "Bearer $lsat")
             )
+            val timing = graphQLResult.timing
             when (graphQLResult) {
                 is GraphQLResult.Success -> {
                     val data = graphQLResult.response.data
                         ?.external
                         ?.createShopperSessionWithAppSwitchEligibility
                     if (data == null) {
-                        APIResult.Failure(APIClientError.noResponseData(graphQLResult.correlationId))
+                        APIResult.Failure(
+                            error = APIClientError.noResponseData(graphQLResult.correlationId),
+                            timing = timing
+                        )
                     } else {
-                        APIResult.Success(data.toResponse())
+                        APIResult.Success(
+                            data = data.toResponse(),
+                            timing = timing
+                        )
                     }
                 }
-                is GraphQLResult.Failure -> APIResult.Failure(graphQLResult.error)
+                is GraphQLResult.Failure -> APIResult.Failure(
+                    error = graphQLResult.error,
+                    timing = timing
+                )
             }
         }
     }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLClient.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLClient.kt
@@ -61,14 +61,21 @@ class GraphQLClient internal constructor(
 
         val httpResponse = http.send(httpRequest)
         val correlationId = httpResponse.headers[PAYPAL_DEBUG_ID]
+        val timing = httpResponse.timing
 
         return when {
             httpResponse.status != HTTP_OK -> {
-                GraphQLResult.Failure(APIClientError.serverResponseError(correlationId))
+                GraphQLResult.Failure(
+                    error = APIClientError.serverResponseError(correlationId),
+                    timing = timing
+                )
             }
 
             httpResponse.body.isNullOrBlank() -> {
-                GraphQLResult.Failure(noResponseData(correlationId))
+                GraphQLResult.Failure(
+                    error = noResponseData(correlationId),
+                    timing = timing
+                )
             }
 
             else -> runCatching {
@@ -76,9 +83,16 @@ class GraphQLClient internal constructor(
                     deserializer = GraphQLResponse.serializer(responseSerializer),
                     string = httpResponse.body
                 )
-                GraphQLResult.Success(response, correlationId = correlationId)
+                GraphQLResult.Success(
+                    response = response,
+                    correlationId = correlationId,
+                    timing = timing
+                )
             }.getOrElse { error ->
-                GraphQLResult.Failure(graphQLJSONParseError(correlationId, error))
+                GraphQLResult.Failure(
+                    error = graphQLJSONParseError(correlationId, error),
+                    timing = timing
+                )
             }
         }
     }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLClient.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLClient.kt
@@ -61,20 +61,20 @@ class GraphQLClient internal constructor(
 
         val httpResponse = http.send(httpRequest)
         val correlationId = httpResponse.headers[PAYPAL_DEBUG_ID]
-        val timing = httpResponse.timing
+        val roundTripTiming = httpResponse.roundTripTiming
 
         return when {
             httpResponse.status != HTTP_OK -> {
                 GraphQLResult.Failure(
                     error = APIClientError.serverResponseError(correlationId),
-                    timing = timing
+                    roundTripTiming = roundTripTiming
                 )
             }
 
             httpResponse.body.isNullOrBlank() -> {
                 GraphQLResult.Failure(
                     error = noResponseData(correlationId),
-                    timing = timing
+                    roundTripTiming = roundTripTiming
                 )
             }
 
@@ -86,12 +86,12 @@ class GraphQLClient internal constructor(
                 GraphQLResult.Success(
                     response = response,
                     correlationId = correlationId,
-                    timing = timing
+                    roundTripTiming = roundTripTiming
                 )
             }.getOrElse { error ->
                 GraphQLResult.Failure(
                     error = graphQLJSONParseError(correlationId, error),
-                    timing = timing
+                    roundTripTiming = roundTripTiming
                 )
             }
         }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLResult.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLResult.kt
@@ -1,6 +1,7 @@
 package com.paypal.android.corepayments.graphql
 
 import androidx.annotation.RestrictTo
+import com.paypal.android.corepayments.HttpRequestTiming
 import com.paypal.android.corepayments.PayPalSDKError
 import kotlinx.serialization.InternalSerializationApi
 
@@ -10,11 +11,22 @@ import kotlinx.serialization.InternalSerializationApi
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 sealed class GraphQLResult<out T> {
 
+    /**
+     * Round-trip timing of the underlying HTTP request, when available. Null when
+     * the request never reached the network (e.g. an invalid URL). Used to emit
+     * API request latency analytics.
+     */
+    abstract val timing: HttpRequestTiming?
+
     @OptIn(InternalSerializationApi::class)
     data class Success<out T>(
         val response: GraphQLResponse<T>,
-        val correlationId: String? = null
+        val correlationId: String? = null,
+        override val timing: HttpRequestTiming? = null
     ) : GraphQLResult<T>()
 
-    data class Failure(val error: PayPalSDKError) : GraphQLResult<Nothing>()
+    data class Failure(
+        val error: PayPalSDKError,
+        override val timing: HttpRequestTiming? = null
+    ) : GraphQLResult<Nothing>()
 }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLResult.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLResult.kt
@@ -1,7 +1,7 @@
 package com.paypal.android.corepayments.graphql
 
 import androidx.annotation.RestrictTo
-import com.paypal.android.corepayments.HttpRequestTiming
+import com.paypal.android.corepayments.HttpRoundTripTiming
 import com.paypal.android.corepayments.PayPalSDKError
 import kotlinx.serialization.InternalSerializationApi
 
@@ -16,17 +16,17 @@ sealed class GraphQLResult<out T> {
      * the request never reached the network (e.g. an invalid URL). Used to emit
      * API request latency analytics.
      */
-    abstract val timing: HttpRequestTiming?
+    abstract val roundTripTiming: HttpRoundTripTiming?
 
     @OptIn(InternalSerializationApi::class)
     data class Success<out T>(
         val response: GraphQLResponse<T>,
         val correlationId: String? = null,
-        override val timing: HttpRequestTiming? = null
+        override val roundTripTiming: HttpRoundTripTiming? = null
     ) : GraphQLResult<T>()
 
     data class Failure(
         val error: PayPalSDKError,
-        override val timing: HttpRequestTiming? = null
+        override val roundTripTiming: HttpRoundTripTiming? = null
     ) : GraphQLResult<Nothing>()
 }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/model/APIResult.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/model/APIResult.kt
@@ -1,21 +1,32 @@
 package com.paypal.android.corepayments.model
 
 import androidx.annotation.RestrictTo
+import com.paypal.android.corepayments.HttpRequestTiming
 import com.paypal.android.corepayments.PayPalSDKError
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 sealed class APIResult<T> {
+
+    /** Round-trip timing of the underlying HTTP request, when available. */
+    abstract val timing: HttpRequestTiming?
+
     /**
      * The request was successful.
      *
      * @property data the data from the response
      */
-    data class Success<T>(val data: T) : APIResult<T>()
+    data class Success<T>(
+        val data: T,
+        override val timing: HttpRequestTiming? = null
+    ) : APIResult<T>()
 
     /**
      * There was an error with the request.
      *
      * @property error the error that occurred
      */
-    data class Failure<T>(val error: PayPalSDKError) : APIResult<T>()
+    data class Failure<T>(
+        val error: PayPalSDKError,
+        override val timing: HttpRequestTiming? = null
+    ) : APIResult<T>()
 }

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/model/APIResult.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/model/APIResult.kt
@@ -1,14 +1,14 @@
 package com.paypal.android.corepayments.model
 
 import androidx.annotation.RestrictTo
-import com.paypal.android.corepayments.HttpRequestTiming
+import com.paypal.android.corepayments.HttpRoundTripTiming
 import com.paypal.android.corepayments.PayPalSDKError
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 sealed class APIResult<T> {
 
     /** Round-trip timing of the underlying HTTP request, when available. */
-    abstract val timing: HttpRequestTiming?
+    abstract val roundTripTiming: HttpRoundTripTiming?
 
     /**
      * The request was successful.
@@ -17,7 +17,7 @@ sealed class APIResult<T> {
      */
     data class Success<T>(
         val data: T,
-        override val timing: HttpRequestTiming? = null
+        override val roundTripTiming: HttpRoundTripTiming? = null
     ) : APIResult<T>()
 
     /**
@@ -27,6 +27,6 @@ sealed class APIResult<T> {
      */
     data class Failure<T>(
         val error: PayPalSDKError,
-        override val timing: HttpRequestTiming? = null
+        override val roundTripTiming: HttpRoundTripTiming? = null
     ) : APIResult<T>()
 }

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/HttpUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/HttpUnitTest.kt
@@ -15,7 +15,9 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -87,7 +89,35 @@ class HttpUnitTest {
         val sut = createHttp(testScheduler)
         val result = sut.send(httpRequest)
 
-        assertSame(httpResponse, result)
+        // Timing is attached by the send() layer, so the response is a copy of the
+        // parser's response with a non-null timing rather than the same instance.
+        assertEquals(httpResponse.status, result.status)
+        assertEquals(httpResponse.body, result.body)
+    }
+
+    @Test
+    fun `send attaches timing to the successful response`() = runTest {
+        val httpRequest = HttpRequest(url, HttpMethod.GET)
+
+        val sut = createHttp(testScheduler)
+        val result = sut.send(httpRequest)
+
+        val timing = result.timing
+        assertNotNull(timing)
+        assertTrue(timing!!.endTime >= timing.startTime)
+    }
+
+    @Test
+    fun `send attaches timing to the error response`() = runTest {
+        every { urlConnection.connect() } throws UnknownHostException()
+
+        val httpRequest = HttpRequest(url, HttpMethod.GET)
+        val sut = createHttp(testScheduler)
+        val result = sut.send(httpRequest)
+
+        val timing = result.timing
+        assertNotNull(timing)
+        assertTrue(timing!!.endTime >= timing.startTime)
     }
 
     @Test

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/HttpUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/HttpUnitTest.kt
@@ -102,9 +102,9 @@ class HttpUnitTest {
         val sut = createHttp(testScheduler)
         val result = sut.send(httpRequest)
 
-        val timing = result.timing
-        assertNotNull(timing)
-        assertTrue(timing!!.endTime >= timing.startTime)
+        val roundTripTiming = result.roundTripTiming
+        assertNotNull(roundTripTiming)
+        assertTrue(roundTripTiming!!.endTime >= roundTripTiming.startTime)
     }
 
     @Test
@@ -115,9 +115,9 @@ class HttpUnitTest {
         val sut = createHttp(testScheduler)
         val result = sut.send(httpRequest)
 
-        val timing = result.timing
-        assertNotNull(timing)
-        assertTrue(timing!!.endTime >= timing.startTime)
+        val roundTripTiming = result.roundTripTiming
+        assertNotNull(roundTripTiming)
+        assertTrue(roundTripTiming!!.endTime >= roundTripTiming.startTime)
     }
 
     @Test

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/TrackingEventsAPIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/TrackingEventsAPIUnitTest.kt
@@ -96,4 +96,42 @@ class TrackingEventsAPIUnitTest {
         val actualBody = apiRequest.body!!
         JSONAssert.assertEquals(JSONObject(expectedBody), JSONObject(actualBody), false)
     }
+
+    @Test
+    fun `sendEvent() serializes latency fields with the expected JSON keys`() = runTest {
+        coEvery { restClient.send(capture(apiRequestSlot)) } returns httpSuccessResponse
+
+        val event = AnalyticsEventData(
+            environment = "fake-environment",
+            eventName = "paypal-web-payments:api-request-latency",
+            timestamp = 123L,
+            orderId = null,
+            appSwitchEnabled = false,
+            startTime = 1000L,
+            endTime = 1500L,
+            endpoint = "/v2/checkout/orders",
+            presentationType = "app-switch",
+            flow = "checkout"
+        )
+        sut.sendEvent(event, deviceData)
+
+        // language=JSON
+        val expectedBody = """
+            {
+                "events": {
+                    "event_params": {
+                        "event_name": "paypal-web-payments:api-request-latency",
+                        "start_time": "1000",
+                        "end_time": "1500",
+                        "endpoint": "/v2/checkout/orders",
+                        "presentation_type": "app-switch",
+                        "flow": "checkout"
+                    }
+                }
+            }
+            """
+
+        val actualBody = apiRequestSlot.captured.body!!
+        JSONAssert.assertEquals(JSONObject(expectedBody), JSONObject(actualBody), false)
+    }
 }

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/analytics/AnalyticsServiceTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/analytics/AnalyticsServiceTest.kt
@@ -110,6 +110,32 @@ class AnalyticsServiceTest {
         assertEquals("live", analyticsEventData.environment)
     }
 
+    @Test
+    fun `sendAnalyticsEvent forwards latency params into AnalyticsEventData`() = runTest {
+        val analyticsEventDataSlot = slot<AnalyticsEventData>()
+        coEvery {
+            trackingEventsAPI.sendEvent(capture(analyticsEventDataSlot), deviceData)
+        } returns httpSuccessResponse
+
+        sut = createAnalyticsService(environment, testScheduler)
+        sut.sendAnalyticsEvent(
+            name = "paypal-web-payments:api-request-latency",
+            startTime = 1000L,
+            endTime = 1500L,
+            endpoint = "/v2/checkout/orders",
+            presentationType = "app-switch",
+            flow = "checkout"
+        )
+        advanceUntilIdle()
+
+        val analyticsEventData = analyticsEventDataSlot.captured
+        assertEquals(1000L, analyticsEventData.startTime)
+        assertEquals(1500L, analyticsEventData.endTime)
+        assertEquals("/v2/checkout/orders", analyticsEventData.endpoint)
+        assertEquals("app-switch", analyticsEventData.presentationType)
+        assertEquals("checkout", analyticsEventData.flow)
+    }
+
     private fun createAnalyticsService(
         environment: Environment,
         testScheduler: TestCoroutineScheduler

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest.kt
@@ -5,6 +5,7 @@ import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.Http
 import com.paypal.android.corepayments.HttpRequest
+import com.paypal.android.corepayments.HttpRequestTiming
 import com.paypal.android.corepayments.HttpResponse
 import com.paypal.android.corepayments.LoadRawResourceResult
 import com.paypal.android.corepayments.PayPalSDKError
@@ -138,6 +139,76 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
         assertEquals("11F1-7BDF-BCAACEF2-91A9-A556CD2372A8", data.shopperSessionConfig.id)
         assertEquals("", data.shopperSessionConfig.expiresAt)
         assertFalse(data.ineligibleReason != null)
+    }
+
+    @Test
+    fun `invoke propagates GraphQL round-trip timing into APIResult Success`() = runTest {
+        val timing = HttpRequestTiming(startTime = 1000L, endTime = 1500L)
+        coEvery { mockHttp.send(any()) } returns HttpResponse(
+            status = 200,
+            body = """
+                {
+                  "data" : {
+                    "external" : {
+                      "createShopperSessionWithAppSwitchEligibility" : {
+                        "appSwitchEligibilityResponse" : {
+                          "appSwitchEligible" : true,
+                          "ineligibleReason" : null,
+                          "checkoutUrls" : {
+                            "redirectURL" : "https://www.paypal.com/app-switch-checkout",
+                            "checkoutFallbackUrl" : "https://www.paypal.com/checkoutnow"
+                          }
+                        },
+                        "shopperSessionResponse" : { "sessionId" : "abc", "expiresAt" : null }
+                      }
+                    }
+                  }
+                }
+            """.trimIndent(),
+            headers = emptyMap(),
+            timing = timing,
+        )
+
+        val result = sut(
+            token = "fake-order-id",
+            tokenType = TokenType.ORDER_ID,
+            params = CreateShopperSessionWithAppSwitchEligibilityParams(
+                returnAppUrl = "https://example.com/return",
+                cancelAppUrl = "https://example.com/cancel",
+                fallbackSchemeUrl = null,
+                paymentType = "CONTINUE",
+                paypalNativeAppInstalled = true,
+            ),
+        )
+
+        assertTrue(result is APIResult.Success)
+        assertEquals(timing, (result as APIResult.Success).timing)
+    }
+
+    @Test
+    fun `invoke propagates GraphQL round-trip timing into APIResult Failure`() = runTest {
+        val timing = HttpRequestTiming(startTime = 2000L, endTime = 2600L)
+        coEvery { mockHttp.send(any()) } returns HttpResponse(
+            status = 500,
+            body = null,
+            headers = emptyMap(),
+            timing = timing,
+        )
+
+        val result = sut(
+            token = "fake-order-id",
+            tokenType = TokenType.ORDER_ID,
+            params = CreateShopperSessionWithAppSwitchEligibilityParams(
+                returnAppUrl = "https://example.com/return",
+                cancelAppUrl = "https://example.com/cancel",
+                fallbackSchemeUrl = null,
+                paymentType = "CONTINUE",
+                paypalNativeAppInstalled = true,
+            ),
+        )
+
+        assertTrue(result is APIResult.Failure)
+        assertEquals(timing, (result as APIResult.Failure).timing)
     }
 
     @Test

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest.kt
@@ -5,7 +5,7 @@ import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.Http
 import com.paypal.android.corepayments.HttpRequest
-import com.paypal.android.corepayments.HttpRequestTiming
+import com.paypal.android.corepayments.HttpRoundTripTiming
 import com.paypal.android.corepayments.HttpResponse
 import com.paypal.android.corepayments.LoadRawResourceResult
 import com.paypal.android.corepayments.PayPalSDKError
@@ -143,7 +143,7 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
 
     @Test
     fun `invoke propagates GraphQL round-trip timing into APIResult Success`() = runTest {
-        val timing = HttpRequestTiming(startTime = 1000L, endTime = 1500L)
+        val roundTripTiming = HttpRoundTripTiming(startTime = 1000L, endTime = 1500L)
         coEvery { mockHttp.send(any()) } returns HttpResponse(
             status = 200,
             body = """
@@ -166,7 +166,7 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
                 }
             """.trimIndent(),
             headers = emptyMap(),
-            timing = timing,
+            roundTripTiming = roundTripTiming,
         )
 
         val result = sut(
@@ -182,17 +182,17 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
         )
 
         assertTrue(result is APIResult.Success)
-        assertEquals(timing, (result as APIResult.Success).timing)
+        assertEquals(roundTripTiming, (result as APIResult.Success).roundTripTiming)
     }
 
     @Test
     fun `invoke propagates GraphQL round-trip timing into APIResult Failure`() = runTest {
-        val timing = HttpRequestTiming(startTime = 2000L, endTime = 2600L)
+        val roundTripTiming = HttpRoundTripTiming(startTime = 2000L, endTime = 2600L)
         coEvery { mockHttp.send(any()) } returns HttpResponse(
             status = 500,
             body = null,
             headers = emptyMap(),
-            timing = timing,
+            roundTripTiming = roundTripTiming,
         )
 
         val result = sut(
@@ -208,7 +208,7 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
         )
 
         assertTrue(result is APIResult.Failure)
-        assertEquals(timing, (result as APIResult.Failure).timing)
+        assertEquals(roundTripTiming, (result as APIResult.Failure).roundTripTiming)
     }
 
     @Test

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/GraphQLClientUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/GraphQLClientUnitTest.kt
@@ -5,6 +5,7 @@ import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.Http
 import com.paypal.android.corepayments.HttpMethod
 import com.paypal.android.corepayments.HttpRequest
+import com.paypal.android.corepayments.HttpRequestTiming
 import com.paypal.android.corepayments.HttpResponse
 import com.paypal.android.corepayments.PayPalSDKErrorCode
 import io.mockk.coEvery
@@ -114,6 +115,27 @@ internal class GraphQLClientUnitTest {
 
         // Verify HTTP send was called
         coVerify(exactly = 1) { mockHttp.send(any()) }
+    }
+
+    @Test
+    fun `test timing is surfaced on the GraphQL result`() = runTest {
+        // Arrange
+        val graphQLRequest = GraphQLRequest(query = testQuery, variables = testVariables)
+        val timing = HttpRequestTiming(startTime = 1000L, endTime = 1750L)
+        val mockResponse = HttpResponse(
+            status = 200,
+            body = """{"data":{"result":"success"}}""",
+            headers = mapOf(GraphQLClient.PAYPAL_DEBUG_ID to testCorrelationId),
+            timing = timing
+        )
+        coEvery { mockHttp.send(any()) } returns mockResponse
+
+        // Act
+        val result = graphQLClient.send<TestResponse, TestRequest>(graphQLRequest)
+
+        // Assert
+        assertTrue(result is GraphQLResult.Success)
+        assertEquals(timing, (result as GraphQLResult.Success).timing)
     }
 
     @OptIn(InternalSerializationApi::class)

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/GraphQLClientUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/GraphQLClientUnitTest.kt
@@ -5,7 +5,7 @@ import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.Http
 import com.paypal.android.corepayments.HttpMethod
 import com.paypal.android.corepayments.HttpRequest
-import com.paypal.android.corepayments.HttpRequestTiming
+import com.paypal.android.corepayments.HttpRoundTripTiming
 import com.paypal.android.corepayments.HttpResponse
 import com.paypal.android.corepayments.PayPalSDKErrorCode
 import io.mockk.coEvery
@@ -121,12 +121,12 @@ internal class GraphQLClientUnitTest {
     fun `test timing is surfaced on the GraphQL result`() = runTest {
         // Arrange
         val graphQLRequest = GraphQLRequest(query = testQuery, variables = testVariables)
-        val timing = HttpRequestTiming(startTime = 1000L, endTime = 1750L)
+        val roundTripTiming = HttpRoundTripTiming(startTime = 1000L, endTime = 1750L)
         val mockResponse = HttpResponse(
             status = 200,
             body = """{"data":{"result":"success"}}""",
             headers = mapOf(GraphQLClient.PAYPAL_DEBUG_ID to testCorrelationId),
-            timing = timing
+            roundTripTiming = roundTripTiming
         )
         coEvery { mockHttp.send(any()) } returns mockResponse
 
@@ -135,7 +135,7 @@ internal class GraphQLClientUnitTest {
 
         // Assert
         assertTrue(result is GraphQLResult.Success)
-        assertEquals(timing, (result as GraphQLResult.Success).timing)
+        assertEquals(roundTripTiming, (result as GraphQLResult.Success).roundTripTiming)
     }
 
     @OptIn(InternalSerializationApi::class)

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -9,6 +9,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
+import com.paypal.android.corepayments.HttpRequestTiming
 import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.corepayments.UpdateClientConfigAPI
 import com.paypal.android.corepayments.analytics.AnalyticsService
@@ -22,7 +23,10 @@ import com.paypal.android.corepayments.model.TokenType
 import com.paypal.android.corepayments.returnUrl
 import com.paypal.android.paypalwebpayments.analytics.CheckoutEvent
 import com.paypal.android.paypalwebpayments.analytics.CreatePayPalSessionEvent
+import com.paypal.android.paypalwebpayments.analytics.LatencyEndpoint
+import com.paypal.android.paypalwebpayments.analytics.LatencyFlow
 import com.paypal.android.paypalwebpayments.analytics.PayPalWebAnalytics
+import com.paypal.android.paypalwebpayments.analytics.PresentationType
 import com.paypal.android.paypalwebpayments.analytics.VaultEvent
 import com.paypal.android.paypalwebpayments.errors.PayPalWebCheckoutError
 import kotlinx.coroutines.CoroutineScope
@@ -140,8 +144,10 @@ class PayPalWebCheckoutClient internal constructor(
         orderId: String,
         callback: PayPalWebStartCallback,
     ) {
+        val startTime = System.currentTimeMillis()
         val deferred = shopperSessionDeferred
         if (deferred == null) {
+            notifyUserPerceivedLatencyError(LatencyFlow.CHECKOUT, startTime)
             notifyCheckoutSessionNotStarted(orderId, callback)
             return
         }
@@ -162,6 +168,7 @@ class PayPalWebCheckoutClient internal constructor(
                         activity = activity,
                         shopperSession = shopperSession,
                         orderId = orderId,
+                        startTime = startTime,
                     )
                 } else {
                     launchCheckoutViaPatchCCOFallback(
@@ -223,8 +230,10 @@ class PayPalWebCheckoutClient internal constructor(
         setupTokenId: String,
         callback: PayPalWebVaultCallback,
     ) {
+        val startTime = System.currentTimeMillis()
         val deferred = shopperSessionDeferred
         if (deferred == null) {
+            notifyUserPerceivedLatencyError(LatencyFlow.VAULT, startTime)
             notifyVaultSessionNotStarted(setupTokenId, callback)
             return
         }
@@ -246,6 +255,7 @@ class PayPalWebCheckoutClient internal constructor(
                         activity = activity,
                         shopperSession = shopperSession,
                         setupTokenId = setupTokenId,
+                        startTime = startTime,
                     )
                 } else {
                     launchVaultViaPatchCCOFallback(
@@ -436,6 +446,7 @@ class PayPalWebCheckoutClient internal constructor(
         activity: Activity,
         shopperSession: CreateShopperSessionWithAppSwitchEligibilityResponse,
         orderId: String,
+        startTime: Long,
     ): PayPalPresentAuthChallengeResult {
         appSwitchEnabled = shopperSession.appSwitchEligible && canAttemptPayPalAppSwitch()
         val launchUri = shopperSession.getLaunchUri(orderId, TokenType.ORDER_ID)
@@ -455,6 +466,7 @@ class PayPalWebCheckoutClient internal constructor(
                 shopperSessionId = shopperSessionId,
             )
         }
+        val endTime = System.currentTimeMillis()
 
         val result = payPalWebLauncher.launchWithUrl(
             context = activity,
@@ -464,6 +476,7 @@ class PayPalWebCheckoutClient internal constructor(
             returnToAppStrategy = ReturnToAppStrategy.AppLink(returnToAppUrlConfig?.returnAppUrl ?: ""),
         )
         logCheckoutPresentAuthChallengeResult(result, launchUri.toString())
+        notifyUserPerceivedLatency(LatencyFlow.CHECKOUT, result, startTime, endTime)
         return result
     }
 
@@ -528,9 +541,11 @@ class PayPalWebCheckoutClient internal constructor(
         activity: Activity,
         shopperSession: CreateShopperSessionWithAppSwitchEligibilityResponse,
         setupTokenId: String,
+        startTime: Long,
     ): PayPalPresentAuthChallengeResult {
         appSwitchEnabled = shopperSession.appSwitchEligible && canAttemptPayPalAppSwitch()
         val launchUri = shopperSession.getLaunchUri(setupTokenId, TokenType.VAULT_ID)
+        val endTime = System.currentTimeMillis()
 
         if (appSwitchEnabled) {
             analytics.notify(
@@ -557,6 +572,7 @@ class PayPalWebCheckoutClient internal constructor(
             returnToAppStrategy = ReturnToAppStrategy.AppLink(returnToAppUrlConfig?.returnAppUrl ?: ""),
         )
         logVaultPresentAuthChallengeResult(result, launchUri.toString())
+        notifyUserPerceivedLatency(LatencyFlow.VAULT, result, startTime, endTime)
         return result
     }
 
@@ -669,6 +685,8 @@ class PayPalWebCheckoutClient internal constructor(
             ),
         )
 
+        notifyApiRequestLatency(LatencyEndpoint.CREATE_SESSION, result.timing)
+
         return when (result) {
             is APIResult.Success -> {
                 analytics.notify(
@@ -726,7 +744,8 @@ class PayPalWebCheckoutClient internal constructor(
                 )
             }
 
-            updateConfigDeferred.await() // waits for completion, ignores result
+            val updateConfigResult = updateConfigDeferred.await() // waits for completion
+            notifyApiRequestLatency(LatencyEndpoint.UPDATE_CLIENT_CONFIG, updateConfigResult.timing)
             launchUriDeferred.await() // returns launch URI
         }
 
@@ -941,6 +960,34 @@ class PayPalWebCheckoutClient internal constructor(
         return requestStrategy ?: urlScheme?.let {
             ReturnToAppStrategy.CustomUrlScheme(urlScheme)
         }
+    }
+
+    private fun notifyUserPerceivedLatency(
+        flow: String,
+        result: PayPalPresentAuthChallengeResult,
+        startTime: Long,
+        endTime: Long
+    ) {
+        val presentationType = when (result) {
+            is PayPalPresentAuthChallengeResult.Success ->
+                if (appSwitchEnabled) PresentationType.APP_SWITCH else PresentationType.BROWSER
+
+            is PayPalPresentAuthChallengeResult.Failure -> PresentationType.ERROR
+        }
+        analytics.notifyUserPerceivedLatency(flow, presentationType, startTime, endTime)
+    }
+
+    private fun notifyUserPerceivedLatencyError(flow: String, startTime: Long) {
+        analytics.notifyUserPerceivedLatency(
+            flow = flow,
+            presentationType = PresentationType.ERROR,
+            startTime = startTime,
+            endTime = System.currentTimeMillis()
+        )
+    }
+
+    private fun notifyApiRequestLatency(endpoint: String, timing: HttpRequestTiming?) {
+        timing?.let { analytics.notifyApiRequestLatency(endpoint, it.startTime, it.endTime) }
     }
 
     // endregion

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -9,7 +9,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
-import com.paypal.android.corepayments.HttpRequestTiming
+import com.paypal.android.corepayments.HttpRoundTripTiming
 import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.corepayments.UpdateClientConfigAPI
 import com.paypal.android.corepayments.analytics.AnalyticsService
@@ -685,7 +685,7 @@ class PayPalWebCheckoutClient internal constructor(
             ),
         )
 
-        notifyApiRequestLatency(LatencyEndpoint.CREATE_SESSION, result.timing)
+        notifyApiRequestLatency(LatencyEndpoint.CREATE_SESSION, result.roundTripTiming)
 
         return when (result) {
             is APIResult.Success -> {
@@ -745,7 +745,7 @@ class PayPalWebCheckoutClient internal constructor(
             }
 
             val updateConfigResult = updateConfigDeferred.await() // waits for completion
-            notifyApiRequestLatency(LatencyEndpoint.UPDATE_CLIENT_CONFIG, updateConfigResult.timing)
+            notifyApiRequestLatency(LatencyEndpoint.UPDATE_CLIENT_CONFIG, updateConfigResult.roundTripTiming)
             launchUriDeferred.await() // returns launch URI
         }
 
@@ -986,8 +986,8 @@ class PayPalWebCheckoutClient internal constructor(
         )
     }
 
-    private fun notifyApiRequestLatency(endpoint: String, timing: HttpRequestTiming?) {
-        timing?.let { analytics.notifyApiRequestLatency(endpoint, it.startTime, it.endTime) }
+    private fun notifyApiRequestLatency(endpoint: String, roundTripTiming: HttpRoundTripTiming?) {
+        roundTripTiming?.let { analytics.notifyApiRequestLatency(endpoint, it.startTime, it.endTime) }
     }
 
     // endregion

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/LatencyEvent.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/LatencyEvent.kt
@@ -1,0 +1,25 @@
+@file:Suppress("SpacingAroundParens", "NoMultipleSpaces", "MaxLineLength")
+
+package com.paypal.android.paypalwebpayments.analytics
+
+internal enum class LatencyEvent(val value: String) {
+    API_REQUEST_LATENCY("paypal-web-payments:api-request-latency"),
+    USER_PERCEIVED_LATENCY("paypal-web-payments:user-perceived-latency"),
+}
+
+internal object PresentationType {
+    const val APP_SWITCH = "app-switch"
+    const val BROWSER = "browser"
+    const val ERROR = "error"
+}
+
+internal object LatencyFlow {
+    const val CHECKOUT = "checkout"
+    const val VAULT = "vault"
+}
+
+internal object LatencyEndpoint {
+    const val UPDATE_CLIENT_CONFIG = "/graphql/UpdateClientConfig"
+    const val CREATE_ORDER = "/v2/checkout/orders"
+    const val CREATE_SESSION = "/graphql/createShopperSessionWithAppSwitchEligibility"
+}

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/PayPalWebAnalytics.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/PayPalWebAnalytics.kt
@@ -57,4 +57,28 @@ internal class PayPalWebAnalytics(private val analyticsService: AnalyticsService
             startTime = startTime,
         )
     }
+
+    fun notifyApiRequestLatency(endpoint: String, startTime: Long, endTime: Long) {
+        analyticsService.sendAnalyticsEvent(
+            name = LatencyEvent.API_REQUEST_LATENCY.value,
+            endpoint = endpoint,
+            startTime = startTime,
+            endTime = endTime
+        )
+    }
+
+    fun notifyUserPerceivedLatency(
+        flow: String,
+        presentationType: String,
+        startTime: Long,
+        endTime: Long
+    ) {
+        analyticsService.sendAnalyticsEvent(
+            name = LatencyEvent.USER_PERCEIVED_LATENCY.value,
+            flow = flow,
+            presentationType = presentationType,
+            startTime = startTime,
+            endTime = endTime
+        )
+    }
 }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -5,7 +5,7 @@ import android.net.Uri
 import androidx.fragment.app.FragmentActivity
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
-import com.paypal.android.corepayments.HttpRequestTiming
+import com.paypal.android.corepayments.HttpRoundTripTiming
 import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.corepayments.UpdateClientConfigAPI
@@ -2272,7 +2272,7 @@ class PayPalWebCheckoutClientUnitTest {
                 )
             } returns APIResult.Success(
                 fakeSessionResponse,
-                timing = HttpRequestTiming(startTime = 1000L, endTime = 1500L)
+                roundTripTiming = HttpRoundTripTiming(startTime = 1000L, endTime = 1500L)
             )
 
             sut.createShopperSessionWithAppSwitchEligibility(
@@ -2301,7 +2301,7 @@ class PayPalWebCheckoutClientUnitTest {
                     tokenType = any(),
                     params = any(),
                 )
-            } returns APIResult.Success(fakeSessionResponse) // timing defaults to null
+            } returns APIResult.Success(fakeSessionResponse) // roundTripTiming defaults to null
 
             sut.createShopperSessionWithAppSwitchEligibility(
                 token = "fake-order-id",
@@ -2857,7 +2857,7 @@ class PayPalWebCheckoutClientUnitTest {
 
         coEvery {
             updateClientConfigAPI.updateClientConfig(any(), any())
-        } returns UpdateClientConfigResult.Success(HttpRequestTiming(1000L, 1500L))
+        } returns UpdateClientConfigResult.Success(HttpRoundTripTiming(1000L, 1500L))
 
         val request = PayPalWebCheckoutRequest(
             "fake-order-id",
@@ -2882,7 +2882,7 @@ class PayPalWebCheckoutClientUnitTest {
 
         coEvery {
             updateClientConfigAPI.updateClientConfig(any(), any())
-        } returns UpdateClientConfigResult.Success(timing = null)
+        } returns UpdateClientConfigResult.Success(roundTripTiming = null)
 
         val request = PayPalWebCheckoutRequest(
             "fake-order-id",

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -5,9 +5,11 @@ import android.net.Uri
 import androidx.fragment.app.FragmentActivity
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
+import com.paypal.android.corepayments.HttpRequestTiming
 import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.corepayments.UpdateClientConfigAPI
+import com.paypal.android.corepayments.UpdateClientConfigResult
 import com.paypal.android.corepayments.api.CreateShopperSessionWithAppSwitchEligibilityAPI
 import com.paypal.android.corepayments.api.PatchCCOWithAppSwitchEligibility
 import com.paypal.android.corepayments.common.DeviceInspector
@@ -19,7 +21,10 @@ import com.paypal.android.corepayments.model.ShopperSessionConfig
 import com.paypal.android.corepayments.model.TokenType
 import com.paypal.android.paypalwebpayments.errors.PayPalWebCheckoutError
 import com.paypal.android.paypalwebpayments.analytics.CheckoutEvent
+import com.paypal.android.paypalwebpayments.analytics.LatencyEndpoint
+import com.paypal.android.paypalwebpayments.analytics.LatencyFlow
 import com.paypal.android.paypalwebpayments.analytics.PayPalWebAnalytics
+import com.paypal.android.paypalwebpayments.analytics.PresentationType
 import com.paypal.android.paypalwebpayments.analytics.VaultEvent
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -2257,6 +2262,61 @@ class PayPalWebCheckoutClientUnitTest {
         }
 
     @Test
+    fun `createShopperSessionWithAppSwitchEligibility() emits api-request-latency with CREATE_SESSION timing`() =
+        runTest {
+            coEvery {
+                createShopperSessionAPI(
+                    token = any(),
+                    tokenType = any(),
+                    params = any(),
+                )
+            } returns APIResult.Success(
+                fakeSessionResponse,
+                timing = HttpRequestTiming(startTime = 1000L, endTime = 1500L)
+            )
+
+            sut.createShopperSessionWithAppSwitchEligibility(
+                token = "fake-order-id",
+                tokenType = TokenType.ORDER_ID,
+                urlConfig = fakeUrlConfig,
+                userIdentity = fakeUserIdentity,
+                userAction = PayPalUserAction.CONTINUE,
+            )
+
+            verify(exactly = 1) {
+                analytics.notifyApiRequestLatency(
+                    endpoint = LatencyEndpoint.CREATE_SESSION,
+                    startTime = 1000L,
+                    endTime = 1500L
+                )
+            }
+        }
+
+    @Test
+    fun `createShopperSessionWithAppSwitchEligibility() does not emit api-request-latency when timing is absent`() =
+        runTest {
+            coEvery {
+                createShopperSessionAPI(
+                    token = any(),
+                    tokenType = any(),
+                    params = any(),
+                )
+            } returns APIResult.Success(fakeSessionResponse) // timing defaults to null
+
+            sut.createShopperSessionWithAppSwitchEligibility(
+                token = "fake-order-id",
+                tokenType = TokenType.ORDER_ID,
+                urlConfig = fakeUrlConfig,
+                userIdentity = fakeUserIdentity,
+                userAction = PayPalUserAction.CONTINUE,
+            )
+
+            verify(exactly = 0) {
+                analytics.notifyApiRequestLatency(any(), any(), any())
+            }
+        }
+
+    @Test
     fun `vault() with setupTokenId clears session deferred so a second call returns SESSION_NOT_CREATED`() =
         runTest {
             val sutV3 = makeSutWithUrlScheme()
@@ -2649,4 +2709,189 @@ class PayPalWebCheckoutClientUnitTest {
                 payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
             }
         }
+    // MARK: - Latency Analytics Tests
+
+    @Test
+    fun `start() emits user-perceived-latency with checkout flow and browser presentation`() =
+        runTest {
+            val sutV3 = makeSutWithUrlScheme()
+            every {
+                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
+            } returns PayPalPresentAuthChallengeResult.Success("auth state")
+
+            // fakeSessionResponse is not app-switch eligible -> browser presentation
+            val callback = mockk<PayPalWebStartCallback>(relaxed = true)
+            sutV3.createPayPalSession(
+                tokenType = TokenType.ORDER_ID,
+                userIdentity = fakeUserIdentity,
+                urlConfig = fakeUrlConfig,
+            )
+            sutV3.shopperSessionDeferred = CompletableDeferred(fakeSessionResponse)
+            sutV3.start(activity, "fake-order-id", callback)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verify(exactly = 1) {
+                analytics.notifyUserPerceivedLatency(
+                    flow = LatencyFlow.CHECKOUT,
+                    presentationType = PresentationType.BROWSER,
+                    startTime = any(),
+                    endTime = any()
+                )
+            }
+        }
+
+    @Test
+    fun `start() emits user-perceived-latency with app-switch presentation when eligible and installed`() =
+        runTest {
+            val sutV3 = makeSutWithUrlScheme()
+            every { deviceInspector.isPayPalInstalled } returns true
+            every { deviceInspector.canResolvePayPalAppSwitch() } returns true
+            every {
+                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
+            } returns PayPalPresentAuthChallengeResult.Success("auth state")
+
+            val appSwitchEligibleResponse = fakeSessionResponse.copy(
+                appSwitchEligible = true,
+                redirectUrl = "https://example.com/app-switch-redirect",
+            )
+            val callback = mockk<PayPalWebStartCallback>(relaxed = true)
+            sutV3.createPayPalSession(
+                tokenType = TokenType.ORDER_ID,
+                userIdentity = fakeUserIdentity,
+                urlConfig = fakeUrlConfig,
+            )
+            sutV3.shopperSessionDeferred = CompletableDeferred(appSwitchEligibleResponse)
+            sutV3.start(activity, "fake-order-id", callback)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verify(exactly = 1) {
+                analytics.notifyUserPerceivedLatency(
+                    flow = LatencyFlow.CHECKOUT,
+                    presentationType = PresentationType.APP_SWITCH,
+                    startTime = any(),
+                    endTime = any()
+                )
+            }
+        }
+
+    @Test
+    fun `start() emits user-perceived-latency with error presentation on launch failure`() =
+        runTest {
+            val sutV3 = makeSutWithUrlScheme()
+            val sdkError = PayPalSDKError(123, "fake error description")
+            every {
+                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
+            } returns PayPalPresentAuthChallengeResult.Failure(sdkError)
+
+            val callback = mockk<PayPalWebStartCallback>(relaxed = true)
+            sutV3.createPayPalSession(
+                tokenType = TokenType.ORDER_ID,
+                userIdentity = fakeUserIdentity,
+                urlConfig = fakeUrlConfig,
+            )
+            sutV3.shopperSessionDeferred = CompletableDeferred(fakeSessionResponse)
+            sutV3.start(activity, "fake-order-id", callback)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verify(exactly = 1) {
+                analytics.notifyUserPerceivedLatency(
+                    flow = LatencyFlow.CHECKOUT,
+                    presentationType = PresentationType.ERROR,
+                    startTime = any(),
+                    endTime = any()
+                )
+            }
+        }
+
+    @Test
+    fun `start() emits user-perceived-latency with error presentation when session not created`() =
+        runTest {
+            val callback = mockk<PayPalWebStartCallback>(relaxed = true)
+
+            sut.start(activity, "fake-order-id", callback)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verify(exactly = 1) {
+                analytics.notifyUserPerceivedLatency(
+                    flow = LatencyFlow.CHECKOUT,
+                    presentationType = PresentationType.ERROR,
+                    startTime = any(),
+                    endTime = any()
+                )
+            }
+        }
+
+    @Test
+    fun `vault() emits user-perceived-latency with vault flow`() =
+        runTest {
+            val sutV3 = makeSutWithUrlScheme()
+            every {
+                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
+            } returns PayPalPresentAuthChallengeResult.Success("auth state")
+
+            val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
+            sutV3.createPayPalSession(
+                tokenType = TokenType.ORDER_ID,
+                userIdentity = fakeUserIdentity,
+                urlConfig = fakeUrlConfig,
+            )
+            sutV3.shopperSessionDeferred = CompletableDeferred(fakeSessionResponse)
+            sutV3.vault(activity, "fake-setup-token-id", callback)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            verify(exactly = 1) {
+                analytics.notifyUserPerceivedLatency(
+                    flow = LatencyFlow.VAULT,
+                    presentationType = any(),
+                    startTime = any(),
+                    endTime = any()
+                )
+            }
+        }
+
+    @Test
+    fun `startAsync() emits api-request-latency using updateClientConfig timing`() = runTest {
+        every {
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
+        } returns PayPalPresentAuthChallengeResult.Success("auth state")
+
+        coEvery {
+            updateClientConfigAPI.updateClientConfig(any(), any())
+        } returns UpdateClientConfigResult.Success(HttpRequestTiming(1000L, 1500L))
+
+        val request = PayPalWebCheckoutRequest(
+            "fake-order-id",
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
+        sut.startAsync(activity, request)
+
+        verify(exactly = 1) {
+            analytics.notifyApiRequestLatency(
+                endpoint = LatencyEndpoint.UPDATE_CLIENT_CONFIG,
+                startTime = 1000L,
+                endTime = 1500L
+            )
+        }
+    }
+
+    @Test
+    fun `startAsync() does not emit api-request-latency when timing is absent`() = runTest {
+        every {
+            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
+        } returns PayPalPresentAuthChallengeResult.Success("auth state")
+
+        coEvery {
+            updateClientConfigAPI.updateClientConfig(any(), any())
+        } returns UpdateClientConfigResult.Success(timing = null)
+
+        val request = PayPalWebCheckoutRequest(
+            "fake-order-id",
+            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
+        )
+        sut.startAsync(activity, request)
+
+        verify(exactly = 0) {
+            analytics.notifyApiRequestLatency(any(), any(), any())
+        }
+    }
 }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/analytics/PayPalWebAnalyticsUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/analytics/PayPalWebAnalyticsUnitTest.kt
@@ -1,0 +1,60 @@
+package com.paypal.android.paypalwebpayments.analytics
+
+import com.paypal.android.corepayments.analytics.AnalyticsService
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PayPalWebAnalyticsUnitTest {
+
+    private lateinit var analyticsService: AnalyticsService
+    private lateinit var sut: PayPalWebAnalytics
+
+    @Before
+    fun beforeEach() {
+        analyticsService = mockk(relaxed = true)
+        sut = PayPalWebAnalytics(analyticsService)
+    }
+
+    @Test
+    fun `notifyApiRequestLatency sends api-request-latency event with endpoint and timing`() {
+        sut.notifyApiRequestLatency(
+            endpoint = LatencyEndpoint.CREATE_ORDER,
+            startTime = 1000L,
+            endTime = 1500L
+        )
+
+        verify {
+            analyticsService.sendAnalyticsEvent(
+                name = LatencyEvent.API_REQUEST_LATENCY.value,
+                endpoint = LatencyEndpoint.CREATE_ORDER,
+                startTime = 1000L,
+                endTime = 1500L
+            )
+        }
+    }
+
+    @Test
+    fun `notifyUserPerceivedLatency sends user-perceived-latency event with flow and presentation type`() {
+        sut.notifyUserPerceivedLatency(
+            flow = LatencyFlow.CHECKOUT,
+            presentationType = PresentationType.APP_SWITCH,
+            startTime = 2000L,
+            endTime = 2200L
+        )
+
+        verify {
+            analyticsService.sendAnalyticsEvent(
+                name = LatencyEvent.USER_PERCEIVED_LATENCY.value,
+                flow = LatencyFlow.CHECKOUT,
+                presentationType = PresentationType.APP_SWITCH,
+                startTime = 2000L,
+                endTime = 2200L
+            )
+        }
+    }
+}


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

Adds two analytics events to the `PayPalWebPayments` flow plus the reusable HTTP-timing and analytics plumbing they require (mirrors `braintree-android`'s `core:api-request-latency` pattern, which `paypal-android` lacked):

- paypal-web-payments:api-request-latency (start_time, end_time, endpoint) — emitted for each backend call on the checkout critical path:
    - updateClientConfig — endpoint `/graphql/UpdateClientConfig`
    - createShopperSessionWithAppSwitchEligibility (Shopper Session) — endpoint `/graphql/createShopperSessionWithAppSwitchEligibility`
- paypal-web-payments:user-perceived-latency (start_time, end_time, presentation_type, flow) — emitted once per start()/vault()

CorePayments:
- New HttpRequestTiming; HttpResponse.timing captured in Http.send() on both success and error paths.
- GraphQLResult / GraphQLClient and UpdateClientConfigResult surface timing.
- AnalyticsEventData / AnalyticsService / TrackingEventParams / TrackingEventsAPI extended with start_time, end_time, endpoint, presentation_type, flow.

PayPalWebPayments:
- LatencyEvent enum + PresentationType/LatencyFlow/LatencyEndpoint constants.
- PayPalWebAnalytics.notifyApiRequestLatency / notifyUserPerceivedLatency.
- PayPalWebCheckoutClient emits user-perceived-latency once per start()/vault() and api-request-latency for the existing updateClientConfig call.

Tests added/updated across CorePayments and PayPalWebPayments. apiDump regenerated; apiCheck, detekt, and unit tests pass.

 ### Checklist

 - [ ] Added a changelog entry N/A

### Tests

```diff
diff --git a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
index 43c4008..b277681 100644
--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
@@ -71,6 +71,12 @@ class AnalyticsService internal constructor(
                     presentationType = presentationType,
                     flow = flow
                 )
+                // TEMP (not for PR): surface ONLY latency analytics events in logcat
+                Log.d(
+                    "PayPalLatencyDemo",
+                    "event=$name endpoint=$endpoint startTime=$startTime endTime=$endTime " +
+                            "presentationType=$presentationType flow=$flow"
+                )
```

### Recording

https://github.com/user-attachments/assets/4d81d38a-5192-4717-8eb7-49caa2392c59

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @ayer-ribeiro