### PR TITLE
Add shopper session analytics events

### DIFF
--- a/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventData.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventData.kt
@@ -60,5 +60,17 @@ internal data class TrackingEventParams(
     @SerialName("button_type")
     val buttonType: String? = null,
     @SerialName("app_switch_enabled")
-    val appSwitchEnabled: Boolean = false
+    val appSwitchEnabled: Boolean = false,
+    @SerialName("shopper_session_id")
+    val shopperSessionId: String? = null,
+    @SerialName("app_switch_url")
+    val appSwitchUrl: String? = null,
+    @SerialName("error_description")
+    val errorDescription: String? = null,
+    @SerialName("start_time")
+    val startTime: String? = null,
+    @SerialName("is_cached_session")
+    val isCachedSession: Boolean? = null,
+    @SerialName("is_vault_request")
+    val isVaultRequest: Boolean? = null
 )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventData.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventData.kt
@@ -60,7 +60,7 @@ internal data class TrackingEventParams(
     @SerialName("button_type")
     val buttonType: String? = null,
     @SerialName("app_switch_enabled")
-    val appSwitchEnabled: Boolean = false,
+    val appSwitchEnabled: Boolean? = null,
     @SerialName("shopper_session_id")
     val shopperSessionId: String? = null,
     @SerialName("app_switch_url")

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventsAPI.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventsAPI.kt
@@ -45,7 +45,13 @@ internal class TrackingEventsAPI constructor(
             tenantName = TENANT_NAME_PAYPAL,
             orderId = event.orderId,
             buttonType = event.buttonType,
-            appSwitchEnabled = event.appSwitchEnabled
+            appSwitchEnabled = event.appSwitchEnabled,
+            shopperSessionId = event.shopperSessionId,
+            appSwitchUrl = event.appSwitchUrl,
+            errorDescription = event.errorDescription,
+            startTime = event.startTime?.toString(),
+            isCachedSession = event.isCachedSession,
+            isVaultRequest = event.isVaultRequest
         )
 
         val events = TrackingEvents(eventParams = eventParams)

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
@@ -7,5 +7,15 @@ internal data class AnalyticsEventData(
     val timestamp: Long,
     val orderId: String?,
     val buttonType: String? = null,
-    val appSwitchEnabled: Boolean
+    val appSwitchEnabled: Boolean,
+    // fields below support the mobile SDK analytics events documented at
+    // https://paypal.atlassian.net/wiki/spaces/~7120203361479131b645799d3eacdd2de5b990/pages/2982842759
+    val shopperSessionId: String? = null,
+    val appSwitchUrl: String? = null,
+    val errorDescription: String? = null,
+    // captured right before firing a `:started` event and passed forward to the matching
+    // `:succeeded`/`:failed` event so FPTI can derive latency as (t - start_time)
+    val startTime: Long? = null,
+    val isCachedSession: Boolean? = null,
+    val isVaultRequest: Boolean? = null
 )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
@@ -8,13 +8,9 @@ internal data class AnalyticsEventData(
     val orderId: String?,
     val buttonType: String? = null,
     val appSwitchEnabled: Boolean,
-    // fields below support the mobile SDK analytics events documented at
-    // https://paypal.atlassian.net/wiki/spaces/~7120203361479131b645799d3eacdd2de5b990/pages/2982842759
     val shopperSessionId: String? = null,
     val appSwitchUrl: String? = null,
     val errorDescription: String? = null,
-    // captured right before firing a `:started` event and passed forward to the matching
-    // `:succeeded`/`:failed` event so FPTI can derive latency as (t - start_time)
     val startTime: Long? = null,
     val isCachedSession: Boolean? = null,
     val isVaultRequest: Boolean? = null

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsEventData.kt
@@ -7,7 +7,7 @@ internal data class AnalyticsEventData(
     val timestamp: Long,
     val orderId: String?,
     val buttonType: String? = null,
-    val appSwitchEnabled: Boolean,
+    val appSwitchEnabled: Boolean? = null,
     val shopperSessionId: String? = null,
     val appSwitchUrl: String? = null,
     val errorDescription: String? = null,

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
@@ -44,7 +44,7 @@ class AnalyticsService internal constructor(
         name: String,
         orderId: String? = null,
         buttonType: String? = null,
-        appSwitchEnabled: Boolean = false,
+        appSwitchEnabled: Boolean? = null,
         shopperSessionId: String? = null,
         appSwitchUrl: String? = null,
         errorDescription: String? = null,

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
@@ -44,7 +44,13 @@ class AnalyticsService internal constructor(
         name: String,
         orderId: String? = null,
         buttonType: String? = null,
-        appSwitchEnabled: Boolean = false
+        appSwitchEnabled: Boolean = false,
+        shopperSessionId: String? = null,
+        appSwitchUrl: String? = null,
+        errorDescription: String? = null,
+        startTime: Long? = null,
+        isCachedSession: Boolean? = null,
+        isVaultRequest: Boolean? = null
     ) {
         // TODO: send analytics event using WorkManager (supports coroutines) to avoid lint error
         // thrown because we don't use the Deferred result
@@ -58,7 +64,13 @@ class AnalyticsService internal constructor(
                     timestamp,
                     orderId = orderId,
                     buttonType = buttonType,
-                    appSwitchEnabled = appSwitchEnabled
+                    appSwitchEnabled = appSwitchEnabled,
+                    shopperSessionId = shopperSessionId,
+                    appSwitchUrl = appSwitchUrl,
+                    errorDescription = errorDescription,
+                    startTime = startTime,
+                    isCachedSession = isCachedSession,
+                    isVaultRequest = isVaultRequest
                 )
                 val response = trackingEventsAPI.sendEvent(analyticsEventData, deviceData)
                 response.error?.message?.let { errorMessage ->

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPI.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPI.kt
@@ -50,32 +50,16 @@ class CreateShopperSessionWithAppSwitchEligibilityAPI internal constructor(
      * @param token The order or setup token (used as contextId).
      * @param tokenType The type of token (ORDER_ID, VAULT_ID, etc.).
      * @param params The app-switch return URLs and payment context for the session.
-     * @param paypalNativeAppInstalled Whether the PayPal native app is installed.
-     * @param countryCode Country calling code for the shopper's phone number (e.g. "1").
-     * @param nationalNumber National (subscriber) number for the shopper's phone number.
-     * @param buyerEmailAddressMerchantPassed The shopper's email address, as passed by the
-     * merchant, used by the backend to pre-identify the shopper.
-     * @param existingPayPalSessionId A server-side shopper session id from a previous session.
      */
     suspend operator fun invoke(
         token: String,
         tokenType: TokenType,
         params: CreateShopperSessionWithAppSwitchEligibilityParams,
-        paypalNativeAppInstalled: Boolean,
-        countryCode: String? = null,
-        nationalNumber: String? = null,
-        buyerEmailAddressMerchantPassed: String? = null,
-        existingPayPalSessionId: String? = null,
     ): APIResult<CreateShopperSessionWithAppSwitchEligibilityResponse> {
         val graphQLRequest = createGraphQLRequest(
             token = token,
             tokenType = tokenType,
             params = params,
-            paypalNativeAppInstalled = paypalNativeAppInstalled,
-            countryCode = countryCode,
-            nationalNumber = nationalNumber,
-            buyerEmailAddressMerchantPassed = buyerEmailAddressMerchantPassed,
-            existingPayPalSessionId = existingPayPalSessionId,
         ) ?: return APIResult.Failure(APIClientError.dataParsingError(correlationId = null))
         return sendGraphQLRequestWithLSATAuthentication(graphQLRequest)
     }
@@ -84,11 +68,6 @@ class CreateShopperSessionWithAppSwitchEligibilityAPI internal constructor(
         token: String,
         tokenType: TokenType,
         params: CreateShopperSessionWithAppSwitchEligibilityParams,
-        paypalNativeAppInstalled: Boolean,
-        countryCode: String? = null,
-        nationalNumber: String? = null,
-        buyerEmailAddressMerchantPassed: String? = null,
-        existingPayPalSessionId: String? = null,
     ): GraphQLRequest<CreateShopperSessionVariables>? {
         val resourceResult = resourceLoader.loadRawResource(
             applicationContext,
@@ -106,7 +85,6 @@ class CreateShopperSessionWithAppSwitchEligibilityAPI internal constructor(
                     appSwitchSupported = true,
                     buyerGUID = null,
                     merchantAccountId = merchantId,
-                    merchantCountry = "US", // TODO: Determine
                     integrationChannel = INTEGRATION_CHANNEL,
                     isWebLLSEligible = false,
                     isWebView = false,
@@ -114,10 +92,10 @@ class CreateShopperSessionWithAppSwitchEligibilityAPI internal constructor(
                 ),
                 merchantOptInForAppSwitch = true,
                 osType = OS_TYPE,
-                paypalNativeAppInstalled = paypalNativeAppInstalled,
+                paypalNativeAppInstalled = params.paypalNativeAppInstalled,
                 tokenType = tokenType.toGraphQLTokenType(),
-                buyerEmailAddressMerchantPassed = buyerEmailAddressMerchantPassed,
-                shoppersSessionId = existingPayPalSessionId,
+                buyerEmailAddressMerchantPassed = params.buyerEmailAddressMerchantPassed,
+                shoppersSessionId = params.existingPayPalSessionId,
             ),
             shopperSessionInput = CreateShopperSessionShopperSessionInput(
                 returnAppUrl = params.returnAppUrl,

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPI.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPI.kt
@@ -51,6 +51,8 @@ class CreateShopperSessionWithAppSwitchEligibilityAPI internal constructor(
      * @param tokenType The type of token (ORDER_ID, VAULT_ID, etc.).
      * @param params The app-switch return URLs and payment context for the session.
      * @param paypalNativeAppInstalled Whether the PayPal native app is installed.
+     * @param countryCode Country calling code for the shopper's phone number (e.g. "1").
+     * @param nationalNumber National (subscriber) number for the shopper's phone number.
      * @param buyerEmailAddressMerchantPassed The shopper's email address, as passed by the
      * merchant, used by the backend to pre-identify the shopper.
      * @param existingPayPalSessionId A server-side shopper session id from a previous session.
@@ -60,6 +62,8 @@ class CreateShopperSessionWithAppSwitchEligibilityAPI internal constructor(
         tokenType: TokenType,
         params: CreateShopperSessionWithAppSwitchEligibilityParams,
         paypalNativeAppInstalled: Boolean,
+        countryCode: String? = null,
+        nationalNumber: String? = null,
         buyerEmailAddressMerchantPassed: String? = null,
         existingPayPalSessionId: String? = null,
     ): APIResult<CreateShopperSessionWithAppSwitchEligibilityResponse> {
@@ -68,6 +72,8 @@ class CreateShopperSessionWithAppSwitchEligibilityAPI internal constructor(
             tokenType = tokenType,
             params = params,
             paypalNativeAppInstalled = paypalNativeAppInstalled,
+            countryCode = countryCode,
+            nationalNumber = nationalNumber,
             buyerEmailAddressMerchantPassed = buyerEmailAddressMerchantPassed,
             existingPayPalSessionId = existingPayPalSessionId,
         ) ?: return APIResult.Failure(APIClientError.dataParsingError(correlationId = null))
@@ -79,6 +85,8 @@ class CreateShopperSessionWithAppSwitchEligibilityAPI internal constructor(
         tokenType: TokenType,
         params: CreateShopperSessionWithAppSwitchEligibilityParams,
         paypalNativeAppInstalled: Boolean,
+        countryCode: String? = null,
+        nationalNumber: String? = null,
         buyerEmailAddressMerchantPassed: String? = null,
         existingPayPalSessionId: String? = null,
     ): GraphQLRequest<CreateShopperSessionVariables>? {

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/model/CreateShopperSessionWithAppSwitchEligibilityModels.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/model/CreateShopperSessionWithAppSwitchEligibilityModels.kt
@@ -31,7 +31,6 @@ internal data class CreateShopperSessionExperimentationContext(
     val appSwitchSupported: Boolean,
     val buyerGUID: String?,
     val merchantAccountId: String?,
-    val merchantCountry: String?,
     val integrationChannel: String,
     val isWebLLSEligible: Boolean,
     val isWebView: Boolean,

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/model/CreateShopperSessionWithAppSwitchEligibilityParams.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/model/CreateShopperSessionWithAppSwitchEligibilityParams.kt
@@ -9,8 +9,12 @@ import androidx.annotation.RestrictTo
  * @param cancelAppUrl Deep-link URL to return to the app on cancellation.
  * @param fallbackSchemeUrl Custom URL scheme used as fallback.
  * @param paymentType GraphQL paymentType value (e.g. "CONTINUE", "PAY_NOW").
+ * @param paypalNativeAppInstalled Whether the PayPal native app is installed.
  * @param countryCode Country calling code for the shopper's phone number (e.g. "1").
  * @param nationalNumber National (subscriber) number for the shopper's phone number.
+ * @param buyerEmailAddressMerchantPassed The shopper's email address, as passed by the
+ * merchant to identify user.
+ * @param existingPayPalSessionId A server-side shopper session id from a previous session.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class CreateShopperSessionWithAppSwitchEligibilityParams(
@@ -18,6 +22,9 @@ data class CreateShopperSessionWithAppSwitchEligibilityParams(
     val cancelAppUrl: String,
     val fallbackSchemeUrl: String?,
     val paymentType: String,
+    val paypalNativeAppInstalled: Boolean,
     val countryCode: String? = null,
     val nationalNumber: String? = null,
+    val buyerEmailAddressMerchantPassed: String? = null,
+    val existingPayPalSessionId: String? = null,
 )

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest.kt
@@ -118,8 +118,8 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
                 cancelAppUrl = "https://example.com/cancel",
                 fallbackSchemeUrl = null,
                 paymentType = "CONTINUE",
+                paypalNativeAppInstalled = true,
             ),
-            paypalNativeAppInstalled = true,
         )
 
         // Then: the response is parsed successfully (previously failed with a JSON parse error
@@ -159,9 +159,9 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
                     fallbackSchemeUrl = null,
                     paymentType = "CONTINUE",
                     paypalNativeAppInstalled = true,
-                countryCode = "1",
-                nationalNumber = "4155551234"),
-                paypalNativeAppInstalled = true,
+                    countryCode = "1",
+                    nationalNumber = "4155551234",
+                ),
             )
 
             val requestBody = requestSlot.captured.body.orEmpty()
@@ -186,8 +186,8 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
                     cancelAppUrl = "https://example.com/cancel",
                     fallbackSchemeUrl = null,
                     paymentType = "CONTINUE",
+                    paypalNativeAppInstalled = true,
                 ),
-                paypalNativeAppInstalled = true,
             )
 
             val requestBody = requestSlot.captured.body.orEmpty()
@@ -212,10 +212,10 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
                     cancelAppUrl = "https://example.com/cancel",
                     fallbackSchemeUrl = null,
                     paymentType = "CONTINUE",
+                    paypalNativeAppInstalled = true,
+                    buyerEmailAddressMerchantPassed = "shopper@example.com",
+                    existingPayPalSessionId = "11F1-7BDF-BCAACEF2-91A9-A556CD2372A8",
                 ),
-                paypalNativeAppInstalled = true,
-                buyerEmailAddressMerchantPassed = "shopper@example.com",
-                existingPayPalSessionId = "11F1-7BDF-BCAACEF2-91A9-A556CD2372A8",
             )
 
             val requestBody = requestSlot.captured.body.orEmpty()
@@ -243,8 +243,8 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
                     cancelAppUrl = "https://example.com/cancel",
                     fallbackSchemeUrl = null,
                     paymentType = "CONTINUE",
+                    paypalNativeAppInstalled = true,
                 ),
-                paypalNativeAppInstalled = true,
             )
 
             val requestBody = requestSlot.captured.body.orEmpty()
@@ -270,8 +270,8 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
                 cancelAppUrl = "https://example.com/cancel",
                 fallbackSchemeUrl = null,
                 paymentType = "CONTINUE",
+                paypalNativeAppInstalled = true,
             ),
-            paypalNativeAppInstalled = true,
         )
 
         // Then: the original error is passed through unchanged as an APIResult.Failure — the

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest.kt
@@ -158,9 +158,9 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
                     cancelAppUrl = "https://example.com/cancel",
                     fallbackSchemeUrl = null,
                     paymentType = "CONTINUE",
-                    countryCode = "1",
-                    nationalNumber = "4155551234"
-                ),
+                    paypalNativeAppInstalled = true,
+                countryCode = "1",
+                nationalNumber = "4155551234"),
                 paypalNativeAppInstalled = true,
             )
 

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -16,11 +16,12 @@ import com.paypal.android.corepayments.api.CreateShopperSessionWithAppSwitchElig
 import com.paypal.android.corepayments.api.PatchCCOWithAppSwitchEligibility
 import com.paypal.android.corepayments.common.DeviceInspector
 import com.paypal.android.corepayments.model.APIResult
-import com.paypal.android.corepayments.model.CreateShopperSessionWithAppSwitchEligibilityParams
 import com.paypal.android.corepayments.model.CreateShopperSessionWithAppSwitchEligibilityResponse
+import com.paypal.android.corepayments.model.CreateShopperSessionWithAppSwitchEligibilityParams
 import com.paypal.android.corepayments.model.TokenType
 import com.paypal.android.corepayments.returnUrl
 import com.paypal.android.paypalwebpayments.analytics.CheckoutEvent
+import com.paypal.android.paypalwebpayments.analytics.CreatePayPalSessionEvent
 import com.paypal.android.paypalwebpayments.analytics.PayPalWebAnalytics
 import com.paypal.android.paypalwebpayments.analytics.VaultEvent
 import com.paypal.android.paypalwebpayments.errors.PayPalWebCheckoutError
@@ -59,6 +60,7 @@ class PayPalWebCheckoutClient internal constructor(
     private var checkoutOrderId: String? = null
     private var vaultSetupTokenId: String? = null
     private var appSwitchEnabled: Boolean = false
+    private var shopperSessionId: String? = null
 
     // Shopper Session id (v3) — set by createPayPalSession(), awaited by start() / vault()
     @VisibleForTesting
@@ -142,6 +144,12 @@ class PayPalWebCheckoutClient internal constructor(
         val deferred = shopperSessionDeferred
         if (deferred == null) {
             applicationScope.launch(Dispatchers.Main) {
+                analytics.notify(
+                    CheckoutEvent.SESSION_NOT_STARTED,
+                    orderId,
+                    appSwitchEnabled,
+                    errorDescription = "startPayPalSession() must be called before start(). "
+                )
                 callback.onPayPalWebStartResult(
                     PayPalPresentAuthChallengeResult.Failure(
                         PayPalWebCheckoutError.sessionNotCreatedError
@@ -155,7 +163,8 @@ class PayPalWebCheckoutClient internal constructor(
             try {
                 val shopperSession = deferred.await()
                 shopperSessionDeferred = null
-                analytics.notify(CheckoutEvent.STARTED, checkoutOrderId, appSwitchEnabled)
+                shopperSessionId = shopperSession?.shopperSessionConfig?.id
+                analytics.notify(CheckoutEvent.STARTED, checkoutOrderId, appSwitchEnabled, shopperSessionId = shopperSessionId)
 
                 val result = if (shopperSession != null) {
                     launchCheckoutWithShopperSession(
@@ -173,7 +182,13 @@ class PayPalWebCheckoutClient internal constructor(
                     callback.onPayPalWebStartResult(result)
                 }
             } catch (e: Exception) {
-                analytics.notify(CheckoutEvent.FAILED, checkoutOrderId, appSwitchEnabled)
+                analytics.notify(
+                    CheckoutEvent.FAILED,
+                    checkoutOrderId,
+                    appSwitchEnabled,
+                    shopperSessionId = shopperSessionId,
+                    errorDescription = e.message,
+                )
                 shopperSessionDeferred = null
                 withContext(Dispatchers.Main) {
                     callback.onPayPalWebStartResult(
@@ -206,6 +221,12 @@ class PayPalWebCheckoutClient internal constructor(
         val deferred = shopperSessionDeferred
         if (deferred == null) {
             applicationScope.launch(Dispatchers.Main) {
+                analytics.notify(
+                    VaultEvent.SESSION_NOT_STARTED,
+                    setupTokenId,
+                    appSwitchEnabled,
+                    errorDescription = "startPayPalSession() must be called before vault()."
+                )
                 callback.onPayPalWebVaultResult(
                     PayPalPresentAuthChallengeResult.Failure(
                         PayPalWebCheckoutError.sessionNotCreatedError
@@ -237,7 +258,13 @@ class PayPalWebCheckoutClient internal constructor(
                     callback.onPayPalWebVaultResult(result)
                 }
             } catch (e: Exception) {
-                analytics.notify(VaultEvent.FAILED, vaultSetupTokenId, appSwitchEnabled)
+                analytics.notify(
+                    VaultEvent.FAILED,
+                    vaultSetupTokenId,
+                    appSwitchEnabled,
+                    shopperSessionId = shopperSessionId,
+                    errorDescription = e.message,
+                )
                 shopperSessionDeferred = null
                 withContext(Dispatchers.Main) {
                     callback.onPayPalWebVaultResult(
@@ -260,41 +287,57 @@ class PayPalWebCheckoutClient internal constructor(
      */
     fun finishStart(intent: Intent): PayPalWebCheckoutFinishStartResult? =
         sessionStore.authState?.let { authState ->
+            analytics.notify(
+                CheckoutEvent.HANDLE_RETURN_STARTED,
+                checkoutOrderId,
+                appSwitchEnabled,
+                shopperSessionId = shopperSessionId,
+            )
             val result = payPalWebLauncher.completeCheckoutAuthRequest(intent, authState)
-            when (result) {
-                is PayPalWebCheckoutFinishStartResult.Success -> {
-                    analytics.notify(
-                        CheckoutEvent.SUCCEEDED,
-                        checkoutOrderId,
-                        appSwitchEnabled
-                    )
-                    sessionStore.clear()
-                }
-
-                is PayPalWebCheckoutFinishStartResult.Canceled -> {
-                    analytics.notify(
-                        CheckoutEvent.CANCELED,
-                        checkoutOrderId,
-                        appSwitchEnabled
-                    )
-                    sessionStore.clear()
-                }
-
-                is PayPalWebCheckoutFinishStartResult.Failure -> {
-                    analytics.notify(
-                        CheckoutEvent.FAILED,
-                        checkoutOrderId,
-                        appSwitchEnabled
-                    )
-                    sessionStore.clear()
-                }
-
-                PayPalWebCheckoutFinishStartResult.NoResult -> {
-                    // no analytics tracking required at the moment
-                }
+            logCheckoutResult(result)
+            if (result != PayPalWebCheckoutFinishStartResult.NoResult) {
+                sessionStore.clear()
             }
             result
         }
+
+    private fun logCheckoutResult(result: PayPalWebCheckoutFinishStartResult) {
+        val (handleReturnResult, checkoutResult, errorDescription) = when (result) {
+            is PayPalWebCheckoutFinishStartResult.Success ->
+                Triple(CheckoutEvent.HANDLE_RETURN_SUCCEEDED, CheckoutEvent.SUCCEEDED, null)
+
+            is PayPalWebCheckoutFinishStartResult.Canceled ->
+                Triple(CheckoutEvent.HANDLE_RETURN_SUCCEEDED, CheckoutEvent.CANCELED, null)
+
+            is PayPalWebCheckoutFinishStartResult.Failure ->
+                Triple(CheckoutEvent.HANDLE_RETURN_FAILED, CheckoutEvent.FAILED, result.error.errorDescription)
+
+            PayPalWebCheckoutFinishStartResult.NoResult -> return // no analytics tracking required at the moment
+        }
+
+        analytics.notify(
+            handleReturnResult,
+            checkoutOrderId,
+            appSwitchEnabled,
+            shopperSessionId = shopperSessionId,
+            errorDescription = errorDescription,
+        )
+        analytics.notify(
+            checkoutResult,
+            checkoutOrderId,
+            appSwitchEnabled,
+            shopperSessionId = shopperSessionId,
+            errorDescription = errorDescription,
+        )
+        if (checkoutResult == CheckoutEvent.CANCELED && appSwitchEnabled) {
+            analytics.notify(
+                CheckoutEvent.APP_SWITCH_CANCELED,
+                checkoutOrderId,
+                appSwitchEnabled,
+                shopperSessionId = shopperSessionId,
+            )
+        }
+    }
 
     /**
      * After a merchant app has re-entered the foreground following an auth challenge
@@ -306,29 +349,57 @@ class PayPalWebCheckoutClient internal constructor(
      */
     fun finishVault(intent: Intent): PayPalWebCheckoutFinishVaultResult? =
         sessionStore.authState?.let { authState ->
+            analytics.notify(
+                VaultEvent.HANDLE_RETURN_STARTED,
+                vaultSetupTokenId,
+                appSwitchEnabled,
+                shopperSessionId = shopperSessionId,
+            )
             val result = payPalWebLauncher.completeVaultAuthRequest(intent, authState)
-            when (result) {
-                is PayPalWebCheckoutFinishVaultResult.Success -> {
-                    analytics.notify(VaultEvent.SUCCEEDED, vaultSetupTokenId, appSwitchEnabled)
-                    sessionStore.clear()
-                }
-
-                is PayPalWebCheckoutFinishVaultResult.Failure -> {
-                    analytics.notify(VaultEvent.FAILED, vaultSetupTokenId, appSwitchEnabled)
-                    sessionStore.clear()
-                }
-
-                PayPalWebCheckoutFinishVaultResult.Canceled -> {
-                    analytics.notify(VaultEvent.CANCELED, vaultSetupTokenId, appSwitchEnabled)
-                    sessionStore.clear()
-                }
-
-                PayPalWebCheckoutFinishVaultResult.NoResult -> {
-                    // no analytics tracking required at the moment
-                }
+            logVaultResult(result)
+            if (result != PayPalWebCheckoutFinishVaultResult.NoResult) {
+                sessionStore.clear()
             }
-            return result
+            result
         }
+
+    private fun logVaultResult(result: PayPalWebCheckoutFinishVaultResult) {
+        val (handleReturnResult, vaultResult, errorDescription) = when (result) {
+            is PayPalWebCheckoutFinishVaultResult.Success ->
+                Triple(VaultEvent.HANDLE_RETURN_SUCCEEDED, VaultEvent.SUCCEEDED, null)
+
+            PayPalWebCheckoutFinishVaultResult.Canceled ->
+                Triple(VaultEvent.HANDLE_RETURN_SUCCEEDED, VaultEvent.CANCELED, null)
+
+            is PayPalWebCheckoutFinishVaultResult.Failure ->
+                Triple(VaultEvent.HANDLE_RETURN_FAILED, VaultEvent.FAILED, result.error.errorDescription)
+
+            PayPalWebCheckoutFinishVaultResult.NoResult -> return // no analytics tracking required at the moment
+        }
+
+        analytics.notify(
+            handleReturnResult,
+            vaultSetupTokenId,
+            appSwitchEnabled,
+            shopperSessionId = shopperSessionId,
+            errorDescription = errorDescription,
+        )
+        analytics.notify(
+            vaultResult,
+            vaultSetupTokenId,
+            appSwitchEnabled,
+            shopperSessionId = shopperSessionId,
+            errorDescription = errorDescription,
+        )
+        if (vaultResult == VaultEvent.CANCELED && appSwitchEnabled) {
+            analytics.notify(
+                VaultEvent.APP_SWITCH_CANCELED,
+                vaultSetupTokenId,
+                appSwitchEnabled,
+                shopperSessionId = shopperSessionId,
+            )
+        }
+    }
 
     /**
      * Launches the PayPal checkout UI after the shopper session has been resolved.
@@ -347,6 +418,22 @@ class PayPalWebCheckoutClient internal constructor(
     ): PayPalPresentAuthChallengeResult {
         appSwitchEnabled = shopperSession.appSwitchEligible && canAttemptPayPalAppSwitch()
         val launchUri = shopperSession.getLaunchUri(orderId, TokenType.ORDER_ID)
+        if (appSwitchEnabled) {
+            analytics.notify(
+                CheckoutEvent.APP_SWITCH_STARTED,
+                checkoutOrderId,
+                appSwitchEnabled,
+                shopperSessionId = shopperSessionId,
+                appSwitchUrl = launchUri.toString(),
+            )
+        } else {
+            analytics.notify(
+                CheckoutEvent.BROWSER_PRESENTATION_STARTED,
+                checkoutOrderId,
+                appSwitchEnabled,
+                shopperSessionId = shopperSessionId,
+            )
+        }
 
         val result = payPalWebLauncher.launchWithUrl(
             context = activity,
@@ -358,19 +445,43 @@ class PayPalWebCheckoutClient internal constructor(
 
         when (result) {
             is PayPalPresentAuthChallengeResult.Success -> {
-                analytics.notify(
-                    CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
-                    checkoutOrderId,
-                    appSwitchEnabled,
-                )
+                if (appSwitchEnabled) {
+                    analytics.notify(
+                        CheckoutEvent.APP_SWITCH_SUCCEEDED,
+                        checkoutOrderId,
+                        appSwitchEnabled,
+                        shopperSessionId = shopperSessionId,
+                        appSwitchUrl = launchUri.toString(),
+                    )
+                } else {
+                    analytics.notify(
+                        CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
+                        checkoutOrderId,
+                        appSwitchEnabled,
+                        shopperSessionId = shopperSessionId,
+                    )
+                }
                 sessionStore.authState = result.authState
             }
             is PayPalPresentAuthChallengeResult.Failure -> {
-                analytics.notify(
-                    CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
-                    checkoutOrderId,
-                    appSwitchEnabled,
-                )
+                if (appSwitchEnabled) {
+                    analytics.notify(
+                        CheckoutEvent.APP_SWITCH_FAILED,
+                        checkoutOrderId,
+                        appSwitchEnabled,
+                        shopperSessionId = shopperSessionId,
+                        appSwitchUrl = launchUri.toString(),
+                        errorDescription = result.error.errorDescription,
+                    )
+                } else {
+                    analytics.notify(
+                        CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
+                        checkoutOrderId,
+                        appSwitchEnabled,
+                        shopperSessionId = shopperSessionId,
+                        errorDescription = result.error.errorDescription,
+                    )
+                }
             }
         }
         return result
@@ -394,6 +505,23 @@ class PayPalWebCheckoutClient internal constructor(
         appSwitchEnabled = shopperSession.appSwitchEligible && canAttemptPayPalAppSwitch()
         val launchUri = shopperSession.getLaunchUri(setupTokenId, TokenType.VAULT_ID)
 
+        if (appSwitchEnabled) {
+            analytics.notify(
+                VaultEvent.APP_SWITCH_STARTED,
+                vaultSetupTokenId,
+                appSwitchEnabled,
+                shopperSessionId = shopperSessionId,
+                appSwitchUrl = launchUri.toString(),
+            )
+        } else {
+            analytics.notify(
+                VaultEvent.BROWSER_PRESENTATION_STARTED,
+                vaultSetupTokenId,
+                appSwitchEnabled,
+                shopperSessionId = shopperSessionId,
+            )
+        }
+
         val result = payPalWebLauncher.launchWithUrl(
             context = activity,
             uri = launchUri,
@@ -404,19 +532,43 @@ class PayPalWebCheckoutClient internal constructor(
 
         when (result) {
             is PayPalPresentAuthChallengeResult.Success -> {
-                analytics.notify(
-                    VaultEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
-                    vaultSetupTokenId,
-                    appSwitchEnabled,
-                )
+                if (appSwitchEnabled) {
+                    analytics.notify(
+                        VaultEvent.APP_SWITCH_SUCCEEDED,
+                        vaultSetupTokenId,
+                        appSwitchEnabled,
+                        shopperSessionId = shopperSessionId,
+                        appSwitchUrl = launchUri.toString(),
+                    )
+                } else {
+                    analytics.notify(
+                        VaultEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
+                        vaultSetupTokenId,
+                        appSwitchEnabled,
+                        shopperSessionId = shopperSessionId,
+                    )
+                }
                 sessionStore.authState = result.authState
             }
             is PayPalPresentAuthChallengeResult.Failure -> {
-                analytics.notify(
-                    VaultEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
-                    vaultSetupTokenId,
-                    appSwitchEnabled,
-                )
+                if (appSwitchEnabled) {
+                    analytics.notify(
+                        VaultEvent.APP_SWITCH_FAILED,
+                        vaultSetupTokenId,
+                        appSwitchEnabled,
+                        shopperSessionId = shopperSessionId,
+                        appSwitchUrl = launchUri.toString(),
+                        errorDescription = result.error.errorDescription,
+                    )
+                } else {
+                    analytics.notify(
+                        VaultEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
+                        vaultSetupTokenId,
+                        appSwitchEnabled,
+                        shopperSessionId = shopperSessionId,
+                        errorDescription = result.error.errorDescription,
+                    )
+                }
             }
         }
         return result
@@ -464,6 +616,10 @@ class PayPalWebCheckoutClient internal constructor(
         userIdentity: PayPalUserIdentity?,
         userAction: PayPalUserAction,
     ): CreateShopperSessionWithAppSwitchEligibilityResponse? {
+        val startTime = System.currentTimeMillis()
+        val isVaultRequest = tokenType != TokenType.ORDER_ID
+        analytics.notify(CreatePayPalSessionEvent.STARTED)
+
         val result = createShopperSessionAPI(
             token = token,
             tokenType = tokenType,
@@ -481,9 +637,28 @@ class PayPalWebCheckoutClient internal constructor(
         )
 
         return when (result) {
-            is APIResult.Success -> result.data
+            is APIResult.Success -> {
+                analytics.notify(
+                    CreatePayPalSessionEvent.SUCCEEDED,
+                    shopperSessionId = result.data.shopperSessionConfig.id,
+                    // TODO: no session-caching is implemented yet (every call re-fetches a new
+                    //  session), so this is always false. Revisit if/when caching is added.
+                    isCachedSession = false,
+                    isVaultRequest = isVaultRequest,
+                    startTime = startTime,
+                )
+                result.data
+            }
             // Session creation failure / network timeout: fall back to patchCCO.
-            is APIResult.Failure -> null
+            is APIResult.Failure -> {
+                analytics.notify(
+                    CreatePayPalSessionEvent.FAILED,
+                    isVaultRequest = isVaultRequest,
+                    errorDescription = result.error.errorDescription,
+                    startTime = startTime,
+                )
+                null
+            }
         }
     }
 

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -674,9 +674,6 @@ class PayPalWebCheckoutClient internal constructor(
                 analytics.notify(
                     CreatePayPalSessionEvent.SUCCEEDED,
                     shopperSessionId = result.data.shopperSessionConfig.id,
-                    // Matches iOS: true when the merchant seeded this call with an existing
-                    // server-side session id (PayPalUserIdentity.existingPayPalSessionId),
-                    // meaning the session was reused rather than created fresh.
                     isCachedSession = userIdentity?.existingPayPalSessionId != null,
                     isVaultRequest = isVaultRequest,
                     startTime = startTime,

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -628,12 +628,12 @@ class PayPalWebCheckoutClient internal constructor(
                 cancelAppUrl = urlConfig.cancelAppUrl,
                 fallbackSchemeUrl = urlConfig.fallbackSchemeUrl,
                 paymentType = userAction.toExternalPaymentType(),
+                paypalNativeAppInstalled = canAttemptPayPalAppSwitch(),
                 countryCode = userIdentity?.phone?.countryCode,
                 nationalNumber = userIdentity?.phone?.nationalNumber,
+                buyerEmailAddressMerchantPassed = userIdentity?.email,
+                existingPayPalSessionId = userIdentity?.existingPayPalSessionId,
             ),
-            paypalNativeAppInstalled = canAttemptPayPalAppSwitch(),
-            buyerEmailAddressMerchantPassed = userIdentity?.email,
-            existingPayPalSessionId = userIdentity?.existingPayPalSessionId,
         )
 
         return when (result) {

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -119,7 +119,6 @@ class PayPalWebCheckoutClient internal constructor(
     ) {
         returnToAppUrlConfig = urlConfig
         shopperSessionDeferred = applicationScope.async {
-            // TODO - Follow up and set token correctly.
             createShopperSessionWithAppSwitchEligibility("ppcp_android", tokenType, urlConfig, userIdentity, userAction)
         }
     }
@@ -143,19 +142,7 @@ class PayPalWebCheckoutClient internal constructor(
     ) {
         val deferred = shopperSessionDeferred
         if (deferred == null) {
-            applicationScope.launch(Dispatchers.Main) {
-                analytics.notify(
-                    CheckoutEvent.SESSION_NOT_STARTED,
-                    orderId,
-                    appSwitchEnabled,
-                    errorDescription = "startPayPalSession() must be called before start(). "
-                )
-                callback.onPayPalWebStartResult(
-                    PayPalPresentAuthChallengeResult.Failure(
-                        PayPalWebCheckoutError.sessionNotCreatedError
-                    )
-                )
-            }
+            notifyCheckoutSessionNotStarted(orderId, callback)
             return
         }
         checkoutOrderId = orderId
@@ -164,7 +151,11 @@ class PayPalWebCheckoutClient internal constructor(
                 val shopperSession = deferred.await()
                 shopperSessionDeferred = null
                 shopperSessionId = shopperSession?.shopperSessionConfig?.id
-                analytics.notify(CheckoutEvent.STARTED, checkoutOrderId, appSwitchEnabled, shopperSessionId = shopperSessionId)
+                analytics.notify(CheckoutEvent.STARTED,
+                    checkoutOrderId,
+                    appSwitchEnabled,
+                    shopperSessionId = shopperSessionId,
+                )
 
                 val result = if (shopperSession != null) {
                     launchCheckoutWithShopperSession(
@@ -201,6 +192,20 @@ class PayPalWebCheckoutClient internal constructor(
         }
     }
 
+    private fun notifyCheckoutSessionNotStarted(orderId: String, callback: PayPalWebStartCallback) {
+        applicationScope.launch(Dispatchers.Main) {
+            analytics.notify(
+                CheckoutEvent.SESSION_NOT_STARTED,
+                orderId,
+                appSwitchEnabled,
+                errorDescription = "startPayPalSession() must be called before start(). "
+            )
+            callback.onPayPalWebStartResult(
+                PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.sessionNotCreatedError)
+            )
+        }
+    }
+
     /**
      * Initiates PayPal vault using the session pre-warmed by [createPayPalSession].
      *
@@ -220,19 +225,7 @@ class PayPalWebCheckoutClient internal constructor(
     ) {
         val deferred = shopperSessionDeferred
         if (deferred == null) {
-            applicationScope.launch(Dispatchers.Main) {
-                analytics.notify(
-                    VaultEvent.SESSION_NOT_STARTED,
-                    setupTokenId,
-                    appSwitchEnabled,
-                    errorDescription = "startPayPalSession() must be called before vault()."
-                )
-                callback.onPayPalWebVaultResult(
-                    PayPalPresentAuthChallengeResult.Failure(
-                        PayPalWebCheckoutError.sessionNotCreatedError
-                    )
-                )
-            }
+            notifyVaultSessionNotStarted(setupTokenId, callback)
             return
         }
         vaultSetupTokenId = setupTokenId
@@ -240,7 +233,13 @@ class PayPalWebCheckoutClient internal constructor(
             try {
                 val shopperSession = deferred.await()
                 shopperSessionDeferred = null
-                analytics.notify(VaultEvent.STARTED, vaultSetupTokenId, appSwitchEnabled)
+                shopperSessionId = shopperSession?.shopperSessionConfig?.id
+                analytics.notify(
+                    VaultEvent.STARTED,
+                    vaultSetupTokenId,
+                    appSwitchEnabled,
+                    shopperSessionId = shopperSessionId,
+                )
 
                 val result = if (shopperSession != null) {
                     launchVaultWithSession(
@@ -274,6 +273,20 @@ class PayPalWebCheckoutClient internal constructor(
                     )
                 }
             }
+        }
+    }
+
+    private fun notifyVaultSessionNotStarted(setupTokenId: String, callback: PayPalWebVaultCallback) {
+        applicationScope.launch(Dispatchers.Main) {
+            analytics.notify(
+                VaultEvent.SESSION_NOT_STARTED,
+                setupTokenId,
+                appSwitchEnabled,
+                errorDescription = "startPayPalSession() must be called before vault(). "
+            )
+            callback.onPayPalWebVaultResult(
+                PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.sessionNotCreatedError)
+            )
         }
     }
 
@@ -442,7 +455,14 @@ class PayPalWebCheckoutClient internal constructor(
             tokenType = TokenType.ORDER_ID,
             returnToAppStrategy = ReturnToAppStrategy.AppLink(returnToAppUrlConfig?.returnAppUrl ?: ""),
         )
+        logCheckoutPresentAuthChallengeResult(result, launchUri.toString())
+        return result
+    }
 
+    private fun logCheckoutPresentAuthChallengeResult(
+        result: PayPalPresentAuthChallengeResult,
+        launchUrl: String,
+    ) {
         when (result) {
             is PayPalPresentAuthChallengeResult.Success -> {
                 if (appSwitchEnabled) {
@@ -451,7 +471,7 @@ class PayPalWebCheckoutClient internal constructor(
                         checkoutOrderId,
                         appSwitchEnabled,
                         shopperSessionId = shopperSessionId,
-                        appSwitchUrl = launchUri.toString(),
+                        appSwitchUrl = launchUrl,
                     )
                 } else {
                     analytics.notify(
@@ -470,7 +490,7 @@ class PayPalWebCheckoutClient internal constructor(
                         checkoutOrderId,
                         appSwitchEnabled,
                         shopperSessionId = shopperSessionId,
-                        appSwitchUrl = launchUri.toString(),
+                        appSwitchUrl = launchUrl,
                         errorDescription = result.error.errorDescription,
                     )
                 } else {
@@ -484,7 +504,6 @@ class PayPalWebCheckoutClient internal constructor(
                 }
             }
         }
-        return result
     }
 
     /**
@@ -529,7 +548,14 @@ class PayPalWebCheckoutClient internal constructor(
             tokenType = TokenType.VAULT_ID,
             returnToAppStrategy = ReturnToAppStrategy.AppLink(returnToAppUrlConfig?.returnAppUrl ?: ""),
         )
+        logVaultPresentAuthChallengeResult(result, launchUri.toString())
+        return result
+    }
 
+    private fun logVaultPresentAuthChallengeResult(
+        result: PayPalPresentAuthChallengeResult,
+        launchUrl: String,
+    ) {
         when (result) {
             is PayPalPresentAuthChallengeResult.Success -> {
                 if (appSwitchEnabled) {
@@ -538,7 +564,7 @@ class PayPalWebCheckoutClient internal constructor(
                         vaultSetupTokenId,
                         appSwitchEnabled,
                         shopperSessionId = shopperSessionId,
-                        appSwitchUrl = launchUri.toString(),
+                        appSwitchUrl = launchUrl,
                     )
                 } else {
                     analytics.notify(
@@ -557,7 +583,7 @@ class PayPalWebCheckoutClient internal constructor(
                         vaultSetupTokenId,
                         appSwitchEnabled,
                         shopperSessionId = shopperSessionId,
-                        appSwitchUrl = launchUri.toString(),
+                        appSwitchUrl = launchUrl,
                         errorDescription = result.error.errorDescription,
                     )
                 } else {
@@ -571,7 +597,6 @@ class PayPalWebCheckoutClient internal constructor(
                 }
             }
         }
-        return result
     }
 
     /**

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -342,9 +342,13 @@ class PayPalWebCheckoutClient internal constructor(
             shopperSessionId = shopperSessionId,
             errorDescription = errorDescription,
         )
-        if (checkoutResult == CheckoutEvent.CANCELED && appSwitchEnabled) {
+        if (checkoutResult == CheckoutEvent.CANCELED) {
+            val event = when (appSwitchEnabled) {
+                true -> CheckoutEvent.APP_SWITCH_CANCELED
+                else -> CheckoutEvent.BROWSER_PRESENTATION_CANCELED
+            }
             analytics.notify(
-                CheckoutEvent.APP_SWITCH_CANCELED,
+                event,
                 checkoutOrderId,
                 appSwitchEnabled,
                 shopperSessionId = shopperSessionId,
@@ -404,9 +408,13 @@ class PayPalWebCheckoutClient internal constructor(
             shopperSessionId = shopperSessionId,
             errorDescription = errorDescription,
         )
-        if (vaultResult == VaultEvent.CANCELED && appSwitchEnabled) {
+        if (vaultResult == VaultEvent.CANCELED) {
+            val event = when (appSwitchEnabled) {
+                true -> VaultEvent.APP_SWITCH_CANCELED
+                else -> VaultEvent.BROWSER_PRESENTATION_CANCELED
+            }
             analytics.notify(
-                VaultEvent.APP_SWITCH_CANCELED,
+                event,
                 vaultSetupTokenId,
                 appSwitchEnabled,
                 shopperSessionId = shopperSessionId,
@@ -475,7 +483,7 @@ class PayPalWebCheckoutClient internal constructor(
                     )
                 } else {
                     analytics.notify(
-                        CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
+                        CheckoutEvent.BROWSER_PRESENTATION_SUCCEEDED,
                         checkoutOrderId,
                         appSwitchEnabled,
                         shopperSessionId = shopperSessionId,
@@ -495,7 +503,7 @@ class PayPalWebCheckoutClient internal constructor(
                     )
                 } else {
                     analytics.notify(
-                        CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
+                        CheckoutEvent.BROWSER_PRESENTATION_FAILED,
                         checkoutOrderId,
                         appSwitchEnabled,
                         shopperSessionId = shopperSessionId,
@@ -568,7 +576,7 @@ class PayPalWebCheckoutClient internal constructor(
                     )
                 } else {
                     analytics.notify(
-                        VaultEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
+                        VaultEvent.BROWSER_PRESENTATION_SUCCEEDED,
                         vaultSetupTokenId,
                         appSwitchEnabled,
                         shopperSessionId = shopperSessionId,
@@ -588,7 +596,7 @@ class PayPalWebCheckoutClient internal constructor(
                     )
                 } else {
                     analytics.notify(
-                        VaultEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
+                        VaultEvent.BROWSER_PRESENTATION_FAILED,
                         vaultSetupTokenId,
                         appSwitchEnabled,
                         shopperSessionId = shopperSessionId,
@@ -666,9 +674,10 @@ class PayPalWebCheckoutClient internal constructor(
                 analytics.notify(
                     CreatePayPalSessionEvent.SUCCEEDED,
                     shopperSessionId = result.data.shopperSessionConfig.id,
-                    // TODO: no session-caching is implemented yet (every call re-fetches a new
-                    //  session), so this is always false. Revisit if/when caching is added.
-                    isCachedSession = false,
+                    // Matches iOS: true when the merchant seeded this call with an existing
+                    // server-side session id (PayPalUserIdentity.existingPayPalSessionId),
+                    // meaning the session was reused rather than created fresh.
+                    isCachedSession = userIdentity?.existingPayPalSessionId != null,
                     isVaultRequest = isVaultRequest,
                     startTime = startTime,
                 )
@@ -695,7 +704,6 @@ class PayPalWebCheckoutClient internal constructor(
     ): PayPalPresentAuthChallengeResult {
 
         checkoutOrderId = request.orderId
-        analytics.notify(CheckoutEvent.STARTED, checkoutOrderId, appSwitchEnabled)
 
         val returnToAppStrategy = resolveReturnToAppStrategy(request.returnToAppStrategy)
             ?: return PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.noReturnToAppStrategyError)
@@ -735,23 +743,11 @@ class PayPalWebCheckoutClient internal constructor(
 
         when (result) {
             is PayPalPresentAuthChallengeResult.Success -> {
-                analytics.notify(
-                    CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
-                    checkoutOrderId,
-                    appSwitchEnabled
-                )
-
                 // update auth state value in session store
                 sessionStore.authState = result.authState
             }
 
-            is PayPalPresentAuthChallengeResult.Failure -> {
-                analytics.notify(
-                    CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
-                    checkoutOrderId,
-                    appSwitchEnabled
-                )
-            }
+            is PayPalPresentAuthChallengeResult.Failure -> {}
         }
 
         return result
@@ -764,7 +760,6 @@ class PayPalWebCheckoutClient internal constructor(
         request: PayPalWebVaultRequest
     ): PayPalPresentAuthChallengeResult {
         vaultSetupTokenId = request.setupTokenId
-        analytics.notify(VaultEvent.STARTED, vaultSetupTokenId, appSwitchEnabled)
 
         val returnToAppStrategy = resolveReturnToAppStrategy(request.returnToAppStrategy)
             ?: return PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.noReturnToAppStrategyError)
@@ -788,23 +783,11 @@ class PayPalWebCheckoutClient internal constructor(
 
         when (result) {
             is PayPalPresentAuthChallengeResult.Success -> {
-                analytics.notify(
-                    VaultEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
-                    vaultSetupTokenId,
-                    appSwitchEnabled
-                )
-
                 // update auth state value in session store
                 sessionStore.authState = result.authState
             }
 
-            is PayPalPresentAuthChallengeResult.Failure -> {
-                analytics.notify(
-                    VaultEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
-                    vaultSetupTokenId,
-                    appSwitchEnabled
-                )
-            }
+            is PayPalPresentAuthChallengeResult.Failure -> {}
         }
 
         return result
@@ -993,7 +976,6 @@ class PayPalWebCheckoutClient internal constructor(
     ): PayPalPresentAuthChallengeResult {
         checkoutOrderId = request.orderId
         appSwitchEnabled = false
-        analytics.notify(CheckoutEvent.STARTED, checkoutOrderId, appSwitchEnabled)
 
         val returnToAppStrategy = resolveReturnToAppStrategy(request.returnToAppStrategy)
             ?: return PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.noReturnToAppStrategyError)
@@ -1014,23 +996,11 @@ class PayPalWebCheckoutClient internal constructor(
 
         when (result) {
             is PayPalPresentAuthChallengeResult.Success -> {
-                analytics.notify(
-                    CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
-                    checkoutOrderId,
-                    appSwitchEnabled
-                )
-
                 // update auth state value in session store
                 sessionStore.authState = result.authState
             }
 
-            is PayPalPresentAuthChallengeResult.Failure -> {
-                analytics.notify(
-                    CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
-                    checkoutOrderId,
-                    appSwitchEnabled
-                )
-            }
+            is PayPalPresentAuthChallengeResult.Failure -> {}
         }
         return result
     }
@@ -1073,7 +1043,6 @@ class PayPalWebCheckoutClient internal constructor(
         request: PayPalWebVaultRequest
     ): PayPalPresentAuthChallengeResult {
         vaultSetupTokenId = request.setupTokenId
-        analytics.notify(VaultEvent.STARTED, vaultSetupTokenId, appSwitchEnabled)
 
         val returnToAppStrategy = resolveReturnToAppStrategy(request.returnToAppStrategy)
             ?: return PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.noReturnToAppStrategyError)
@@ -1090,23 +1059,11 @@ class PayPalWebCheckoutClient internal constructor(
 
         when (result) {
             is PayPalPresentAuthChallengeResult.Success -> {
-                analytics.notify(
-                    VaultEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
-                    vaultSetupTokenId,
-                    appSwitchEnabled
-                )
-
                 // update auth state value in session store
                 sessionStore.authState = result.authState
             }
 
-            is PayPalPresentAuthChallengeResult.Failure -> {
-                analytics.notify(
-                    VaultEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
-                    vaultSetupTokenId,
-                    appSwitchEnabled
-                )
-            }
+            is PayPalPresentAuthChallengeResult.Failure -> {}
         }
 
         return result

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/CheckoutEvent.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/CheckoutEvent.kt
@@ -9,22 +9,17 @@ internal enum class CheckoutEvent(val value: String) {
     FAILED(   "paypal-web-payments:checkout:failed"),
     CANCELED( "paypal-web-payments:checkout:canceled"),
 
-    AUTH_CHALLENGE_PRESENTATION_SUCCEEDED("paypal-web-payments:checkout:auth-challenge-presentation:succeeded"),
-    AUTH_CHALLENGE_PRESENTATION_FAILED(   "paypal-web-payments:checkout:auth-challenge-presentation:failed"),
-
-    // Ref: https://paypal.atlassian.net/wiki/spaces/~7120203361479131b645799d3eacdd2de5b990/pages/2982842759
     SESSION_NOT_STARTED("paypal-web-payments:checkout:session-not-started"),
 
-    // NOTE: matches iOS's existing `app-switch-open:*` string for SUCCEEDED/FAILED so both
-    // platforms agree today. iOS also has a `app-switch-open:*` vs `app-switch:*` naming
-    // inconsistency across its own events per the doc — flagged there as needing alignment
-    // before shipping, independent of this Android change.
     APP_SWITCH_STARTED(  "paypal-web-payments:checkout:app-switch:started"),
     APP_SWITCH_SUCCEEDED("paypal-web-payments:checkout:app-switch-open:succeeded"),
     APP_SWITCH_FAILED(   "paypal-web-payments:checkout:app-switch-open:failed"),
     APP_SWITCH_CANCELED( "paypal-web-payments:checkout:app-switch:canceled"),
 
     BROWSER_PRESENTATION_STARTED("paypal-web-payments:checkout:browser-presentation:started"),
+    BROWSER_PRESENTATION_SUCCEEDED("paypal-web-payments:checkout:browser-presentation:succeeded"),
+    BROWSER_PRESENTATION_FAILED("paypal-web-payments:checkout:browser-presentation:failed"),
+    BROWSER_PRESENTATION_CANCELED("paypal-web-payments:checkout:browser-presentation:canceled"),
 
     HANDLE_RETURN_STARTED(  "paypal-web-payments:checkout:handle-return:started"),
     HANDLE_RETURN_SUCCEEDED("paypal-web-payments:checkout:handle-return:succeeded"),

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/CheckoutEvent.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/CheckoutEvent.kt
@@ -11,5 +11,23 @@ internal enum class CheckoutEvent(val value: String) {
 
     AUTH_CHALLENGE_PRESENTATION_SUCCEEDED("paypal-web-payments:checkout:auth-challenge-presentation:succeeded"),
     AUTH_CHALLENGE_PRESENTATION_FAILED(   "paypal-web-payments:checkout:auth-challenge-presentation:failed"),
+
+    // Ref: https://paypal.atlassian.net/wiki/spaces/~7120203361479131b645799d3eacdd2de5b990/pages/2982842759
+    SESSION_NOT_STARTED("paypal-web-payments:checkout:session-not-started"),
+
+    // NOTE: matches iOS's existing `app-switch-open:*` string for SUCCEEDED/FAILED so both
+    // platforms agree today. iOS also has a `app-switch-open:*` vs `app-switch:*` naming
+    // inconsistency across its own events per the doc — flagged there as needing alignment
+    // before shipping, independent of this Android change.
+    APP_SWITCH_STARTED(  "paypal-web-payments:checkout:app-switch:started"),
+    APP_SWITCH_SUCCEEDED("paypal-web-payments:checkout:app-switch-open:succeeded"),
+    APP_SWITCH_FAILED(   "paypal-web-payments:checkout:app-switch-open:failed"),
+    APP_SWITCH_CANCELED( "paypal-web-payments:checkout:app-switch:canceled"),
+
+    BROWSER_PRESENTATION_STARTED("paypal-web-payments:checkout:browser-presentation:started"),
+
+    HANDLE_RETURN_STARTED(  "paypal-web-payments:checkout:handle-return:started"),
+    HANDLE_RETURN_SUCCEEDED("paypal-web-payments:checkout:handle-return:succeeded"),
+    HANDLE_RETURN_FAILED(   "paypal-web-payments:checkout:handle-return:failed"),
     // @formatter:on
 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/CreatePayPalSessionEvent.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/CreatePayPalSessionEvent.kt
@@ -6,8 +6,6 @@ package com.paypal.android.paypalwebpayments.analytics
  * Fires from [com.paypal.android.paypalwebpayments.PayPalWebCheckoutClient.createPayPalSession],
  * for both the checkout and vault flows, under the same event strings. [PayPalWebAnalytics]
  * distinguishes which flow fired the event via the `is_vault_request` param.
- *
- * Ref: https://paypal.atlassian.net/wiki/spaces/~7120203361479131b645799d3eacdd2de5b990/pages/2982842759
  */
 internal enum class CreatePayPalSessionEvent(val value: String) {
     // @formatter:off

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/CreatePayPalSessionEvent.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/CreatePayPalSessionEvent.kt
@@ -1,0 +1,18 @@
+@file:Suppress("SpacingAroundParens", "NoMultipleSpaces", "MaxLineLength")
+
+package com.paypal.android.paypalwebpayments.analytics
+
+/**
+ * Fires from [com.paypal.android.paypalwebpayments.PayPalWebCheckoutClient.createPayPalSession],
+ * for both the checkout and vault flows, under the same event strings. [PayPalWebAnalytics]
+ * distinguishes which flow fired the event via the `is_vault_request` param.
+ *
+ * Ref: https://paypal.atlassian.net/wiki/spaces/~7120203361479131b645799d3eacdd2de5b990/pages/2982842759
+ */
+internal enum class CreatePayPalSessionEvent(val value: String) {
+    // @formatter:off
+    STARTED(  "paypal-web-payments:checkout:ssid-session:started"),
+    SUCCEEDED("paypal-web-payments:create-paypal-session:succeeded"),
+    FAILED(   "paypal-web-payments:create-paypal-session:failed"),
+    // @formatter:on
+}

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/PayPalWebAnalytics.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/PayPalWebAnalytics.kt
@@ -4,19 +4,57 @@ import com.paypal.android.corepayments.analytics.AnalyticsService
 
 internal class PayPalWebAnalytics(private val analyticsService: AnalyticsService) {
 
-    fun notify(event: CheckoutEvent, orderId: String?, appSwitchEnabled: Boolean) {
+    fun notify(
+        event: CheckoutEvent,
+        orderId: String?,
+        appSwitchEnabled: Boolean,
+        shopperSessionId: String? = null,
+        appSwitchUrl: String? = null,
+        errorDescription: String? = null,
+    ) {
         analyticsService.sendAnalyticsEvent(
             name = event.value,
             orderId = orderId,
-            appSwitchEnabled = appSwitchEnabled
+            appSwitchEnabled = appSwitchEnabled,
+            shopperSessionId = shopperSessionId,
+            appSwitchUrl = appSwitchUrl,
+            errorDescription = errorDescription,
         )
     }
 
-    fun notify(event: VaultEvent, setupTokenId: String?, appSwitchEnabled: Boolean) {
+    fun notify(
+        event: VaultEvent,
+        setupTokenId: String?,
+        appSwitchEnabled: Boolean,
+        shopperSessionId: String? = null,
+        appSwitchUrl: String? = null,
+        errorDescription: String? = null,
+    ) {
         analyticsService.sendAnalyticsEvent(
             name = event.value,
             orderId = setupTokenId,
-            appSwitchEnabled = appSwitchEnabled
+            appSwitchEnabled = appSwitchEnabled,
+            shopperSessionId = shopperSessionId,
+            appSwitchUrl = appSwitchUrl,
+            errorDescription = errorDescription,
+        )
+    }
+
+    fun notify(
+        event: CreatePayPalSessionEvent,
+        shopperSessionId: String? = null,
+        isCachedSession: Boolean? = null,
+        isVaultRequest: Boolean? = null,
+        errorDescription: String? = null,
+        startTime: Long? = null,
+    ) {
+        analyticsService.sendAnalyticsEvent(
+            name = event.value,
+            shopperSessionId = shopperSessionId,
+            isCachedSession = isCachedSession,
+            isVaultRequest = isVaultRequest,
+            errorDescription = errorDescription,
+            startTime = startTime,
         )
     }
 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/VaultEvent.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/VaultEvent.kt
@@ -9,13 +9,6 @@ internal enum class VaultEvent(val value: String) {
     FAILED(   "paypal-web-payments:vault-wo-purchase:failed"),
     CANCELED( "paypal-web-payments:vault-wo-purchase:canceled"),
 
-    AUTH_CHALLENGE_PRESENTATION_SUCCEEDED("paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded"),
-    AUTH_CHALLENGE_PRESENTATION_FAILED(   "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed"),
-
-    // Ref: https://paypal.atlassian.net/wiki/spaces/~7120203361479131b645799d3eacdd2de5b990/pages/2982842759
-    // The doc only shows a `checkout:*` row for these four (no explicit vault line), but per
-    // request we mirror them to vault-wo-purchase since vault goes through the same
-    // launcher / return-handling code paths as checkout.
     SESSION_NOT_STARTED("paypal-web-payments:vault-wo-purchase:session-not-started"),
 
     APP_SWITCH_STARTED(  "paypal-web-payments:vault-wo-purchase:app-switch:started"),
@@ -24,6 +17,9 @@ internal enum class VaultEvent(val value: String) {
     APP_SWITCH_CANCELED( "paypal-web-payments:vault-wo-purchase:app-switch:canceled"),
 
     BROWSER_PRESENTATION_STARTED("paypal-web-payments:vault-wo-purchase:browser-presentation:started"),
+    BROWSER_PRESENTATION_SUCCEEDED("paypal-web-payments:vault-wo-purchase:browser-presentation:succeeded"),
+    BROWSER_PRESENTATION_FAILED("paypal-web-payments:vault-wo-purchase:browser-presentation:failed"),
+    BROWSER_PRESENTATION_CANCELED("paypal-web-payments:vault-wo-purchase:browser-presentation:canceled"),
 
     HANDLE_RETURN_STARTED(  "paypal-web-payments:vault-wo-purchase:handle-return:started"),
     HANDLE_RETURN_SUCCEEDED("paypal-web-payments:vault-wo-purchase:handle-return:succeeded"),

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/VaultEvent.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/VaultEvent.kt
@@ -11,5 +11,22 @@ internal enum class VaultEvent(val value: String) {
 
     AUTH_CHALLENGE_PRESENTATION_SUCCEEDED("paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded"),
     AUTH_CHALLENGE_PRESENTATION_FAILED(   "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed"),
+
+    // Ref: https://paypal.atlassian.net/wiki/spaces/~7120203361479131b645799d3eacdd2de5b990/pages/2982842759
+    // The doc only shows a `checkout:*` row for these four (no explicit vault line), but per
+    // request we mirror them to vault-wo-purchase since vault goes through the same
+    // launcher / return-handling code paths as checkout.
+    SESSION_NOT_STARTED("paypal-web-payments:vault-wo-purchase:session-not-started"),
+
+    APP_SWITCH_STARTED(  "paypal-web-payments:vault-wo-purchase:app-switch:started"),
+    APP_SWITCH_SUCCEEDED("paypal-web-payments:vault-wo-purchase:app-switch-open:succeeded"),
+    APP_SWITCH_FAILED(   "paypal-web-payments:vault-wo-purchase:app-switch-open:failed"),
+    APP_SWITCH_CANCELED( "paypal-web-payments:vault-wo-purchase:app-switch:canceled"),
+
+    BROWSER_PRESENTATION_STARTED("paypal-web-payments:vault-wo-purchase:browser-presentation:started"),
+
+    HANDLE_RETURN_STARTED(  "paypal-web-payments:vault-wo-purchase:handle-return:started"),
+    HANDLE_RETURN_SUCCEEDED("paypal-web-payments:vault-wo-purchase:handle-return:succeeded"),
+    HANDLE_RETURN_FAILED(   "paypal-web-payments:vault-wo-purchase:handle-return:failed"),
     // @formatter:on
 }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -2334,7 +2334,14 @@ class PayPalWebCheckoutClientUnitTest {
         sut.finishStart(intent)
 
         // Then
-        verify { analytics.notify(CheckoutEvent.FAILED, "fake-order-id", false) }
+        verify {
+            analytics.notify(
+                CheckoutEvent.FAILED,
+                "fake-order-id",
+                false,
+                errorDescription = "fake-error-description",
+            )
+        }
     }
 
     @Test
@@ -2574,7 +2581,13 @@ class PayPalWebCheckoutClientUnitTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             verify {
-                analytics.notify(CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_FAILED, "fake-order-id", false)
+                analytics.notify(
+                    CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
+                    "fake-order-id",
+                    false,
+                    shopperSessionId = "fake-session-id",
+                    errorDescription = "fake error description",
+                )
             }
             verify {
                 callback.onPayPalWebStartResult(match {
@@ -2603,7 +2616,13 @@ class PayPalWebCheckoutClientUnitTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             verify {
-                analytics.notify(VaultEvent.AUTH_CHALLENGE_PRESENTATION_FAILED, "fake-setup-token-id", false)
+                analytics.notify(
+                    VaultEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
+                    "fake-setup-token-id",
+                    false,
+                    shopperSessionId = "fake-session-id",
+                    errorDescription = "fake error description",
+                )
             }
             verify {
                 callback.onPayPalWebVaultResult(match {
@@ -2627,7 +2646,14 @@ class PayPalWebCheckoutClientUnitTest {
             sutV3.start(activity, "fake-order-id", callback)
             testDispatcher.scheduler.advanceUntilIdle()
 
-            verify { analytics.notify(CheckoutEvent.FAILED, "fake-order-id", false) }
+            verify {
+                analytics.notify(
+                    CheckoutEvent.FAILED,
+                    "fake-order-id",
+                    false,
+                    errorDescription = "session error",
+                )
+            }
         }
 
     @Test
@@ -2645,7 +2671,14 @@ class PayPalWebCheckoutClientUnitTest {
             sutV3.vault(activity, "fake-setup-token-id", callback)
             testDispatcher.scheduler.advanceUntilIdle()
 
-            verify { analytics.notify(VaultEvent.FAILED, "fake-setup-token-id", false) }
+            verify {
+                analytics.notify(
+                    VaultEvent.FAILED,
+                    "fake-setup-token-id",
+                    false,
+                    errorDescription = "session error",
+                )
+            }
         }
 
     @Test

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -2245,35 +2245,6 @@ class PayPalWebCheckoutClientUnitTest {
     // MARK: - Analytics Tests for appSwitchEnabled
 
     @Test
-    fun `startAsync() sends analytics with appSwitchEnabled false when app switch is not used`() =
-        runTest {
-            // Given
-            every { deviceInspector.isPayPalInstalled } returns false
-            val request = PayPalWebCheckoutRequest(
-                "fake-order-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-            every {
-                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-            } returns launchResult
-
-            // When
-            sut.startAsync(activity, request)
-
-            // Then
-            verify { analytics.notify(CheckoutEvent.STARTED, "fake-order-id", false) }
-            verify {
-                analytics.notify(
-                    CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
-                    "fake-order-id",
-                    false
-                )
-            }
-        }
-
-    @Test
     fun `finishStart() sends analytics with appSwitchEnabled false for canceled event`() = runTest {
         // Given
         every { deviceInspector.isPayPalInstalled } returns false
@@ -2335,88 +2306,6 @@ class PayPalWebCheckoutClientUnitTest {
         }
     }
 
-    @Test
-    fun `vaultAsync() sends analytics with appSwitchEnabled false when app switch is not used`() =
-        runTest {
-            // Given
-            every { deviceInspector.isPayPalInstalled } returns false
-            val request = PayPalWebVaultRequest(
-                "fake-setup-token-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-            every {
-                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-            } returns launchResult
-
-            // When
-            sut.vaultAsync(activity, request)
-
-            // Then
-            verify { analytics.notify(VaultEvent.STARTED, "fake-setup-token-id", false) }
-            verify {
-                analytics.notify(
-                    VaultEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
-                    "fake-setup-token-id",
-                    false
-                )
-            }
-        }
-
-    @Test
-    fun `deprecated start() sends analytics with appSwitchEnabled false`() {
-        // Given
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebCheckoutRequest(
-            "fake-order-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-
-        // When
-        sut.start(activity, request)
-
-        // Then
-        verify { analytics.notify(CheckoutEvent.STARTED, "fake-order-id", false) }
-        verify {
-            analytics.notify(
-                CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
-                "fake-order-id",
-                false
-            )
-        }
-    }
-
-    @Test
-    fun `deprecated vault() sends analytics with appSwitchEnabled false`() {
-        // Given
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebVaultRequest(
-            "fake-setup-token-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-
-        // When
-        sut.vault(activity, request)
-
-        // Then
-        verify { analytics.notify(VaultEvent.STARTED, "fake-setup-token-id", false) }
-        verify {
-            analytics.notify(
-                VaultEvent.AUTH_CHALLENGE_PRESENTATION_SUCCEEDED,
-                "fake-setup-token-id",
-                false
-            )
-        }
-    }
 
     // MARK: - Additional coverage: app-switch-eligible redirectUrl, failure analytics, noReturnToAppStrategyError
 
@@ -2573,7 +2462,7 @@ class PayPalWebCheckoutClientUnitTest {
 
             verify {
                 analytics.notify(
-                    CheckoutEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
+                    CheckoutEvent.BROWSER_PRESENTATION_FAILED,
                     "fake-order-id",
                     false,
                     shopperSessionId = "fake-session-id",
@@ -2608,7 +2497,7 @@ class PayPalWebCheckoutClientUnitTest {
 
             verify {
                 analytics.notify(
-                    VaultEvent.AUTH_CHALLENGE_PRESENTATION_FAILED,
+                    VaultEvent.BROWSER_PRESENTATION_FAILED,
                     "fake-setup-token-id",
                     false,
                     shopperSessionId = "fake-session-id",

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -1286,9 +1286,6 @@ class PayPalWebCheckoutClientUnitTest {
         // Verify it returns the launch result
         assertSame(launchResult, result)
 
-        // Verify analytics was called with CheckoutEvent
-        verify { analytics.notify(any<CheckoutEvent>(), "fake-order-id", any()) }
-
         // Verify launchWithUrl is called (the deprecated method calls it directly)
         verify(exactly = 1) {
             payPalWebLauncher.launchWithUrl(
@@ -1346,9 +1343,6 @@ class PayPalWebCheckoutClientUnitTest {
 
         // Verify it returns the launch result
         assertSame(launchResult, result)
-
-        // Verify analytics was called with VaultEvent
-        verify { analytics.notify(any<VaultEvent>(), any(), any()) }
 
         // Verify launchWithUrl is called (the deprecated method calls it directly)
         verify(exactly = 1) {
@@ -2305,7 +2299,6 @@ class PayPalWebCheckoutClientUnitTest {
             )
         }
     }
-
 
     // MARK: - Additional coverage: app-switch-eligible redirectUrl, failure analytics, noReturnToAppStrategyError
 

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -2134,9 +2134,6 @@ class PayPalWebCheckoutClientUnitTest {
                 token = any(),
                 tokenType = any(),
                 params = any(),
-                paypalNativeAppInstalled = any(),
-                buyerEmailAddressMerchantPassed = any(),
-                existingPayPalSessionId = any(),
             )
         } returns APIResult.Success(fakeSessionResponse)
 
@@ -2160,9 +2157,6 @@ class PayPalWebCheckoutClientUnitTest {
                     token = any(),
                     tokenType = any(),
                     params = any(),
-                    paypalNativeAppInstalled = any(),
-                    buyerEmailAddressMerchantPassed = any(),
-                    existingPayPalSessionId = any(),
                 )
             } returns APIResult.Failure(sessionError)
 
@@ -2188,9 +2182,6 @@ class PayPalWebCheckoutClientUnitTest {
                     token = any(),
                     tokenType = any(),
                     params = any(),
-                    paypalNativeAppInstalled = any(),
-                    buyerEmailAddressMerchantPassed = any(),
-                    existingPayPalSessionId = any(),
                 )
             } throws lsatError
 


### PR DESCRIPTION
Thank you for your contribution to PayPal.
> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes
 - Added new shopper-session-aware analytics events for `CheckoutEvent`/`VaultEvent`: `SESSION_NOT_STARTED`, `APP_SWITCH_STARTED/SUCCEEDED/FAILED/CANCELED`, `BROWSER_PRESENTATION_STARTED/SUCCEEDED/FAILED/CANCELED`, and `HANDLE_RETURN_STARTED/SUCCEEDED/FAILED`, replacing the old `AUTH_CHALLENGE_PRESENTATION_*` events.
 - Added a new `CreatePayPalSessionEvent` (`STARTED`/`SUCCEEDED`/`FAILED`) fired from `createPayPalSession()` for both checkout and vault flows.
 - Threaded `shopper_session_id`, `app_switch_url`, `error_description`, `start_time`, `is_cached_session`, and `is_vault_request` through `PayPalWebAnalytics` → `AnalyticsService` → `AnalyticsEventData` → `TrackingEventsAPI` so they're included in the FPTI payload.
 - Updated `PayPalWebCheckoutClient`'s `start()`/`vault()`/`finishStart()`/`finishVault()` flows to fire the new events with the resolved `shopperSessionId` at each stage.
 - `is_cached_session` is now derived from whether the caller passed an `existingPayPalSessionId` into `createPayPalSession()`, matching how iOS derives it from `PayPalUserIdentity`.
 - Moved `paypalNativeAppInstalled`, `buyerEmailAddressMerchantPassed`, and `existingPayPalSessionId` off of `CreateShopperSessionWithAppSwitchEligibilityAPI.invoke()`'s parameter list and onto `CreateShopperSessionWithAppSwitchEligibilityParams`, updating all call sites and tests. Also removed the unused `merchantCountry` field.
 - Removed `analytics.notify()` calls from the deprecated/legacy `startAsync`, `vaultAsync`, and deprecated `start()`/`vault()` paths (these methods are being removed in a follow-up PR), and updated/removed the corresponding unit tests.
 - General lint cleanup (detekt `LongMethod`/`MaxLineLength` fixes via pure extract-method refactors, no behavior change).

### Checklist
 - [ ] Added a changelog entry (not needed — no merchant-facing changes)

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- anibalb2500
