### PR TITLE
Check if PayPal Supports App Switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
   * Add `PayPalWebCheckoutClient.vault(context, setupTokenId, callback)` method (v3) — requires a prior call to `createPayPalSession()`
   * Deprecate `PayPalWebCheckoutClient.start(activity, request, callback)` — use `createPayPalSession()` followed by `start(context, orderId, callback)` instead
   * Deprecate `PayPalWebCheckoutClient.vault(activity, request, callback)` — use `createPayPalSession()` followed by `vault(context, setupTokenId, callback)` instead
-  * Fix: app switch (via `createPayPalSession()` / `start()` / `vault()`) is now only attempted when the installed PayPal app meets a minimum supported version; older, incompatible versions fall back to Chrome Custom Tabs checkout
 
 * Adds new property `appLinkUrl` in `PayPalWebCheckoutRequest` to specify app link url that will be
   used to re-open app after approving order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Add `PayPalWebCheckoutClient.vault(context, setupTokenId, callback)` method (v3) — requires a prior call to `createPayPalSession()`
   * Deprecate `PayPalWebCheckoutClient.start(activity, request, callback)` — use `createPayPalSession()` followed by `start(context, orderId, callback)` instead
   * Deprecate `PayPalWebCheckoutClient.vault(activity, request, callback)` — use `createPayPalSession()` followed by `vault(context, setupTokenId, callback)` instead
+  * Fix: app switch (via `createPayPalSession()` / `start()` / `vault()`) is now only attempted when the installed PayPal app meets a minimum supported version; older, incompatible versions fall back to Chrome Custom Tabs checkout
 
 * Adds new property `appLinkUrl` in `PayPalWebCheckoutRequest` to specify app link url that will be
   used to re-open app after approving order

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/common/DeviceInspector.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/common/DeviceInspector.kt
@@ -13,6 +13,16 @@ class DeviceInspector(private val context: Context) {
     val isPayPalInstalled: Boolean
         get() = isAppInstalled(PAYPAL_APP_PACKAGE)
 
+    /**
+     * The installed PayPal app's `versionName` (e.g. "9.1.0"), or `null` if the app isn't
+     * installed or its version can't be read. Callers decide what to do with this (e.g. gating
+     * app-switch eligibility to a minimum major version) — this just surfaces the raw value.
+     */
+    val payPalAppVersionName: String?
+        get() = runCatching {
+            context.packageManager.getPackageInfo(PAYPAL_APP_PACKAGE, 0).versionName
+        }.getOrNull()
+
     private fun isAppInstalled(packageName: String): Boolean = runCatching {
         context.packageManager.getApplicationInfo(packageName, 0).enabled
     }.getOrDefault(false)
@@ -21,6 +31,11 @@ class DeviceInspector(private val context: Context) {
      * Whether [uri] actually resolves to the PayPal app, not just whether it's installed — the
      * user may have unchecked "Open supported links" for it. Mirrors Braintree Android's
      * `ResolvePayPalUseCase`.
+     *
+     * Also requires the installed PayPal app to meet [APP_SWITCH_MIN_MAJOR_VERSION], the minimum
+     * major version that supports this SDK's app-switch flow. If the installed app's version
+     * can't be determined, this fails closed (returns false) rather than risk switching into a
+     * build that doesn't support it.
      */
     fun canResolvePayPalAppSwitch(uri: Uri = DEFAULT_APP_SWITCH_URI): Boolean {
         val intent = Intent(Intent.ACTION_VIEW, uri).apply {
@@ -30,7 +45,18 @@ class DeviceInspector(private val context: Context) {
             intent,
             PackageManager.MATCH_DEFAULT_ONLY
         )
-        return resolvedActivity?.activityInfo?.packageName == PAYPAL_APP_PACKAGE
+        val resolvesToPayPalApp = resolvedActivity?.activityInfo?.packageName == PAYPAL_APP_PACKAGE
+        return resolvesToPayPalApp && isAppSwitchSupportedVersion(payPalAppVersionName)
+    }
+
+    /**
+     * Parses the leading major-version integer from [versionName] (e.g. "9.1.0" -> 9) and
+     * checks whether it meets [APP_SWITCH_MIN_MAJOR_VERSION]. Returns false if [versionName] is
+     * null or its leading segment isn't a parseable integer.
+     */
+    private fun isAppSwitchSupportedVersion(versionName: String?): Boolean {
+        val majorVersion = versionName?.substringBefore('.')?.toIntOrNull()
+        return majorVersion != null && majorVersion >= APP_SWITCH_MIN_MAJOR_VERSION
     }
 
     fun isDeepLinkConfiguredInManifest(returnUrlScheme: String): Boolean {
@@ -46,6 +72,7 @@ class DeviceInspector(private val context: Context) {
     companion object {
         const val PAYPAL_APP_PACKAGE = "com.paypal.android.p2pmobile"
         private const val PAYPAL_APP_SWITCH_URL = "https://www.paypal.com/app-switch-checkout"
+        private const val APP_SWITCH_MIN_MAJOR_VERSION = 9
         private val DEFAULT_APP_SWITCH_URI: Uri
             get() = PAYPAL_APP_SWITCH_URL.toUri()
     }

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/common/DeviceInspectorUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/common/DeviceInspectorUnitTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 import android.net.Uri
@@ -12,6 +13,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -83,17 +85,121 @@ class DeviceInspectorUnitTest {
     }
 
     @Test
-    fun `canResolvePayPalAppSwitch returns true when the PayPal app resolves the app-switch uri`() {
+    fun `payPalAppVersionName returns the installed PayPal app's versionName`() {
+        every {
+            packageManager.getPackageInfo(DeviceInspector.PAYPAL_APP_PACKAGE, 0)
+        } returns PackageInfo().apply { versionName = "10.1.0" }
+
+        val result = sut.payPalAppVersionName
+
+        assertEquals("10.1.0", result)
+    }
+
+    @Test
+    fun `payPalAppVersionName returns null when PayPal app is not installed`() {
+        every {
+            packageManager.getPackageInfo(DeviceInspector.PAYPAL_APP_PACKAGE, 0)
+        } throws PackageManager.NameNotFoundException("Package not found")
+
+        val result = sut.payPalAppVersionName
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `payPalAppVersionName returns null when PackageManager throws unexpected exception`() {
+        every {
+            packageManager.getPackageInfo(DeviceInspector.PAYPAL_APP_PACKAGE, 0)
+        } throws RuntimeException("Unexpected error")
+
+        val result = sut.payPalAppVersionName
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `canResolvePayPalAppSwitch returns true when the PayPal app resolves the uri and meets the min version`() {
         val resolveInfo = ResolveInfo().apply {
             activityInfo = ActivityInfo().apply { packageName = DeviceInspector.PAYPAL_APP_PACKAGE }
         }
         every {
             packageManager.resolveActivity(any(), PackageManager.MATCH_DEFAULT_ONLY)
         } returns resolveInfo
+        every {
+            packageManager.getPackageInfo(DeviceInspector.PAYPAL_APP_PACKAGE, 0)
+        } returns PackageInfo().apply { versionName = "9.1.0" }
 
         val result = sut.canResolvePayPalAppSwitch()
 
         assertTrue(result)
+    }
+
+    @Test
+    fun `canResolvePayPalAppSwitch returns true when installed version is exactly the minimum major version`() {
+        val resolveInfo = ResolveInfo().apply {
+            activityInfo = ActivityInfo().apply { packageName = DeviceInspector.PAYPAL_APP_PACKAGE }
+        }
+        every {
+            packageManager.resolveActivity(any(), PackageManager.MATCH_DEFAULT_ONLY)
+        } returns resolveInfo
+        every {
+            packageManager.getPackageInfo(DeviceInspector.PAYPAL_APP_PACKAGE, 0)
+        } returns PackageInfo().apply { versionName = "9.0.0" }
+
+        val result = sut.canResolvePayPalAppSwitch()
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `canResolvePayPalAppSwitch returns false when the resolved app's version is below the minimum`() {
+        val resolveInfo = ResolveInfo().apply {
+            activityInfo = ActivityInfo().apply { packageName = DeviceInspector.PAYPAL_APP_PACKAGE }
+        }
+        every {
+            packageManager.resolveActivity(any(), PackageManager.MATCH_DEFAULT_ONLY)
+        } returns resolveInfo
+        every {
+            packageManager.getPackageInfo(DeviceInspector.PAYPAL_APP_PACKAGE, 0)
+        } returns PackageInfo().apply { versionName = "8.9.9" }
+
+        val result = sut.canResolvePayPalAppSwitch()
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `canResolvePayPalAppSwitch returns false when the resolved app's version can't be determined`() {
+        val resolveInfo = ResolveInfo().apply {
+            activityInfo = ActivityInfo().apply { packageName = DeviceInspector.PAYPAL_APP_PACKAGE }
+        }
+        every {
+            packageManager.resolveActivity(any(), PackageManager.MATCH_DEFAULT_ONLY)
+        } returns resolveInfo
+        every {
+            packageManager.getPackageInfo(DeviceInspector.PAYPAL_APP_PACKAGE, 0)
+        } throws PackageManager.NameNotFoundException("Package not found")
+
+        val result = sut.canResolvePayPalAppSwitch()
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `canResolvePayPalAppSwitch returns false when the resolved app's version has an unparseable major segment`() {
+        val resolveInfo = ResolveInfo().apply {
+            activityInfo = ActivityInfo().apply { packageName = DeviceInspector.PAYPAL_APP_PACKAGE }
+        }
+        every {
+            packageManager.resolveActivity(any(), PackageManager.MATCH_DEFAULT_ONLY)
+        } returns resolveInfo
+        every {
+            packageManager.getPackageInfo(DeviceInspector.PAYPAL_APP_PACKAGE, 0)
+        } returns PackageInfo().apply { versionName = "not-a-version" }
+
+        val result = sut.canResolvePayPalAppSwitch()
+
+        assertFalse(result)
     }
 
     @Test

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -625,6 +625,9 @@ class PayPalWebCheckoutClient internal constructor(
      * would open a URL that isn't meant to be loaded standalone, landing on an error page. This
      * mirrors the `deviceInspector.isPayPalInstalled() && resolvePayPalUseCase()` guard used by
      * the Braintree Android SDK.
+     *
+     * [DeviceInspector.canResolvePayPalAppSwitch] additionally requires the installed PayPal app
+     * to meet a minimum supported version — see its doc for details.
      */
     private fun canAttemptPayPalAppSwitch(): Boolean =
         deviceInspector.isPayPalInstalled && deviceInspector.canResolvePayPalAppSwitch()


### PR DESCRIPTION
Thank you for your contribution to PayPal.

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

- Restrict PayPal app switch to installs that meet a minimum supported app version. `DeviceInspector.canResolvePayPalAppSwitch()` now checks the installed PayPal app's version in addition to its existing "does this URI resolve to the PayPal app" check, and fails closed (no app switch) if the version can't be determined.
- Add `DeviceInspector.payPalAppVersionName`, which reads the installed PayPal app's `PackageInfo.versionName` via `PackageManager`, returning `null` if the app isn't installed or the version can't be read.
- Add a private `DeviceInspector.isAppSwitchSupportedVersion()` helper that parses the leading major-version integer from `versionName` (e.g. `"9.1.0"` → `9`) and compares it against a new `APP_SWITCH_MIN_MAJOR_VERSION` constant.
- Update `PayPalWebCheckoutClient.canAttemptPayPalAppSwitch()` KDoc to reference the new version-gating behavior now living in `DeviceInspector`. No logic change in this class — the check is fully encapsulated in `DeviceInspector.canResolvePayPalAppSwitch()`, so this only affects the shopper-session (v3) app-switch flow, not the legacy `PatchCCOWithAppSwitchEligibility` path.
- Add unit test coverage in `DeviceInspectorUnitTest` for the new version accessor and gating logic: exact boundary, below-minimum, undeterminable, and unparseable version cases.

Resolves [DTPPMOBILE-547](https://paypal.atlassian.net/browse/DTPPMOBILE-547).

### Checklist

- [ ] Added a changelog entry

### Authors

> List GitHub usernames for everyone who contributed to this pull request.
