### PR TITLE
[PATCH] Add analytics tracking to Venmo checkout flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     * `VenmoFinishStartResult.Canceled` when user cancels payment
     * `VenmoFinishStartResult.NoResult` when intent is unrelated to Venmo flow
     * `VenmoFinishStartResult.Failure` for errors
+  * Add comprehensive analytics tracking to checkout flow with events for start, launch success/failure, and completion (success/canceled/failed)
 * Adds new property `appSwitchWhenEligible`in `PayPalWebCheckoutRequest` to control app switch
   behavior
 * Adds new property `appSwitchWhenEligible`in `PayPalWebVaultRequest` to control app switch behavior

--- a/Venmo/src/main/java/com/paypal/android/venmo/VenmoClient.kt
+++ b/Venmo/src/main/java/com/paypal/android/venmo/VenmoClient.kt
@@ -9,11 +9,14 @@ import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.corepayments.PayPalSDKErrorCode
 import com.paypal.android.corepayments.UpdateClientConfigAPI
+import com.paypal.android.corepayments.analytics.AnalyticsService
 import com.paypal.android.corepayments.api.GetFundingEligibility
 import com.paypal.android.corepayments.browserswitch.ChromeCustomTabOptions
 import com.paypal.android.corepayments.browserswitch.ChromeCustomTabsClient
 import com.paypal.android.corepayments.browserswitch.LaunchChromeCustomTabResult
 import com.paypal.android.corepayments.model.APIResult
+import com.paypal.android.venmo.analytics.VenmoAnalytics
+import com.paypal.android.venmo.analytics.VenmoCheckoutEvent
 
 class VenmoClient internal constructor(
     private val context: Context,
@@ -21,6 +24,7 @@ class VenmoClient internal constructor(
     private val ccoAPI: UpdateClientConfigAPI,
     private val getFundingEligibility: GetFundingEligibility,
     private val chromeCustomTabsClient: ChromeCustomTabsClient,
+    private val analytics: VenmoAnalytics,
 ) {
 
     companion object {
@@ -42,7 +46,8 @@ class VenmoClient internal constructor(
         coreConfig = config,
         ccoAPI = UpdateClientConfigAPI(context, config),
         getFundingEligibility = GetFundingEligibility(config),
-        chromeCustomTabsClient = ChromeCustomTabsClient()
+        chromeCustomTabsClient = ChromeCustomTabsClient(),
+        analytics = VenmoAnalytics(AnalyticsService(context.applicationContext, config))
     )
 
     suspend fun isEligible(buyerCountry: String): VenmoEligibilityResult {
@@ -84,6 +89,8 @@ class VenmoClient internal constructor(
     ): VenmoStartResult {
         require(orderId.isNotBlank()) { "Order ID cannot be blank" }
 
+        analytics.notify(VenmoCheckoutEvent.START, orderId)
+
         // Update client config; ignore result as transaction should proceed regardless
         ccoAPI.updateClientConfig(
             tokenId = orderId,
@@ -99,8 +106,13 @@ class VenmoClient internal constructor(
         return try {
             val cctOptions = ChromeCustomTabOptions(launchUri = appSwitchUri)
             when (chromeCustomTabsClient.launch(activity, cctOptions)) {
-                LaunchChromeCustomTabResult.Success -> VenmoStartResult.Success
+                LaunchChromeCustomTabResult.Success -> {
+                    analytics.notify(VenmoCheckoutEvent.LAUNCH_SUCCESS, orderId)
+                    VenmoStartResult.Success
+                }
+
                 LaunchChromeCustomTabResult.ActivityNotFound -> {
+                    analytics.notify(VenmoCheckoutEvent.LAUNCH_FAILED, orderId)
                     val error = PayPalSDKError(
                         code = PayPalSDKErrorCode.CHECKOUT_ERROR.ordinal,
                         errorDescription = "Unable to launch Venmo app or web browser"
@@ -109,6 +121,7 @@ class VenmoClient internal constructor(
                 }
             }
         } catch (e: Exception) {
+            analytics.notify(VenmoCheckoutEvent.LAUNCH_FAILED, orderId)
             val error = PayPalSDKError(
                 code = PayPalSDKErrorCode.CHECKOUT_ERROR.ordinal,
                 errorDescription = e.message ?: "Failed to launch Venmo"
@@ -126,12 +139,14 @@ class VenmoClient internal constructor(
 
         return when {
             canceled -> {
+                analytics.notify(VenmoCheckoutEvent.CANCELED, orderId.takeIf { it.isNotEmpty() })
                 VenmoFinishStartResult.Canceled(orderId.takeIf { it.isNotEmpty() })
             }
 
             approved -> {
                 val payerId = deepLinkUri.getQueryParameter(PAYER_ID_PARAM)
                 if (payerId.isNullOrEmpty()) {
+                    analytics.notify(VenmoCheckoutEvent.FAIL, orderId.takeIf { it.isNotEmpty() })
                     VenmoFinishStartResult.Failure(
                         PayPalSDKError(
                             code = PayPalSDKErrorCode.DATA_PARSING_ERROR.ordinal,
@@ -139,11 +154,13 @@ class VenmoClient internal constructor(
                         )
                     )
                 } else {
+                    analytics.notify(VenmoCheckoutEvent.SUCCESS, orderId)
                     VenmoFinishStartResult.Success(orderId, payerId, true)
                 }
             }
 
             else -> {
+                analytics.notify(VenmoCheckoutEvent.FAIL, orderId.takeIf { it.isNotEmpty() })
                 VenmoFinishStartResult.Failure(
                     PayPalSDKError(
                         code = PayPalSDKErrorCode.DATA_PARSING_ERROR.ordinal,

--- a/Venmo/src/main/java/com/paypal/android/venmo/VenmoClient.kt
+++ b/Venmo/src/main/java/com/paypal/android/venmo/VenmoClient.kt
@@ -166,6 +166,7 @@ class VenmoClient internal constructor(
             }
 
             else -> {
+                analytics.notify(VenmoCheckoutEvent.FAIL, orderId.takeIf { it.isNotEmpty() })
                 VenmoFinishStartResult.Failure(
                     PayPalSDKError(
                         code = PayPalSDKErrorCode.DATA_PARSING_ERROR.ordinal,

--- a/Venmo/src/main/java/com/paypal/android/venmo/analytics/VenmoAnalytics.kt
+++ b/Venmo/src/main/java/com/paypal/android/venmo/analytics/VenmoAnalytics.kt
@@ -1,0 +1,14 @@
+package com.paypal.android.venmo.analytics
+
+import com.paypal.android.corepayments.analytics.AnalyticsService
+
+internal class VenmoAnalytics(private val analyticsService: AnalyticsService) {
+
+    fun notify(event: VenmoCheckoutEvent, orderId: String?) {
+        analyticsService.sendAnalyticsEvent(
+            name = event.value,
+            orderId = orderId,
+            appSwitchEnabled = true
+        )
+    }
+}

--- a/Venmo/src/main/java/com/paypal/android/venmo/analytics/VenmoCheckoutEvent.kt
+++ b/Venmo/src/main/java/com/paypal/android/venmo/analytics/VenmoCheckoutEvent.kt
@@ -1,0 +1,15 @@
+@file:Suppress("SpacingAroundParens", "NoMultipleSpaces", "MaxLineLength")
+
+package com.paypal.android.venmo.analytics
+
+internal enum class VenmoCheckoutEvent(val value: String) {
+    // @formatter:off
+    START(            "venmo:checkout:start"),
+    SUCCESS(          "venmo:checkout:success"),
+    FAIL(             "venmo:checkout:fail"),
+    CANCELED(           "venmo:checkout:canceled"),
+
+    LAUNCH_SUCCESS("venmo:checkout:launched:success"),
+    LAUNCH_FAILED(   "venmo:checkout:launched:failed"),
+    // @formatter:on
+}

--- a/Venmo/src/test/java/com/paypal/android/venmo/VenmoClientUnitTest.kt
+++ b/Venmo/src/test/java/com/paypal/android/venmo/VenmoClientUnitTest.kt
@@ -14,10 +14,13 @@ import com.paypal.android.corepayments.browserswitch.ChromeCustomTabsClient
 import com.paypal.android.corepayments.browserswitch.LaunchChromeCustomTabResult
 import com.paypal.android.corepayments.model.APIResult
 import com.paypal.android.corepayments.model.FundingEligibility
+import com.paypal.android.venmo.analytics.VenmoAnalytics
+import com.paypal.android.venmo.analytics.VenmoCheckoutEvent
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -35,6 +38,7 @@ class VenmoClientUnitTest {
     private val ccoAPI = mockk<UpdateClientConfigAPI>(relaxed = true)
     private val getFundingEligibility = mockk<GetFundingEligibility>(relaxed = true)
     private val chromeCustomTabsClient = mockk<ChromeCustomTabsClient>(relaxed = true)
+    private val analytics = mockk<VenmoAnalytics>(relaxed = true)
 
     private lateinit var venmoClient: VenmoClient
 
@@ -49,7 +53,8 @@ class VenmoClientUnitTest {
             coreConfig = coreConfig,
             ccoAPI = ccoAPI,
             getFundingEligibility = getFundingEligibility,
-            chromeCustomTabsClient = chromeCustomTabsClient
+            chromeCustomTabsClient = chromeCustomTabsClient,
+            analytics = analytics
         )
     }
 
@@ -156,6 +161,10 @@ class VenmoClientUnitTest {
         val result = venmoClient.start(activity, orderId)
 
         assertTrue(result is VenmoStartResult.Success)
+        verify {
+            analytics.notify(VenmoCheckoutEvent.START, orderId)
+            analytics.notify(VenmoCheckoutEvent.LAUNCH_SUCCESS, orderId)
+        }
     }
 
     @Test
@@ -168,6 +177,10 @@ class VenmoClientUnitTest {
 
         assertTrue(result is VenmoStartResult.Failure)
         assertEquals("Unable to launch Venmo app or web browser", (result as VenmoStartResult.Failure).error.errorDescription)
+        verify {
+            analytics.notify(VenmoCheckoutEvent.START, orderId)
+            analytics.notify(VenmoCheckoutEvent.LAUNCH_FAILED, orderId)
+        }
     }
 
     @Test
@@ -181,6 +194,10 @@ class VenmoClientUnitTest {
 
         assertTrue(result is VenmoStartResult.Failure)
         assertEquals(exceptionMessage, (result as VenmoStartResult.Failure).error.errorDescription)
+        verify {
+            analytics.notify(VenmoCheckoutEvent.START, orderId)
+            analytics.notify(VenmoCheckoutEvent.LAUNCH_FAILED, orderId)
+        }
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -252,6 +269,9 @@ class VenmoClientUnitTest {
 
         assertTrue(result is VenmoFinishStartResult.Canceled)
         assertEquals(orderId, (result as VenmoFinishStartResult.Canceled).orderId)
+        verify {
+            analytics.notify(VenmoCheckoutEvent.CANCELED, orderId)
+        }
     }
 
     @Test
@@ -266,6 +286,9 @@ class VenmoClientUnitTest {
 
         assertTrue(result is VenmoFinishStartResult.Canceled)
         assertNull((result as VenmoFinishStartResult.Canceled).orderId)
+        verify {
+            analytics.notify(VenmoCheckoutEvent.CANCELED, null)
+        }
     }
 
     @Test
@@ -287,6 +310,9 @@ class VenmoClientUnitTest {
         assertEquals(orderId, successResult.token)
         assertEquals(payerId, successResult.payerId)
         assertEquals(true, successResult.approved)
+        verify {
+            analytics.notify(VenmoCheckoutEvent.SUCCESS, orderId)
+        }
     }
 
     @Test
@@ -305,6 +331,9 @@ class VenmoClientUnitTest {
         val failureResult = result as VenmoFinishStartResult.Failure
         assertEquals(PayPalSDKErrorCode.DATA_PARSING_ERROR.ordinal, failureResult.error.code)
         assertTrue(failureResult.error.errorDescription.contains("Payer ID"))
+        verify {
+            analytics.notify(VenmoCheckoutEvent.FAIL, orderId)
+        }
     }
 
     @Test
@@ -320,6 +349,9 @@ class VenmoClientUnitTest {
         assertTrue(result is VenmoFinishStartResult.Failure)
         val failureResult = result as VenmoFinishStartResult.Failure
         assertEquals(PayPalSDKErrorCode.DATA_PARSING_ERROR.ordinal, failureResult.error.code)
+        verify {
+            analytics.notify(VenmoCheckoutEvent.FAIL, null)
+        }
     }
 
     @Test
@@ -330,5 +362,8 @@ class VenmoClientUnitTest {
         val result = venmoClient.finishStart(intent)
 
         assertTrue(result is VenmoFinishStartResult.Failure)
+        verify {
+            analytics.notify(VenmoCheckoutEvent.FAIL, null)
+        }
     }
 }

--- a/Venmo/src/test/java/com/paypal/android/venmo/analytics/VenmoAnalyticsUnitTest.kt
+++ b/Venmo/src/test/java/com/paypal/android/venmo/analytics/VenmoAnalyticsUnitTest.kt
@@ -1,0 +1,134 @@
+package com.paypal.android.venmo.analytics
+
+import com.paypal.android.corepayments.analytics.AnalyticsService
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class VenmoAnalyticsUnitTest {
+
+    private val analyticsService = mockk<AnalyticsService>(relaxed = true)
+    private lateinit var venmoAnalytics: VenmoAnalytics
+
+    @Before
+    fun setUp() {
+        venmoAnalytics = VenmoAnalytics(analyticsService)
+    }
+
+    @Test
+    fun notify_withStartEvent_sendsAnalyticsEvent() {
+        val orderId = "order-123"
+
+        venmoAnalytics.notify(VenmoCheckoutEvent.START, orderId)
+
+        verify {
+            analyticsService.sendAnalyticsEvent(
+                name = "venmo:checkout:start",
+                orderId = orderId,
+                appSwitchEnabled = true
+            )
+        }
+    }
+
+    @Test
+    fun notify_withSuccessEvent_sendsAnalyticsEvent() {
+        val orderId = "order-456"
+
+        venmoAnalytics.notify(VenmoCheckoutEvent.SUCCESS, orderId)
+
+        verify {
+            analyticsService.sendAnalyticsEvent(
+                name = "venmo:checkout:success",
+                orderId = orderId,
+                appSwitchEnabled = true
+            )
+        }
+    }
+
+    @Test
+    fun notify_withFailEvent_sendsAnalyticsEvent() {
+        val orderId = "order-789"
+
+        venmoAnalytics.notify(VenmoCheckoutEvent.FAIL, orderId)
+
+        verify {
+            analyticsService.sendAnalyticsEvent(
+                name = "venmo:checkout:fail",
+                orderId = orderId,
+                appSwitchEnabled = true
+            )
+        }
+    }
+
+    @Test
+    fun notify_withCanceledEvent_sendsAnalyticsEvent() {
+        val orderId = "order-101"
+
+        venmoAnalytics.notify(VenmoCheckoutEvent.CANCELED, orderId)
+
+        verify {
+            analyticsService.sendAnalyticsEvent(
+                name = "venmo:checkout:canceled",
+                orderId = orderId,
+                appSwitchEnabled = true
+            )
+        }
+    }
+
+    @Test
+    fun notify_withLaunchSuccessEvent_sendsAnalyticsEvent() {
+        val orderId = "order-202"
+
+        venmoAnalytics.notify(VenmoCheckoutEvent.LAUNCH_SUCCESS, orderId)
+
+        verify {
+            analyticsService.sendAnalyticsEvent(
+                name = "venmo:checkout:launched:success",
+                orderId = orderId,
+                appSwitchEnabled = true
+            )
+        }
+    }
+
+    @Test
+    fun notify_withLaunchFailedEvent_sendsAnalyticsEvent() {
+        val orderId = "order-303"
+
+        venmoAnalytics.notify(VenmoCheckoutEvent.LAUNCH_FAILED, orderId)
+
+        verify {
+            analyticsService.sendAnalyticsEvent(
+                name = "venmo:checkout:launched:failed",
+                orderId = orderId,
+                appSwitchEnabled = true
+            )
+        }
+    }
+
+    @Test
+    fun notify_withNullOrderId_sendsAnalyticsEvent() {
+        venmoAnalytics.notify(VenmoCheckoutEvent.START, null)
+
+        verify {
+            analyticsService.sendAnalyticsEvent(
+                name = "venmo:checkout:start",
+                orderId = null,
+                appSwitchEnabled = true
+            )
+        }
+    }
+
+    @Test
+    fun notify_alwaysSetsAppSwitchEnabledToTrue() {
+        venmoAnalytics.notify(VenmoCheckoutEvent.SUCCESS, "order-123")
+
+        verify {
+            analyticsService.sendAnalyticsEvent(
+                name = "venmo:checkout:success",
+                orderId = "order-123",
+                appSwitchEnabled = true
+            )
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- Add comprehensive analytics tracking to Venmo checkout flow
- Below events are added
   - START → venmo:checkout:start          
  - SUCCESS → venmo:checkout:success
  - FAIL → venmo:checkout:fail                                                                                                                                                       
  - CANCELED → venmo:checkout:canceled
  - LAUNCH_SUCCESS → venmo:checkout:launched:success                                                                                                                                 
  - LAUNCH_FAILED → venmo:checkout:launched:failed  

### API / Contract Changes

## New

None

## Breaking Changes

- [ ] No breaking changes
- [ ] Breaking changes (describe migration steps below)

## Migration:

(None)

### Checklist

- [ ] Added a changelog entry