### PR TITLE
Use per-app-start sessionId as createShopperSession contextId

### DIFF
--- a/CorePayments/api/CorePayments.api
+++ b/CorePayments/api/CorePayments.api
@@ -135,6 +135,10 @@ public final class com/paypal/android/corepayments/ReturnToAppStrategy$CustomUrl
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/paypal/android/corepayments/SessionIdRepository$Companion {
+	public final fun getInstance ()Lcom/paypal/android/corepayments/SessionIdRepository;
+}
+
 public final class com/paypal/android/corepayments/UpdateClientConfigAPI$Defaults {
 	public static final field INSTANCE Lcom/paypal/android/corepayments/UpdateClientConfigAPI$Defaults;
 	public static final field INTEGRATION_ARTIFACT Ljava/lang/String;

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/SessionIdRepository.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/SessionIdRepository.kt
@@ -1,0 +1,35 @@
+package com.paypal.android.corepayments
+
+import androidx.annotation.RestrictTo
+
+/**
+ * Holds a [sessionId] that is generated once per app start and reused for the lifetime of the
+ * process. The value is used as the `contextId` for the
+ * `createShopperSessionWithAppSwitchEligibility` call so that events belonging to the same app
+ * session can be tied together.
+ *
+ * The id is an in-memory, immutable value backed by a lazily-created process-wide
+ * singleton ([instance]).
+ *
+ * @suppress
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class SessionIdRepository(
+    uuidHelper: UUIDHelper = UUIDHelper()
+) {
+
+    /**
+     * Unique identifier generated once per app start. Held in memory only (not persisted), so a
+     * new value is created the next time the process starts.
+     */
+    val sessionId: String = uuidHelper.formattedUUID
+
+    companion object {
+
+        /**
+         * Process-wide singleton. Created lazily on first access, which fixes the [sessionId]
+         * value for the remainder of the app's lifetime.
+         */
+        val instance: SessionIdRepository by lazy { SessionIdRepository() }
+    }
+}

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/UUIDHelper.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/UUIDHelper.kt
@@ -1,0 +1,20 @@
+package com.paypal.android.corepayments
+
+import androidx.annotation.RestrictTo
+import java.util.UUID
+
+/**
+ * Helper for generating unique identifiers used across the SDK.
+ *
+ * @suppress
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class UUIDHelper {
+
+    /**
+     * A random UUID with the dashes stripped, e.g. a 32-character lowercase hex string.
+     */
+    val formattedUUID: String
+        // Strip dashes so the value can be used directly as a contextId/session identifier.
+        get() = UUID.randomUUID().toString().replace("-", "")
+}

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/SessionIdRepositoryUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/SessionIdRepositoryUnitTest.kt
@@ -1,0 +1,37 @@
+package com.paypal.android.corepayments
+
+import io.mockk.every
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertSame
+import org.junit.Test
+
+class SessionIdRepositoryUnitTest {
+
+    @Test
+    fun `sessionId is the formatted UUID from the UUIDHelper`() {
+        val uuidHelper = mockk<UUIDHelper> {
+            every { formattedUUID } returns "0123456789abcdef0123456789abcdef"
+        }
+
+        val sut = SessionIdRepository(uuidHelper)
+
+        assertEquals("0123456789abcdef0123456789abcdef", sut.sessionId)
+    }
+
+    @Test
+    fun `sessionId is stable across multiple reads on the same instance`() {
+        val sut = SessionIdRepository()
+
+        assertEquals(sut.sessionId, sut.sessionId)
+    }
+
+    @Test
+    fun `instance is a singleton with a stable sessionId`() {
+        assertSame(SessionIdRepository.instance, SessionIdRepository.instance)
+        assertEquals(
+            SessionIdRepository.instance.sessionId,
+            SessionIdRepository.instance.sessionId
+        )
+    }
+}

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/UUIDHelperUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/UUIDHelperUnitTest.kt
@@ -1,0 +1,26 @@
+package com.paypal.android.corepayments
+
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class UUIDHelperUnitTest {
+
+    private val sut = UUIDHelper()
+
+    @Test
+    fun `formattedUUID is a 32 character lowercase hex string with no dashes`() {
+        val uuid = sut.formattedUUID
+
+        assertEquals(32, uuid.length)
+        assertFalse(uuid.contains("-"))
+        assertTrue(uuid.matches(Regex("[0-9a-f]{32}")))
+    }
+
+    @Test
+    fun `formattedUUID returns a new random value on each access`() {
+        assertNotEquals(sut.formattedUUID, sut.formattedUUID)
+    }
+}

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -10,6 +10,7 @@ import androidx.core.net.toUri
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.ReturnToAppStrategy
+import com.paypal.android.corepayments.SessionIdRepository
 import com.paypal.android.corepayments.UpdateClientConfigAPI
 import com.paypal.android.corepayments.analytics.AnalyticsService
 import com.paypal.android.corepayments.api.CreateShopperSessionWithAppSwitchEligibilityAPI
@@ -119,7 +120,13 @@ class PayPalWebCheckoutClient internal constructor(
     ) {
         returnToAppUrlConfig = urlConfig
         shopperSessionDeferred = applicationScope.async {
-            createShopperSessionWithAppSwitchEligibility("ppcp_android", tokenType, urlConfig, userIdentity, userAction)
+            createShopperSessionWithAppSwitchEligibility(
+                token = SessionIdRepository.instance.sessionId,
+                tokenType = tokenType,
+                urlConfig = urlConfig,
+                userIdentity = userIdentity,
+                userAction = userAction
+            )
         }
     }
 

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -7,6 +7,7 @@ import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.corepayments.ReturnToAppStrategy
+import com.paypal.android.corepayments.SessionIdRepository
 import com.paypal.android.corepayments.UpdateClientConfigAPI
 import com.paypal.android.corepayments.api.CreateShopperSessionWithAppSwitchEligibilityAPI
 import com.paypal.android.corepayments.api.PatchCCOWithAppSwitchEligibility
@@ -2649,4 +2650,32 @@ class PayPalWebCheckoutClientUnitTest {
                 payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
             }
         }
+
+    @Test
+    fun `createPayPalSession passes the per-app-start sessionId as the contextId token`() = runTest {
+        val sutV3 = makeSutWithUrlScheme()
+        coEvery {
+            createShopperSessionAPI(
+                token = any(),
+                tokenType = any(),
+                params = any(),
+            )
+        } returns APIResult.Success(fakeSessionResponse)
+
+        sutV3.createPayPalSession(
+            tokenType = TokenType.ORDER_ID,
+            userIdentity = fakeUserIdentity,
+            urlConfig = fakeUrlConfig,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // The token passed into the API becomes the contextId; it must be the stored, per-app-start sessionId.
+        coVerify(exactly = 1) {
+            createShopperSessionAPI(
+                token = SessionIdRepository.instance.sessionId,
+                tokenType = TokenType.ORDER_ID,
+                params = any(),
+            )
+        }
+    }
 }


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 Introduce a unique sessionId generated once per app start, stored in a process-wide singleton, and pass it as the token (which the SDK sends as `contextId`) of the createShopperSessionWithAppSwitchEligibility call.

- Add UUIDHelper.formattedUUID (UUID without dashes, 32-char hex)
- Add SessionIdRepository with a lazy singleton instance holding an immutable, in-memory sessionId (generated once per app start)
- In PayPalWebCheckoutClient.createPayPalSession, pass SessionIdRepository.instance.sessionId where the token is passed into the API. CreateShopperSessionWithAppSwitchEligibilityAPI is unchanged: it does not know about SessionIdRepository and no signatures change.
- Tests: UUIDHelper, SessionIdRepository, and a client test asserting the sessionId is passed as the token/contextId

 ### Checklist

 - [ ] Added a changelog entry N/A

### Recording

https://github.com/user-attachments/assets/ad6c1102-bb10-4283-99ee-e3b6deaee722

https://github.com/user-attachments/assets/accc25b8-1de5-4f5e-95ea-c2e6e55bee3b

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @ayer-ribeiro
