### PR TITLE
adding required query params to app switch and fallback urls

### DIFF
--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -672,17 +672,6 @@ class PayPalWebCheckoutClient internal constructor(
         return uriWithSessionId.appendObservabilityQueryParams(tokenType)
     }
 
-    /**
-     * Appends query params required by PayPal's app-side observability/latency dashboards
-     * (DTPPMOBILE-503), mirroring the params BT Native SDK, PPCP JS SDK, and iOS's
-     * `PayPalWebCheckoutURLBuilder` already send. Applied to both the app-switch (redirectUrl)
-     * and fallback (checkoutFallbackUrl) launch URIs, since both currently flow through
-     * [getLaunchUri].
-     *
-     * `funding_source` is hardcoded to PayPal, matching iOS's non-deprecated session-based
-     * start()/vault(): the new [createPayPalSession]-based flow has no funding-source parameter
-     * (that only exists on the deprecated [PayPalWebCheckoutRequest]).
-     */
     private fun Uri.appendObservabilityQueryParams(tokenType: TokenType): Uri {
         val flowType = when (tokenType) {
             TokenType.ORDER_ID -> "ecs"

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -658,13 +658,40 @@ class PayPalWebCheckoutClient internal constructor(
             checkoutFallbackUrl.toUri()
         }.appendTokenQueryParam(token, tokenType)
 
-        return if (shopperSessionConfig.id.isNotBlank()) {
+        val uriWithSessionId = if (shopperSessionConfig.id.isNotBlank()) {
             launchUri.buildUpon()
                 .appendQueryParameter("shopperSessionId", shopperSessionConfig.id)
                 .build()
         } else {
             launchUri
         }
+
+        return uriWithSessionId.appendObservabilityQueryParams(tokenType)
+    }
+
+    /**
+     * Appends query params required by PayPal's app-side observability/latency dashboards
+     * (DTPPMOBILE-503), mirroring the params BT Native SDK, PPCP JS SDK, and iOS's
+     * `PayPalWebCheckoutURLBuilder` already send. Applied to both the app-switch (redirectUrl)
+     * and fallback (checkoutFallbackUrl) launch URIs, since both currently flow through
+     * [getLaunchUri].
+     *
+     * `funding_source` is hardcoded to PayPal, matching iOS's non-deprecated session-based
+     * start()/vault(): the new [createPayPalSession]-based flow has no funding-source parameter
+     * (that only exists on the deprecated [PayPalWebCheckoutRequest]).
+     */
+    private fun Uri.appendObservabilityQueryParams(tokenType: TokenType): Uri {
+        val flowType = when (tokenType) {
+            TokenType.ORDER_ID -> "ecs"
+            TokenType.VAULT_ID, TokenType.BILLING_TOKEN -> "va"
+        }
+        return buildUpon()
+            .appendQueryParameter("source", "pda")
+            .appendQueryParameter("merchant", coreConfig.merchantId)
+            .appendQueryParameter("flow_type", flowType)
+            .appendQueryParameter("funding_source", PayPalWebCheckoutFundingSource.PAYPAL.value)
+            .appendQueryParameter("switch_initiated_time", System.currentTimeMillis().toString())
+            .build()
     }
 
     private fun buildPayPalCheckoutUri(

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -31,6 +31,7 @@ import io.mockk.slot
 import io.mockk.verify
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertSame
 import junit.framework.TestCase.assertTrue
@@ -1794,6 +1795,37 @@ class PayPalWebCheckoutClientUnitTest {
         }
 
     @Test
+    fun `start() with orderId includes observability query params on the launch uri`() = runTest {
+        val sutV3 = makeSutWithUrlScheme()
+        val uriSlot = slot<Uri>()
+        val beforeMillis = System.currentTimeMillis()
+        every {
+            payPalWebLauncher.launchWithUrl(any(), capture(uriSlot), any(), any(), any())
+        } returns PayPalPresentAuthChallengeResult.Success("auth-state")
+
+        val callback = mockk<PayPalWebStartCallback>(relaxed = true)
+        sutV3.createPayPalSession(
+            tokenType = TokenType.ORDER_ID,
+            userIdentity = fakeUserIdentity,
+            urlConfig = fakeUrlConfig,
+        )
+        sutV3.shopperSessionDeferred = CompletableDeferred(fakeSessionResponse)
+        sutV3.start(activity, "fake-order-id", callback)
+        testDispatcher.scheduler.advanceUntilIdle()
+        val afterMillis = System.currentTimeMillis()
+
+        val launchedUri = uriSlot.captured
+        assertEquals("pda", launchedUri.getQueryParameter("source"))
+        assertEquals("fake-merchant-id", launchedUri.getQueryParameter("merchant"))
+        assertEquals("ecs", launchedUri.getQueryParameter("flow_type"))
+        assertEquals("paypal", launchedUri.getQueryParameter("funding_source"))
+
+        val switchInitiatedTime = launchedUri.getQueryParameter("switch_initiated_time")?.toLongOrNull()
+        assertNotNull(switchInitiatedTime)
+        assertTrue(switchInitiatedTime!! in beforeMillis..afterMillis)
+    }
+
+    @Test
     fun `start() with orderId delivers failure without falling back to patchCCO when createShopperSession throws`() =
         runTest {
             val sutV3 = makeSutWithUrlScheme()
@@ -1997,6 +2029,38 @@ class PayPalWebCheckoutClientUnitTest {
             )
         }
         verify { callback.onPayPalWebVaultResult(launchResult) }
+    }
+
+    @Test
+    fun `vault() with setupTokenId includes observability query params on the launch uri`() = runTest {
+        val sutV3 = makeSutWithUrlScheme()
+        val uriSlot = slot<Uri>()
+        val beforeMillis = System.currentTimeMillis()
+        every {
+            payPalWebLauncher.launchWithUrl(any(), capture(uriSlot), any(), any(), any())
+        } returns PayPalPresentAuthChallengeResult.Success("auth-state")
+
+        val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
+        sutV3.createPayPalSession(
+            tokenType = TokenType.VAULT_ID,
+            userIdentity = fakeUserIdentity,
+            urlConfig = fakeUrlConfig,
+        )
+        sutV3.shopperSessionDeferred = CompletableDeferred(fakeSessionResponse)
+        sutV3.vault(activity, "fake-setup-token-id", callback)
+        testDispatcher.scheduler.advanceUntilIdle()
+        val afterMillis = System.currentTimeMillis()
+
+        val launchedUri = uriSlot.captured
+        assertEquals("fake-session-id", launchedUri.getQueryParameter("shopperSessionId"))
+        assertEquals("pda", launchedUri.getQueryParameter("source"))
+        assertEquals("fake-merchant-id", launchedUri.getQueryParameter("merchant"))
+        assertEquals("va", launchedUri.getQueryParameter("flow_type"))
+        assertEquals("paypal", launchedUri.getQueryParameter("funding_source"))
+
+        val switchInitiatedTime = launchedUri.getQueryParameter("switch_initiated_time")?.toLongOrNull()
+        assertNotNull(switchInitiatedTime)
+        assertTrue(switchInitiatedTime!! in beforeMillis..afterMillis)
     }
 
     @Test


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Adds source, merchant, flow_type, funding_source, and switch_initiated_time query params to the app-switch and fallback launch URLs built in PayPalWebCheckoutClient.getLaunchUri(), for app-side observability/latency dashboards. 

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

