### PR TITLE
Remove deprecated PayPalWebCheckoutClient methods

### DIFF
--- a/PayPalWebPayments/api/PayPalWebPayments.api
+++ b/PayPalWebPayments/api/PayPalWebPayments.api
@@ -71,21 +71,14 @@ public final class com/paypal/android/paypalwebpayments/PayPalUserIdentity {
 
 public final class com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient {
 	public fun <init> (Landroid/content/Context;Lcom/paypal/android/corepayments/CoreConfig;)V
-	public fun <init> (Landroid/content/Context;Lcom/paypal/android/corepayments/CoreConfig;Ljava/lang/String;)V
 	public final fun createPayPalSession (Lcom/paypal/android/corepayments/model/TokenType;Lcom/paypal/android/paypalwebpayments/PayPalUserIdentity;Lcom/paypal/android/paypalwebpayments/ReturnToAppUrlConfig;Lcom/paypal/android/paypalwebpayments/PayPalUserAction;)V
 	public static synthetic fun createPayPalSession$default (Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutClient;Lcom/paypal/android/corepayments/model/TokenType;Lcom/paypal/android/paypalwebpayments/PayPalUserIdentity;Lcom/paypal/android/paypalwebpayments/ReturnToAppUrlConfig;Lcom/paypal/android/paypalwebpayments/PayPalUserAction;ILjava/lang/Object;)V
 	public final fun finishStart (Landroid/content/Intent;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFinishStartResult;
-	public final fun finishStart (Landroid/content/Intent;Ljava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFinishStartResult;
 	public final fun finishVault (Landroid/content/Intent;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFinishVaultResult;
-	public final fun finishVault (Landroid/content/Intent;Ljava/lang/String;)Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutFinishVaultResult;
 	public final fun getInstanceState ()Ljava/lang/String;
 	public final fun restore (Ljava/lang/String;)V
-	public final fun start (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;)Lcom/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult;
-	public final fun start (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebCheckoutRequest;Lcom/paypal/android/paypalwebpayments/PayPalWebStartCallback;)V
 	public final fun start (Landroid/app/Activity;Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebStartCallback;)V
-	public final fun vault (Landroid/app/Activity;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;)Lcom/paypal/android/paypalwebpayments/PayPalPresentAuthChallengeResult;
 	public final fun vault (Landroid/app/Activity;Ljava/lang/String;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultCallback;)V
-	public final fun vault (Landroidx/activity/ComponentActivity;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultRequest;Lcom/paypal/android/paypalwebpayments/PayPalWebVaultCallback;)V
 }
 
 public abstract class com/paypal/android/paypalwebpayments/PayPalWebCheckoutFinishStartResult {

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -4,11 +4,9 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import androidx.activity.ComponentActivity
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.paypal.android.corepayments.CoreConfig
-import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.HttpRoundTripTiming
 import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.corepayments.UpdateClientConfigAPI
@@ -20,7 +18,6 @@ import com.paypal.android.corepayments.model.APIResult
 import com.paypal.android.corepayments.model.CreateShopperSessionWithAppSwitchEligibilityResponse
 import com.paypal.android.corepayments.model.CreateShopperSessionWithAppSwitchEligibilityParams
 import com.paypal.android.corepayments.model.TokenType
-import com.paypal.android.corepayments.returnUrl
 import com.paypal.android.paypalwebpayments.analytics.AppSwitchAnalyticsEventParams
 import com.paypal.android.paypalwebpayments.analytics.CheckoutEvent
 import com.paypal.android.paypalwebpayments.analytics.CreatePayPalSessionEvent
@@ -57,7 +54,6 @@ class PayPalWebCheckoutClient internal constructor(
     private val updateClientConfigAPI: UpdateClientConfigAPI,
     private val patchCCOWithAppSwitchEligibility: PatchCCOWithAppSwitchEligibility,
     private val createShopperSessionAPI: CreateShopperSessionWithAppSwitchEligibilityAPI,
-    private val urlScheme: String? = null,
     private val applicationScope: CoroutineScope = CoroutineScope(SupervisorJob()),
 ) {
 
@@ -79,7 +75,6 @@ class PayPalWebCheckoutClient internal constructor(
         sessionStore = PayPalWebCheckoutSessionStore(),
         deviceInspector = DeviceInspector(context),
         coreConfig = configuration,
-        urlScheme = null,
         patchCCOWithAppSwitchEligibility = PatchCCOWithAppSwitchEligibility(configuration),
         createShopperSessionAPI = CreateShopperSessionWithAppSwitchEligibilityAPI(
             configuration,
@@ -626,97 +621,6 @@ class PayPalWebCheckoutClient internal constructor(
         }
     }
 
-    // Used by deprecated start() methods
-    @VisibleForTesting
-    internal suspend fun startAsync(
-        activity: Activity,
-        request: PayPalWebCheckoutRequest
-    ): PayPalPresentAuthChallengeResult {
-        val returnToAppStrategy = resolveReturnToAppStrategy(request.returnToAppStrategy)
-            ?: return PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.noReturnToAppStrategyError)
-
-        val launchUri = withContext(Dispatchers.IO) {
-            // perform updateCCO and getLaunchUri in parallel
-            val updateConfigDeferred = async {
-                updateClientConfigAPI.updateClientConfig(
-                    request.orderId,
-                    request.fundingSource.value
-                )
-            }
-            val launchUriDeferred = async {
-                getLaunchUri(
-                    context = activity.applicationContext,
-                    token = request.orderId,
-                    tokenType = TokenType.ORDER_ID,
-                    fallbackUri = buildPayPalCheckoutUri(
-                        orderId = request.orderId,
-                        funding = request.fundingSource,
-                        returnUrl = returnToAppStrategy.returnUrl
-                    )
-                )
-            }
-
-            updateConfigDeferred.await() // waits for completion, ignores result
-            launchUriDeferred.await() // returns launch URI
-        }
-
-        val result = payPalWebLauncher.launchWithUrl(
-            context = activity,
-            uri = launchUri,
-            token = request.orderId,
-            tokenType = TokenType.ORDER_ID,
-            returnToAppStrategy = returnToAppStrategy
-        )
-
-        when (result) {
-            is PayPalPresentAuthChallengeResult.Success -> {
-                // update auth state value in session store
-                sessionStore.authState = result.authState
-            }
-
-            is PayPalPresentAuthChallengeResult.Failure -> {}
-        }
-
-        return result
-    }
-
-    // Used by deprecated start() methods
-    @VisibleForTesting
-    internal suspend fun vaultAsync(
-        activity: Activity,
-        request: PayPalWebVaultRequest
-    ): PayPalPresentAuthChallengeResult {
-        val returnToAppStrategy = resolveReturnToAppStrategy(request.returnToAppStrategy)
-            ?: return PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.noReturnToAppStrategyError)
-
-        val launchUri = withContext(Dispatchers.IO) {
-            getLaunchUri(
-                context = activity.applicationContext,
-                token = request.setupTokenId,
-                tokenType = TokenType.VAULT_ID,
-                fallbackUri = buildPayPalVaultUri(request.setupTokenId)
-            )
-        }
-
-        val result = payPalWebLauncher.launchWithUrl(
-            context = activity,
-            uri = launchUri,
-            token = request.setupTokenId,
-            tokenType = TokenType.VAULT_ID,
-            returnToAppStrategy = returnToAppStrategy
-        )
-
-        when (result) {
-            is PayPalPresentAuthChallengeResult.Success -> {
-                // update auth state value in session store
-                sessionStore.authState = result.authState
-            }
-
-            is PayPalPresentAuthChallengeResult.Failure -> {}
-        }
-
-        return result
-    }
     // endregion
 
     // region Private Helpers
@@ -798,40 +702,6 @@ class PayPalWebCheckoutClient internal constructor(
             .build()
     }
 
-    private fun buildPayPalCheckoutUri(
-        orderId: String?,
-        funding: PayPalWebCheckoutFundingSource?,
-        returnUrl: String?
-    ): Uri {
-        val uriBuilder = baseUrl.toUri()
-            .buildUpon()
-            .appendPath("checkoutnow")
-            .appendQueryParameter("token", orderId)
-            .appendQueryParameter("redirect_uri", returnUrl)
-            .appendQueryParameter("native_xo", "1")
-            .appendQueryParameter("integration_artifact", UpdateClientConfigAPI.Defaults.INTEGRATION_ARTIFACT)
-
-        funding?.let { uriBuilder.appendQueryParameter("fundingSource", it.value) }
-        return uriBuilder.build()
-    }
-
-    private fun buildPayPalVaultUri(
-        setupTokenId: String
-    ): Uri {
-        return baseUrl.toUri()
-            .buildUpon()
-            .appendPath("agreements")
-            .appendPath("approve")
-            .appendQueryParameter("approval_session_id", setupTokenId)
-            .build()
-    }
-
-    private val baseUrl: String
-        get() = when (coreConfig.environment) {
-            Environment.LIVE -> "https://paypal.com/"
-            else -> "https://sandbox.paypal.com/"
-        }
-
     private suspend fun getLaunchUri(
         context: Context,
         token: String,
@@ -860,18 +730,6 @@ class PayPalWebCheckoutClient internal constructor(
         } else {
             appSwitchEnabled = false
             fallbackUri
-        }
-    }
-
-    /**
-     * Resolves the return to app strategy from request or falls back to urlScheme.
-     * if both are not available then throws error
-     */
-    private fun resolveReturnToAppStrategy(
-        requestStrategy: ReturnToAppStrategy?
-    ): ReturnToAppStrategy? {
-        return requestStrategy ?: urlScheme?.let {
-            ReturnToAppStrategy.CustomUrlScheme(urlScheme)
         }
     }
 
@@ -921,229 +779,6 @@ class PayPalWebCheckoutClient internal constructor(
         bnCode = coreConfig.bnCode,
         clientId = coreConfig.clientId,
     )
-    // endregion
-
-    // region Deprecated Methods
-
-    /**
-     * Create a new instance of [PayPalWebCheckoutClient].
-     *
-     * @param context an Android context
-     * @param configuration a [CoreConfig] object
-     * @param urlScheme the custom URl scheme used to return to your app from a browser switch flow
-     */
-    @Deprecated(
-        message = "Use PayPalWebCheckoutClient(context, configuration) instead.",
-        replaceWith = ReplaceWith("PayPalWebCheckoutClient(context, configuration)")
-    )
-    constructor(
-        context: Context,
-        configuration: CoreConfig,
-        urlScheme: String
-    ) : this(
-        analytics = PayPalWebAnalytics(AnalyticsService(context.applicationContext, configuration)),
-        payPalWebLauncher = PayPalWebLauncher(context),
-        sessionStore = PayPalWebCheckoutSessionStore(),
-        deviceInspector = DeviceInspector(context),
-        coreConfig = configuration,
-        urlScheme = urlScheme,
-        patchCCOWithAppSwitchEligibility = PatchCCOWithAppSwitchEligibility(configuration),
-        createShopperSessionAPI = CreateShopperSessionWithAppSwitchEligibilityAPI(
-            configuration,
-            context.applicationContext,
-        ),
-        updateClientConfigAPI = UpdateClientConfigAPI(context, configuration),
-    )
-
-    /**
-     * Confirm PayPal payment source for an order.
-     *
-     * @param request [PayPalWebCheckoutRequest] for requesting an order approval
-     */
-    @Deprecated(
-        message = "Use start(activity, request, callback) for callback-based flows, includes app switching feature",
-        replaceWith = ReplaceWith("start(activity, request, callback)")
-    )
-    fun start(
-        activity: Activity,
-        request: PayPalWebCheckoutRequest
-    ): PayPalPresentAuthChallengeResult {
-        appSwitchEnabled = false
-
-        val returnToAppStrategy = resolveReturnToAppStrategy(request.returnToAppStrategy)
-            ?: return PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.noReturnToAppStrategyError)
-
-        val launchUri = buildPayPalCheckoutUri(
-            orderId = request.orderId,
-            funding = request.fundingSource,
-            returnUrl = returnToAppStrategy.returnUrl
-        )
-
-        val result = payPalWebLauncher.launchWithUrl(
-            context = activity,
-            uri = launchUri,
-            token = request.orderId,
-            tokenType = TokenType.ORDER_ID,
-            returnToAppStrategy = returnToAppStrategy
-        )
-
-        when (result) {
-            is PayPalPresentAuthChallengeResult.Success -> {
-                // update auth state value in session store
-                sessionStore.authState = result.authState
-            }
-
-            is PayPalPresentAuthChallengeResult.Failure -> {}
-        }
-        return result
-    }
-
-    /**
-     * Confirm PayPal payment source for an order with callback.
-     *
-     * @param activity The activity to launch the PayPal web checkout from
-     * @param request [PayPalWebCheckoutRequest] for requesting an order approval
-     * @param callback [PayPalWebStartCallback] to receive the result
-     */
-    @Deprecated(
-        message = "Use createPayPalSession() followed by start(activity, orderId, callback) instead.",
-        replaceWith = ReplaceWith("start(activity, request.orderId, callback)")
-    )
-    fun start(
-        activity: Activity,
-        request: PayPalWebCheckoutRequest,
-        callback: PayPalWebStartCallback
-    ) {
-        applicationScope.launch {
-            val result = startAsync(activity, request)
-            withContext(Dispatchers.Main) {
-                callback.onPayPalWebStartResult(result)
-            }
-        }
-    }
-
-    /**
-     * Vault PayPal as a payment method.
-     *
-     * @param request [PayPalWebVaultRequest] for vaulting PayPal as a payment method
-     */
-    @Deprecated(
-        message = "Use vault(activity, request, callback) for callback-based flows, includes app switching feature",
-        replaceWith = ReplaceWith("vault(activity, request, callback)")
-    )
-    fun vault(
-        activity: Activity,
-        request: PayPalWebVaultRequest
-    ): PayPalPresentAuthChallengeResult {
-        val returnToAppStrategy = resolveReturnToAppStrategy(request.returnToAppStrategy)
-            ?: return PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.noReturnToAppStrategyError)
-
-        val launchUri = buildPayPalVaultUri(request.setupTokenId)
-
-        val result = payPalWebLauncher.launchWithUrl(
-            context = activity,
-            uri = launchUri,
-            token = request.setupTokenId,
-            tokenType = TokenType.VAULT_ID,
-            returnToAppStrategy = returnToAppStrategy
-        )
-
-        when (result) {
-            is PayPalPresentAuthChallengeResult.Success -> {
-                // update auth state value in session store
-                sessionStore.authState = result.authState
-            }
-
-            is PayPalPresentAuthChallengeResult.Failure -> {}
-        }
-
-        return result
-    }
-
-    /**
-     * Vault PayPal as a payment method with callback.
-     *
-     * @param activity the ComponentActivity to launch the auth challenge from
-     * @param request [PayPalWebVaultRequest] for vaulting PayPal as a payment method
-     * @param callback callback to receive the result
-     */
-    @Deprecated(
-        message = "Use createPayPalSession() followed by vault(activity, setupTokenId, callback) instead.",
-        replaceWith = ReplaceWith("vault(activity, request.setupTokenId, callback)")
-    )
-    fun vault(
-        activity: ComponentActivity,
-        request: PayPalWebVaultRequest,
-        callback: PayPalWebVaultCallback
-    ) {
-        applicationScope.launch(Dispatchers.Main) {
-            callback.onPayPalWebVaultResult(vaultAsync(activity, request))
-        }
-    }
-
-    /**
-     * After a merchant app has re-entered the foreground following an auth challenge
-     * (@see [PayPalWebCheckoutClient.start]), call this method to see if a user has
-     * successfully authorized a PayPal account as a payment source.
-     *
-     * @param [intent] An Android intent that holds the deep link put the merchant app
-     * back into the foreground after an auth challenge.
-     * @param [authState] A continuation state received from [PayPalPresentAuthChallengeResult.Success]
-     * when calling [PayPalWebCheckoutClient.start]. This is needed to properly verify that an
-     * authorization completed successfully.
-     */
-    @Deprecated(
-        message = "Auth state is now captured internally by the SDK. Please migrate to finishStart(intent).",
-        replaceWith = ReplaceWith("finishStart(intent)")
-    )
-    fun finishStart(intent: Intent, authState: String): PayPalWebCheckoutFinishStartResult {
-        val result = payPalWebLauncher.completeCheckoutAuthRequest(intent, authState)
-        when (result) {
-            is PayPalWebCheckoutFinishStartResult.Success -> { /* Do Nothing. Will remove deprecated methods*/ }
-
-            is PayPalWebCheckoutFinishStartResult.Canceled -> { /* Do Nothing. Will remove deprecated methods*/ }
-
-            is PayPalWebCheckoutFinishStartResult.Failure -> { /* Do Nothing. Will remove deprecated methods*/ }
-
-            PayPalWebCheckoutFinishStartResult.NoResult -> {
-                // no analytics tracking required at the moment
-            }
-        }
-        return result
-    }
-
-    /**
-     * After a merchant app has re-entered the foreground following an auth challenge
-     * (@see [PayPalWebCheckoutClient.vault]), call this method to see if a user has
-     * successfully authorized a PayPal account for vaulting.
-     *
-     * @param [intent] An Android intent that holds the deep link put the merchant app
-     * back into the foreground after an auth challenge.
-     * @param [authState] A continuation state received from [PayPalPresentAuthChallengeResult.Success]
-     * when calling [PayPalWebCheckoutClient.vault]. This is needed to properly verify that an
-     * authorization completed successfully.
-     */
-    @Deprecated(
-        message = "Auth state is now captured internally by the SDK. Please migrate to finishVault(intent).",
-        replaceWith = ReplaceWith("finishVault(intent)")
-    )
-    fun finishVault(intent: Intent, authState: String): PayPalWebCheckoutFinishVaultResult {
-        val result = payPalWebLauncher.completeVaultAuthRequest(intent, authState)
-        // TODO: see if we can get setup token id from somewhere for tracking
-        when (result) {
-            is PayPalWebCheckoutFinishVaultResult.Success -> { /* Do Nothing. Will remove deprecated methods*/ }
-
-            is PayPalWebCheckoutFinishVaultResult.Failure -> { /* Do Nothing. Will remove deprecated methods*/ }
-
-            PayPalWebCheckoutFinishVaultResult.Canceled -> { /* Do Nothing. Will remove deprecated methods*/ }
-
-            PayPalWebCheckoutFinishVaultResult.NoResult -> {
-                // no analytics tracking required at the moment
-            }
-        }
-        return result
-    }
-
     // endregion
 }
 

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -7,9 +7,7 @@ import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.HttpRoundTripTiming
 import com.paypal.android.corepayments.PayPalSDKError
-import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.corepayments.UpdateClientConfigAPI
-import com.paypal.android.corepayments.UpdateClientConfigResult
 import com.paypal.android.corepayments.api.CreateShopperSessionWithAppSwitchEligibilityAPI
 import com.paypal.android.corepayments.api.PatchCCOWithAppSwitchEligibility
 import com.paypal.android.corepayments.common.DeviceInspector
@@ -83,11 +81,9 @@ class PayPalWebCheckoutClientUnitTest {
     @MockK
     private val deviceInspector: DeviceInspector = mockk(relaxed = true)
     private val coreConfig = CoreConfig("fake-client-id", "fake-merchant-id", Environment.SANDBOX)
-    private val urlScheme = "com.example.app"
 
     @MockK
     private val updateClientConfigAPI: UpdateClientConfigAPI = mockk(relaxed = true)
-    private val appLinkUrl = "https://example.com/"
 
     private val intent = Intent()
 
@@ -117,1597 +113,25 @@ class PayPalWebCheckoutClientUnitTest {
     fun afterEach() {
         Dispatchers.resetMain()
     }
-
-    @Test
-    fun `startAsync() launches PayPal web checkout`() = runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns launchResult
-
-        val request = PayPalWebCheckoutRequest(
-            "fake-order-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-        sut.startAsync(activity, request)
-
-        // Verify launchWithUrl is called with correct parameters
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-order-id",
-                tokenType = TokenType.ORDER_ID,
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-        }
-    }
-
-    @Test
-    fun `startAsync() notifies merchant of browser switch failure`() = runTest {
-        val sdkError = PayPalSDKError(123, "fake error description")
-        val launchResult = PayPalPresentAuthChallengeResult.Failure(sdkError)
-        every {
-            payPalWebLauncher.launchWithUrl(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns launchResult
-
-        val appLinkUrl = "https://example.com/return"
-        val request = PayPalWebCheckoutRequest(
-            "fake-order-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-        val result = sut.startAsync(activity, request)
-        assertSame(launchResult, result)
-    }
-
-    @Test
-    fun `vaultAsync() launches PayPal web checkout`() = runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns launchResult
-
-        val appLinkUrl = "https://example.com/vault/return"
-        val request = PayPalWebVaultRequest(
-            "fake-setup-token-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-        sut.vaultAsync(activity, request)
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-setup-token-id",
-                tokenType = TokenType.VAULT_ID,
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-        }
-    }
-
-    @Test
-    fun `vaultAsync() notifies merchant of browser switch failure`() = runTest {
-        val sdkError = PayPalSDKError(123, "fake error description")
-        val launchResult = PayPalPresentAuthChallengeResult.Failure(sdkError)
-        every {
-            payPalWebLauncher.launchWithUrl(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns launchResult
-
-        val appLinkUrl = "https://example.com/vault/return"
-        val request = PayPalWebVaultRequest(
-            "fake-setup-token-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-        val result = sut.vaultAsync(activity, request) as PayPalPresentAuthChallengeResult.Failure
-
-        assertSame(sdkError, result.error)
-    }
-
-    @Test
-    fun `finishStart() with merchant provided auth state forwards success result from auth launcher`() {
-        val successResult =
-            PayPalWebCheckoutFinishStartResult.Success("fake-order-id", "fake-payer-id")
-        every {
-            payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
-        } returns successResult
-
-        val result = sut.finishStart(intent, "auth state")
-        assertSame(successResult, result)
-    }
-
-    @Test
-    fun `finishStart() with merchant provided auth state forwards error result from auth launcher`() {
-        val error = PayPalSDKError(123, "fake-error-description")
-        val failureResult = PayPalWebCheckoutFinishStartResult.Failure(error, null)
-        every {
-            payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
-        } returns failureResult
-
-        val result = sut.finishStart(intent, "auth state")
-        assertSame(failureResult, result)
-    }
-
-    @Test
-    fun `finishStart() with merchant provided auth state forwards cancellation result from auth launcher`() {
-        val canceledResult = PayPalWebCheckoutFinishStartResult.Canceled("fake-order-id")
-        every {
-            payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
-        } returns canceledResult
-
-        val result = sut.finishStart(intent, "auth state")
-        assertSame(canceledResult, result)
-    }
-
     @Test
     fun `finishStart() with session auth state returns null when start has not been called`() {
         assertNull(sut.finishStart(intent))
     }
-
-    @Test
-    fun `finishStart() with session auth state forwards success result from auth launcher`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val successResult =
-            PayPalWebCheckoutFinishStartResult.Success("fake-order-id", "fake-payer-id")
-        every {
-            payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
-        } returns successResult
-
-            val request = PayPalWebCheckoutRequest(
-                "fake-order-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            sut.startAsync(activity, request)
-        val result = sut.finishStart(intent)
-        assertSame(successResult, result)
-    }
-
-    @Test
-    fun `finishStart() with restored session auth state forwards success result from auth launcher`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val successResult =
-            PayPalWebCheckoutFinishStartResult.Success("fake-order-id", "fake-payer-id")
-        every {
-            payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
-        } returns successResult
-
-            val launchWithUrlClient = PayPalWebCheckoutClient(
-            analytics = analytics,
-            payPalWebLauncher = payPalWebLauncher,
-            sessionStore = PayPalWebCheckoutSessionStore(),
-            updateClientConfigAPI = updateClientConfigAPI,
-                deviceInspector = deviceInspector,
-                coreConfig = coreConfig,
-                urlScheme = urlScheme,
-                patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
-            createShopperSessionAPI = createShopperSessionAPI,
-        )
-        val request = PayPalWebCheckoutRequest("fake-order-id")
-            launchWithUrlClient.startAsync(activity, request)
-
-            sut.restore(launchWithUrlClient.instanceState)
-        val result = sut.finishStart(intent)
-        assertSame(successResult, result)
-    }
-
-    @Test
-    fun `finishStart() with session auth state forwards error result from auth launcher`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val error = PayPalSDKError(123, "fake-error-description")
-        val failureResult = PayPalWebCheckoutFinishStartResult.Failure(error, null)
-        every {
-            payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
-        } returns failureResult
-
-            val request = PayPalWebCheckoutRequest(
-                "fake-order-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            sut.startAsync(activity, request)
-        val result = sut.finishStart(intent)
-        assertSame(failureResult, result)
-    }
-
-    @Test
-    fun `finishStart() with restored session auth state forwards error result from auth launcher`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val error = PayPalSDKError(123, "fake-error-description")
-        val failureResult = PayPalWebCheckoutFinishStartResult.Failure(error, null)
-        every {
-            payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
-        } returns failureResult
-
-            val request = PayPalWebCheckoutRequest(
-                "fake-order-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            sut.startAsync(activity, request)
-        val result = sut.finishStart(intent)
-        assertSame(failureResult, result)
-    }
-
-    @Test
-    fun `finishStart() with session auth state forwards cancellation result from auth launcher`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val canceledResult = PayPalWebCheckoutFinishStartResult.Canceled("fake-order-id")
-        every {
-            payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
-        } returns canceledResult
-
-            val request = PayPalWebCheckoutRequest(
-                "fake-order-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            sut.startAsync(activity, request)
-        val result = sut.finishStart(intent)
-        assertSame(canceledResult, result)
-    }
-
-    @Test
-    fun `finishStart() with restored session auth state forwards cancellation result from auth launcher`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val canceledResult = PayPalWebCheckoutFinishStartResult.Canceled("fake-order-id")
-        every {
-            payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
-        } returns canceledResult
-
-            val launchWithUrlClient = PayPalWebCheckoutClient(
-            analytics = analytics,
-            payPalWebLauncher = payPalWebLauncher,
-            sessionStore = PayPalWebCheckoutSessionStore(),
-            updateClientConfigAPI = updateClientConfigAPI,
-                deviceInspector = deviceInspector,
-                coreConfig = coreConfig,
-                urlScheme = urlScheme,
-                patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
-            createShopperSessionAPI = createShopperSessionAPI
-        )
-        val request = PayPalWebCheckoutRequest("fake-order-id")
-            launchWithUrlClient.startAsync(activity, request)
-
-            sut.restore(launchWithUrlClient.instanceState)
-        val result = sut.finishStart(intent)
-        assertSame(canceledResult, result)
-    }
-
-    @Test
-    fun `finishStart() with session auth state clears session to prevent delivering success event twice`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val successResult =
-            PayPalWebCheckoutFinishStartResult.Success("fake-order-id", "fake-payer-id")
-        every {
-            payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
-        } returns successResult
-
-            sut.startAsync(
-                activity,
-                PayPalWebCheckoutRequest(
-                    "fake-order-id",
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            )
-        sut.finishStart(intent)
-        assertNull(sut.finishStart(intent))
-    }
-
-    @Test
-    fun `finishStart() with session auth state clears session to prevent delivering error event twice`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val error = PayPalSDKError(123, "fake-error-description")
-        val failureResult = PayPalWebCheckoutFinishStartResult.Failure(error, null)
-        every {
-            payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
-        } returns failureResult
-
-            sut.startAsync(
-                activity,
-                PayPalWebCheckoutRequest(
-                    "fake-order-id",
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            )
-        sut.finishStart(intent)
-        assertNull(sut.finishStart(intent))
-    }
-
-    @Test
-    fun `finishStart() with session auth state clears session to prevent delivering cancellation event twice`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val canceledResult = PayPalWebCheckoutFinishStartResult.Canceled("fake-order-id")
-        every {
-            payPalWebLauncher.completeCheckoutAuthRequest(intent, "auth state")
-        } returns canceledResult
-
-            sut.startAsync(
-                activity,
-                PayPalWebCheckoutRequest(
-                    "fake-order-id",
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            )
-        sut.finishStart(intent)
-        assertNull(sut.finishStart(intent))
-    }
-
-    @Test
-    fun `finishVault() with merchant provided auth forwards vault success from PayPal web launcher`() {
-        val successResult =
-            PayPalWebCheckoutFinishVaultResult.Success("fake-approval-session-id")
-        every {
-            payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-        } returns successResult
-
-        val result = sut.finishVault(intent, "auth state")
-                as PayPalWebCheckoutFinishVaultResult.Success
-        assertSame("fake-approval-session-id", result.approvalSessionId)
-    }
-
-    @Test
-    fun `finishVault() with merchant provided auth notifies merchant of vault failure`() {
-        val error = PayPalSDKError(123, "fake-error-description")
-        every {
-            payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-        } returns PayPalWebCheckoutFinishVaultResult.Failure(error)
-
-        val result = sut.finishVault(intent, "auth state")
-                as PayPalWebCheckoutFinishVaultResult.Failure
-        assertSame(error, result.error)
-    }
-
-    @Test
-    fun `finishVault with merchant provided auth forwards vault cancellation`() {
-        every {
-            payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-        } returns PayPalWebCheckoutFinishVaultResult.Canceled
-
-        val result = sut.finishVault(intent, "auth state")
-        assertTrue(result is PayPalWebCheckoutFinishVaultResult.Canceled)
-    }
-
-    @Test
-    fun `finishVault with merchant provided auth forwards no result`() {
-        every {
-            payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-        } returns PayPalWebCheckoutFinishVaultResult.NoResult
-
-        val result = sut.finishVault(intent, "auth state")
-        assertTrue(result is PayPalWebCheckoutFinishVaultResult.NoResult)
-    }
-
-    @Test
-    fun `start() falls back to web checkout when app switch is enabled but URL is null`() =
-        runTest {
-            // Given
-            every { deviceInspector.isPayPalInstalled } returns true
-            val request = PayPalWebCheckoutRequest(
-                "fake-order-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            val appSwitchResponse = createAppSwitchEligibilityResponse(null)
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-            coEvery {
-                patchCCOWithAppSwitchEligibility(any(), any(), any(), any(), any())
-            } returns APIResult.Success(appSwitchResponse)
-
-            every {
-                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-            } returns launchResult
-
-            // When
-            val result = sut.startAsync(activity, request)
-
-            // Then
-            verify {
-                payPalWebLauncher.launchWithUrl(
-                    context = activity,
-                    uri = any(),
-                    token = "fake-order-id",
-                    tokenType = TokenType.ORDER_ID,
-                    returnToAppStrategy = any()
-                )
-            }
-            assertSame(launchResult, result)
-        }
-
-    @Test
-    fun `start() falls back to web checkout when app switch is enabled but empty URL is returned`() =
-        runTest {
-            // Given
-            every { deviceInspector.isPayPalInstalled } returns true
-            val request = PayPalWebCheckoutRequest(
-                "fake-order-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            val appSwitchResponse = createAppSwitchEligibilityResponse("")
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-            coEvery {
-                patchCCOWithAppSwitchEligibility(any(), any(), any(), any(), any())
-            } returns APIResult.Success(appSwitchResponse)
-
-            every {
-                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-            } returns launchResult
-
-            // When
-            val result = sut.startAsync(activity, request)
-
-            // Then
-            verify {
-                payPalWebLauncher.launchWithUrl(
-                    context = activity,
-                    uri = any(),
-                    token = "fake-order-id",
-                    tokenType = TokenType.ORDER_ID,
-                    returnToAppStrategy = any()
-                )
-            }
-            assertSame(launchResult, result)
-        }
-
     // VAULT APP SWITCH TESTS
-    @Test
-    fun `vault() falls back to web vault when app switch is enabled but empty URL is returned`() =
-        runTest {
-            // Given
-            every { deviceInspector.isPayPalInstalled } returns true
-            val request = PayPalWebVaultRequest(
-                "fake-setup-token-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            val appSwitchResponse = createAppSwitchEligibilityResponse("")
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-            coEvery {
-                patchCCOWithAppSwitchEligibility(any(), any(), any(), any(), any())
-            } returns APIResult.Success(appSwitchResponse)
-
-            every {
-                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-            } returns launchResult
-
-            // When
-            val result = sut.vaultAsync(activity, request)
-
-            // Then
-            verify {
-                payPalWebLauncher.launchWithUrl(
-                    context = activity,
-                    uri = any(),
-                    token = "fake-setup-token-id",
-                    tokenType = TokenType.VAULT_ID,
-                    returnToAppStrategy = any()
-                )
-            }
-            assertSame(launchResult, result)
-        }
-
-    @Test
-    fun `vault() falls back to web vault when app switch request fails`() = runTest {
-        // Given
-        every { deviceInspector.isPayPalInstalled } returns true
-        val request = PayPalWebVaultRequest(
-            "fake-setup-token-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-        coEvery {
-            patchCCOWithAppSwitchEligibility(any(), any(), any(), any(), any())
-        } returns APIResult.Failure(PayPalSDKError(1001, "Test vault failure"))
-
-        every {
-            payPalWebLauncher.launchWithUrl(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns launchResult
-
-        // When
-        val result = sut.vaultAsync(activity, request)
-
-        // Then
-        verify {
-            payPalWebLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-setup-token-id",
-                tokenType = TokenType.VAULT_ID,
-                returnToAppStrategy = any()
-            )
-        }
-        assertSame(launchResult, result)
-    }
-
-    @Test
-    fun `start() skips app switch when app switch enabled but PayPal app not installed`() =
-        runTest {
-            // Given
-            every { deviceInspector.isPayPalInstalled } returns false
-            val request = PayPalWebCheckoutRequest(
-                "fake-order-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-            every {
-                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-            } returns launchResult
-
-            // When
-            val result = sut.startAsync(activity, request)
-
-            // Then
-            coVerify(exactly = 0) {
-                patchCCOWithAppSwitchEligibility.invoke(any(), any(), any(), any(), any())
-            }
-            verify {
-                payPalWebLauncher.launchWithUrl(
-                    context = activity,
-                    uri = any(),
-                    token = "fake-order-id",
-                    tokenType = TokenType.ORDER_ID,
-                    returnToAppStrategy = any()
-                )
-            }
-            assertSame(launchResult, result)
-        }
-
-    @Test
-    fun `vault() skips app switch when app switch enabled but PayPal app not installed`() =
-        runTest {
-            // Given
-            every { deviceInspector.isPayPalInstalled } returns false
-            val request = PayPalWebVaultRequest(
-                "fake-setup-token-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-            every {
-                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-            } returns launchResult
-
-            // When
-            val result = sut.vaultAsync(activity, request)
-
-            // Then
-            coVerify(exactly = 0) {
-                patchCCOWithAppSwitchEligibility.invoke(any(), any(), any(), any(), any())
-            }
-            verify {
-                payPalWebLauncher.launchWithUrl(
-                    context = activity,
-                    uri = any(),
-                    token = "fake-setup-token-id",
-                    tokenType = TokenType.VAULT_ID,
-                    returnToAppStrategy = any()
-                )
-            }
-            assertSame(launchResult, result)
-        }
-
     @Test
     fun `finishVault() with session auth state returns null when start has not been called`() {
         assertNull(sut.finishVault(intent))
     }
-
-    @Test
-    fun `finishVault() with session auth state forwards success result from auth launcher`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-        val previousClient = PayPalWebCheckoutClient(
-            analytics = analytics,
-            payPalWebLauncher = payPalWebLauncher,
-            sessionStore = PayPalWebCheckoutSessionStore(),
-            updateClientConfigAPI = updateClientConfigAPI,
-            deviceInspector = deviceInspector,
-            coreConfig = coreConfig,
-            patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
-            createShopperSessionAPI = createShopperSessionAPI
-        )
-
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val successResult =
-            PayPalWebCheckoutFinishVaultResult.Success("fake-approval-session-id")
-        every {
-            payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-        } returns successResult
-
-            previousClient.vaultAsync(
-                activity,
-                PayPalWebVaultRequest(
-                    "fake-setup-token-id",
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            )
-
-            sut.restore(previousClient.instanceState)
-            val result = sut.finishVault(intent) as PayPalWebCheckoutFinishVaultResult.Success
-            assertSame("fake-approval-session-id", result.approvalSessionId)
-        }
-
-    @Test
-    fun `finishVault() with restored session auth state forwards success result from auth launcher`() =
-        runTest {
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-        val previousClient = PayPalWebCheckoutClient(
-            analytics = analytics,
-            payPalWebLauncher = payPalWebLauncher,
-            sessionStore = PayPalWebCheckoutSessionStore(),
-            updateClientConfigAPI = updateClientConfigAPI,
-            deviceInspector = deviceInspector,
-            coreConfig = coreConfig,
-            patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
-            createShopperSessionAPI = createShopperSessionAPI
-        )
-
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-            val successResult =
-                PayPalWebCheckoutFinishVaultResult.Success("fake-approval-session-id")
-            every {
-                payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-            } returns successResult
-
-            previousClient.vaultAsync(
-                activity,
-                PayPalWebVaultRequest(
-                    "fake-setup-token-id",
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            )
-
-        sut.restore(previousClient.instanceState)
-        val result = sut.finishVault(intent) as PayPalWebCheckoutFinishVaultResult.Success
-        assertSame("fake-approval-session-id", result.approvalSessionId)
-    }
-
-    @Test
-    fun `finishVault() with session auth state forwards error result from auth launcher`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val error = PayPalSDKError(123, "fake-error-description")
-        every {
-            payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-        } returns PayPalWebCheckoutFinishVaultResult.Failure(error)
-
-            sut.vaultAsync(
-                activity,
-                PayPalWebVaultRequest(
-                    "fake-setup-token-id",
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            )
-        val result = sut.finishVault(intent) as PayPalWebCheckoutFinishVaultResult.Failure
-        assertSame(error, result.error)
-    }
-
-    @Test
-    fun `finishVault() with restored session auth state forwards error result from auth launcher`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val error = PayPalSDKError(123, "fake-error-description")
-        every {
-            payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-        } returns PayPalWebCheckoutFinishVaultResult.Failure(error)
-
-            sut.vaultAsync(
-                activity,
-                PayPalWebVaultRequest(
-                    "fake-setup-token-id",
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            )
-
-            sut.restore(sut.instanceState)
-        val result = sut.finishVault(intent) as PayPalWebCheckoutFinishVaultResult.Failure
-        assertSame(error, result.error)
-    }
-
-    @Test
-    fun `finishVault() with session auth state forwards cancellation result from auth launcher`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        every {
-            payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-        } returns PayPalWebCheckoutFinishVaultResult.Canceled
-
-            sut.vaultAsync(
-                activity,
-                PayPalWebVaultRequest(
-                    "fake-setup-token-id",
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            )
-        val result = sut.finishVault(intent)
-        assertSame(PayPalWebCheckoutFinishVaultResult.Canceled, result)
-    }
-
-    @Test
-    fun `finishVault() with restored session auth state forwards cancellation result from auth launcher`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        every {
-            payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-        } returns PayPalWebCheckoutFinishVaultResult.Canceled
-
-            sut.vaultAsync(
-                activity,
-                PayPalWebVaultRequest(
-                    "fake-setup-token-id",
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            )
-
-            sut.restore(sut.instanceState)
-        val result = sut.finishVault(intent)
-        assertSame(PayPalWebCheckoutFinishVaultResult.Canceled, result)
-    }
-
-    @Test
-    fun `finishVault() with session auth state clears session to prevent delivering success event twice`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val successResult =
-            PayPalWebCheckoutFinishVaultResult.Success("fake-approval-session-id")
-        every {
-            payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-        } returns successResult
-
-            sut.vaultAsync(
-                activity,
-                PayPalWebVaultRequest(
-                    "fake-setup-token-id",
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            )
-        sut.finishVault(intent)
-        assertNull(sut.finishVault(intent))
-    }
-
-    @Test
-    fun `finishVault() with session auth state clears session to prevent delivering error event twice`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        val error = PayPalSDKError(123, "fake-error-description")
-        every {
-            payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-        } returns PayPalWebCheckoutFinishVaultResult.Failure(error)
-
-            sut.vaultAsync(
-                activity,
-                PayPalWebVaultRequest(
-                    "fake-setup-token-id",
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            )
-        sut.finishVault(intent)
-        assertNull(sut.finishVault(intent))
-    }
-
-    @Test
-    fun `finishVault() with session auth state clears session to prevent delivering cancellation event twice`() =
-        runTest {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-            every {
-                payPalWebLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-        every {
-            payPalWebLauncher.completeVaultAuthRequest(intent, "auth state")
-        } returns PayPalWebCheckoutFinishVaultResult.Canceled
-
-            sut.vaultAsync(
-                activity,
-                PayPalWebVaultRequest(
-                    "fake-setup-token-id",
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            )
-        sut.finishVault(intent)
-        assertNull(sut.finishVault(intent))
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `start() with deprecated urlScheme constructor passes urlScheme to launcher`() = runTest {
-        val mockLauncher = mockk<PayPalWebLauncher>(relaxed = true)
-        val clientWithUrlScheme = PayPalWebCheckoutClient(
-            analytics = analytics,
-            payPalWebLauncher = mockLauncher,
-            sessionStore = PayPalWebCheckoutSessionStore(),
-            updateClientConfigAPI = updateClientConfigAPI,
-            patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
-            createShopperSessionAPI = createShopperSessionAPI,
-            deviceInspector = deviceInspector,
-            coreConfig = coreConfig,
-            urlScheme = urlScheme
-        )
-
-        val request = PayPalWebCheckoutRequest("fake-order-id")
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-        every {
-            mockLauncher.launchWithUrl(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns launchResult
-
-        // When
-        clientWithUrlScheme.startAsync(activity, request)
-
-        // Then
-        verify {
-            mockLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-order-id",
-                tokenType = TokenType.ORDER_ID,
-                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(urlScheme)
-            )
-        }
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `vault() with deprecated urlScheme constructor passes urlScheme to launcher`() = runTest {
-        val mockLauncher = mockk<PayPalWebLauncher>(relaxed = true)
-        val clientWithUrlScheme = PayPalWebCheckoutClient(
-            analytics = analytics,
-            payPalWebLauncher = mockLauncher,
-            sessionStore = PayPalWebCheckoutSessionStore(),
-            updateClientConfigAPI = updateClientConfigAPI,
-            patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
-            createShopperSessionAPI = createShopperSessionAPI,
-            deviceInspector = deviceInspector,
-            coreConfig = coreConfig,
-            urlScheme = urlScheme
-        )
-
-        val request = PayPalWebVaultRequest("fake-setup-token-id")
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-        every {
-            mockLauncher.launchWithUrl(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns launchResult
-
-        // When
-        clientWithUrlScheme.vaultAsync(activity, request)
-
-        // Then
-        verify {
-            mockLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-setup-token-id",
-                tokenType = TokenType.VAULT_ID,
-                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(urlScheme)
-            )
-        }
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `start() with deprecated urlScheme constructor and AppLink in request prioritizes AppLink`() =
-        runTest {
-            val mockLauncher = mockk<PayPalWebLauncher>(relaxed = true)
-            val clientWithUrlScheme = PayPalWebCheckoutClient(
-                analytics = analytics,
-                payPalWebLauncher = mockLauncher,
-                sessionStore = PayPalWebCheckoutSessionStore(),
-                updateClientConfigAPI = updateClientConfigAPI,
-                patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
-            createShopperSessionAPI = createShopperSessionAPI,
-                deviceInspector = deviceInspector,
-                coreConfig = coreConfig,
-                urlScheme = urlScheme
-            )
-
-            val appLinkUrl = "https://example.com/return"
-            val request = PayPalWebCheckoutRequest(
-                "fake-order-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-            every {
-                mockLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-            // When
-            clientWithUrlScheme.startAsync(activity, request)
-
-            // Then
-            verify {
-                mockLauncher.launchWithUrl(
-                    context = activity,
-                    uri = any(),
-                    token = "fake-order-id",
-                    tokenType = TokenType.ORDER_ID,
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            }
-        }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `vault() with deprecated urlScheme constructor and AppLink in request prioritizes AppLink`() =
-        runTest {
-            val mockLauncher = mockk<PayPalWebLauncher>(relaxed = true)
-            val clientWithUrlScheme = PayPalWebCheckoutClient(
-                analytics = analytics,
-                payPalWebLauncher = mockLauncher,
-                sessionStore = PayPalWebCheckoutSessionStore(),
-                updateClientConfigAPI = updateClientConfigAPI,
-                patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
-            createShopperSessionAPI = createShopperSessionAPI,
-                deviceInspector = deviceInspector,
-                coreConfig = coreConfig,
-                urlScheme = urlScheme
-            )
-
-            val appLinkUrl = "https://example.com/vault/return"
-            val request = PayPalWebVaultRequest(
-                "fake-setup-token-id",
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-            val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-
-            every {
-                mockLauncher.launchWithUrl(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
-                )
-            } returns launchResult
-
-            // When
-            clientWithUrlScheme.vaultAsync(activity, request)
-
-            // Then
-            verify {
-                mockLauncher.launchWithUrl(
-                    context = activity,
-                    uri = any(),
-                    token = "fake-setup-token-id",
-                    tokenType = TokenType.VAULT_ID,
-                    returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-                )
-            }
-        }
-
     // MARK: - Tests for Deprecated Methods
-
-    @Test
-    fun `deprecated start() calls analytics and launchWithUrl correctly`() {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns launchResult
-
-        val request = PayPalWebCheckoutRequest(
-            "fake-order-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-        val result = sut.start(activity, request)
-
-        // Verify it returns the launch result
-        assertSame(launchResult, result)
-
-        // Verify launchWithUrl is called (the deprecated method calls it directly)
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-order-id",
-                tokenType = TokenType.ORDER_ID,
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-        }
-    }
-
-    @Test
-    fun `deprecated start() handles failure correctly`() {
-        val sdkError = PayPalSDKError(123, "fake error description")
-        val launchResult = PayPalPresentAuthChallengeResult.Failure(sdkError)
-        every {
-            payPalWebLauncher.launchWithUrl(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns launchResult
-
-        val request = PayPalWebCheckoutRequest(
-            "fake-order-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-        val result = sut.start(activity, request) as PayPalPresentAuthChallengeResult.Failure
-
-        assertSame(sdkError, result.error)
-    }
-
-    @Test
-    fun `deprecated vault() calls analytics and launchWithUrl correctly`() {
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns launchResult
-
-        val appLinkUrl = "https://example.com/vault/return"
-        val request = PayPalWebVaultRequest(
-            "fake-setup-token-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-        val result = sut.vault(activity, request)
-
-        // Verify it returns the launch result
-        assertSame(launchResult, result)
-
-        // Verify launchWithUrl is called (the deprecated method calls it directly)
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-setup-token-id",
-                tokenType = TokenType.VAULT_ID,
-                returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-            )
-        }
-    }
-
-    @Test
-    fun `deprecated vault() handles failure correctly`() {
-        val sdkError = PayPalSDKError(123, "fake error description")
-        val launchResult = PayPalPresentAuthChallengeResult.Failure(sdkError)
-        every {
-            payPalWebLauncher.launchWithUrl(
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns launchResult
-
-        val appLinkUrl = "https://example.com/vault/return"
-        val request = PayPalWebVaultRequest(
-            "fake-setup-token-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-        val result = sut.vault(activity, request) as PayPalPresentAuthChallengeResult.Failure
-
-        assertSame(sdkError, result.error)
-    }
-
     // MARK: - Tests for Callback-based Methods
     // Note: Callback-based methods use applicationScope.launch which doesn't integrate well
     // with test coroutine dispatchers, so these are tested implicitly through the methods they call
-
-    @Test
-    fun `start() with callback method exists and can be called`() {
-        // This test just verifies the callback method can be called without throwing
-        val callback = mockk<PayPalWebStartCallback>(relaxed = true)
-        val request = PayPalWebCheckoutRequest(
-            "fake-order-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-
-        // Mock the async dependencies to avoid side effects
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns PayPalPresentAuthChallengeResult.Success("auth state")
-
-        // This should not throw an exception
-        sut.start(activity, request, callback)
-    }
-
-    @Test
-    fun `vault() with callback method exists and can be called`() {
-        // This test just verifies the callback method can be called without throwing
-        val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
-        val request = PayPalWebVaultRequest(
-            "fake-setup-token-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-
-        // Mock the async dependencies to avoid side effects
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns PayPalPresentAuthChallengeResult.Success("auth state")
-
-        // This should not throw an exception
-        sut.vault(activity, request, callback)
-    }
-
     // Tests for returnToAppStrategy functionality
-
-    @Test
-    fun `startAsync() uses CustomUrlScheme when provided`() = runTest {
-        val fallbackScheme = "com.example.fallback"
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebCheckoutRequest(
-            orderId = "fake-order-id",
-            returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
-        )
-        sut.startAsync(activity, request)
-
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-order-id",
-                tokenType = TokenType.ORDER_ID,
-                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
-            )
-        }
-    }
-
-    @Test
-    fun `startAsync() uses default urlScheme when returnToAppStrategy is null`() = runTest {
-        // Create a client with urlScheme
-        val clientWithUrlScheme = PayPalWebCheckoutClient(
-            analytics = analytics,
-            payPalWebLauncher = payPalWebLauncher,
-            sessionStore = PayPalWebCheckoutSessionStore(),
-            updateClientConfigAPI = updateClientConfigAPI,
-            patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
-            createShopperSessionAPI = createShopperSessionAPI,
-            deviceInspector = deviceInspector,
-            coreConfig = coreConfig,
-            urlScheme = urlScheme
-        )
-
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebCheckoutRequest(
-            orderId = "fake-order-id",
-            returnToAppStrategy = null
-        )
-        clientWithUrlScheme.startAsync(activity, request)
-
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-order-id",
-                tokenType = TokenType.ORDER_ID,
-                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(urlScheme)
-            )
-        }
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `start() with deprecated method uses CustomUrlScheme when provided`() {
-        val fallbackScheme = "com.example.fallback"
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebCheckoutRequest(
-            orderId = "fake-order-id",
-            returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
-        )
-        sut.start(activity, request)
-
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-order-id",
-                tokenType = TokenType.ORDER_ID,
-                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
-            )
-        }
-    }
-
-    @Test
-    fun `startAsync() with CustomUrlScheme uses CustomUrlScheme when provided`() = runTest {
-        val fallbackScheme = "com.example.fallback"
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebCheckoutRequest(
-            orderId = "fake-order-id",
-            returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
-        )
-        sut.startAsync(activity, request)
-
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-order-id",
-                tokenType = TokenType.ORDER_ID,
-                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
-            )
-        }
-    }
-
-    @Test
-    fun `vaultAsync() uses CustomUrlScheme when provided`() = runTest {
-        val fallbackScheme = "com.example.fallback"
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebVaultRequest(
-            setupTokenId = "fake-setup-token-id",
-            returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
-        )
-        sut.vaultAsync(activity, request)
-
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-setup-token-id",
-                tokenType = TokenType.VAULT_ID,
-                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
-            )
-        }
-    }
-
-    @Test
-    fun `vaultAsync() uses default urlScheme when returnToAppStrategy is null`() = runTest {
-        // Create a client with urlScheme
-        val clientWithUrlScheme = PayPalWebCheckoutClient(
-            analytics = analytics,
-            payPalWebLauncher = payPalWebLauncher,
-            sessionStore = PayPalWebCheckoutSessionStore(),
-            updateClientConfigAPI = updateClientConfigAPI,
-            patchCCOWithAppSwitchEligibility = patchCCOWithAppSwitchEligibility,
-            createShopperSessionAPI = createShopperSessionAPI,
-            deviceInspector = deviceInspector,
-            coreConfig = coreConfig,
-            urlScheme = urlScheme
-        )
-
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebVaultRequest(
-            setupTokenId = "fake-setup-token-id",
-            returnToAppStrategy = null
-        )
-        clientWithUrlScheme.vaultAsync(activity, request)
-
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-setup-token-id",
-                tokenType = TokenType.VAULT_ID,
-                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(urlScheme)
-            )
-        }
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `vault() with deprecated method uses CustomUrlScheme when provided`() {
-        val fallbackScheme = "com.example.fallback"
-        val launchResult = PayPalPresentAuthChallengeResult.Success("auth state")
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns launchResult
-
-        val request = PayPalWebVaultRequest(
-            setupTokenId = "fake-setup-token-id",
-            returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
-        )
-        sut.vault(activity, request)
-
-        verify(exactly = 1) {
-            payPalWebLauncher.launchWithUrl(
-                context = activity,
-                uri = any(),
-                token = "fake-setup-token-id",
-                tokenType = TokenType.VAULT_ID,
-                returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
-            )
-        }
-    }
-
-    @Test
-    fun `vault() with callback uses CustomUrlScheme when provided`() {
-        // This test verifies the callback method can be called with CustomUrlScheme without throwing
-        val fallbackScheme = "com.example.fallback"
-        val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns PayPalPresentAuthChallengeResult.Success("auth state")
-
-        val request = PayPalWebVaultRequest(
-            setupTokenId = "fake-setup-token-id",
-            returnToAppStrategy = ReturnToAppStrategy.CustomUrlScheme(fallbackScheme)
-        )
-
-        // This should not throw an exception
-        sut.vault(activity, request, callback)
-    }
-
-    @Test
-    fun `vault() with callback uses default urlScheme when returnToAppStrategy is null`() {
-        // This test verifies the callback method can be called with null returnToAppStrategy without throwing
-        val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns PayPalPresentAuthChallengeResult.Success("auth state")
-
-        val request = PayPalWebVaultRequest(
-            setupTokenId = "fake-setup-token-id",
-            returnToAppStrategy = null
-        )
-
-        // This should not throw an exception
-        sut.vault(activity, request, callback)
-    }
-
     // MARK: - V3 Methods (createPayPalSession / start(orderId) / vault(setupTokenId))
 
-    // Build a client with urlScheme so launchCheckoutWithSession / launchVaultWithSession
-    // can resolve a ReturnToAppStrategy via the fallback path.
     // Inject test-controlled applicationScope so coroutines launched by v3 methods
     // run on the test scheduler and are drained by testDispatcher.scheduler.advanceUntilIdle().
-    private fun makeSutWithUrlScheme(): PayPalWebCheckoutClient = PayPalWebCheckoutClient(
+    private fun makeSutWithTestScope(): PayPalWebCheckoutClient = PayPalWebCheckoutClient(
             analytics = analytics,
             payPalWebLauncher = payPalWebLauncher,
             sessionStore = PayPalWebCheckoutSessionStore(),
@@ -1716,7 +140,6 @@ class PayPalWebCheckoutClientUnitTest {
             createShopperSessionAPI = createShopperSessionAPI,
             deviceInspector = deviceInspector,
             coreConfig = coreConfig,
-            urlScheme = urlScheme,
             applicationScope = CoroutineScope(SupervisorJob() + testDispatcher),
     )
 
@@ -1762,7 +185,7 @@ class PayPalWebCheckoutClientUnitTest {
 
     @Test
     fun `start() with orderId launches checkout when session resolves successfully`() = runTest {
-        val sutV3 = makeSutWithUrlScheme()
+        val sutV3 = makeSutWithTestScope()
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth-state")
         every { payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any()) } returns launchResult
 
@@ -1791,7 +214,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `start() with orderId includes shopperSessionId in the launch uri when the session id is non-blank`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             val uriSlot = slot<Uri>()
             every {
                 payPalWebLauncher.launchWithUrl(any(), capture(uriSlot), any(), any(), any())
@@ -1813,7 +236,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `start() with orderId omits shopperSessionId from the launch uri when the session id is blank`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             val uriSlot = slot<Uri>()
             every {
                 payPalWebLauncher.launchWithUrl(any(), capture(uriSlot), any(), any(), any())
@@ -1843,7 +266,7 @@ class PayPalWebCheckoutClientUnitTest {
 
     @Test
     fun `start() with orderId includes observability query params on the launch uri`() = runTest {
-        val sutV3 = makeSutWithUrlScheme()
+        val sutV3 = makeSutWithTestScope()
         val uriSlot = slot<Uri>()
         val beforeMillis = System.currentTimeMillis()
         every {
@@ -1875,7 +298,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `start() with orderId delivers failure without falling back to patchCCO when createShopperSession throws`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             val callback = mockk<PayPalWebStartCallback>(relaxed = true)
             sutV3.createPayPalSession(
                 tokenType = TokenType.ORDER_ID,
@@ -1906,7 +329,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `start() falls back to patchCCO when shopper session fetch reports a session-creation-or-network failure`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every { deviceInspector.isPayPalInstalled } returns true
             val callback = mockk<PayPalWebStartCallback>(relaxed = true)
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth-state")
@@ -1965,7 +388,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `start() appends token and strips a trailing ampersand from the patchCCO launch url`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every { deviceInspector.isPayPalInstalled } returns true
             val callback = mockk<PayPalWebStartCallback>(relaxed = true)
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth-state")
@@ -2004,7 +427,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `start() with orderId clears session deferred so a second call returns SESSION_NOT_CREATED`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every { payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any()) } returns
                 PayPalPresentAuthChallengeResult.Success("auth-state")
 
@@ -2052,7 +475,7 @@ class PayPalWebCheckoutClientUnitTest {
 
     @Test
     fun `vault() with setupTokenId launches vault when session resolves successfully`() = runTest {
-        val sutV3 = makeSutWithUrlScheme()
+        val sutV3 = makeSutWithTestScope()
         val launchResult = PayPalPresentAuthChallengeResult.Success("auth-state")
         every { payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any()) } returns launchResult
 
@@ -2080,7 +503,7 @@ class PayPalWebCheckoutClientUnitTest {
 
     @Test
     fun `vault() with setupTokenId includes observability query params on the launch uri`() = runTest {
-        val sutV3 = makeSutWithUrlScheme()
+        val sutV3 = makeSutWithTestScope()
         val uriSlot = slot<Uri>()
         val beforeMillis = System.currentTimeMillis()
         every {
@@ -2113,7 +536,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `vault() with setupTokenId delivers failure without patchCCO fallback when createShopperSession throws`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
             sutV3.createPayPalSession(
                 tokenType = TokenType.VAULT_ID,
@@ -2144,7 +567,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `vault() falls back to patchCCO when shopper session fetch reports a session-creation-or-network failure`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every { deviceInspector.isPayPalInstalled } returns true
             val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth-state")
@@ -2203,7 +626,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `vault() falls back to a vault URI, not a checkout URI, when patchCCO has no launch url`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every { deviceInspector.isPayPalInstalled } returns false
             val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
             val launchResult = PayPalPresentAuthChallengeResult.Success("auth-state")
@@ -2367,7 +790,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `vault() with setupTokenId clears session deferred so a second call returns SESSION_NOT_CREATED`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every { payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any()) } returns
                 PayPalPresentAuthChallengeResult.Success("auth-state")
 
@@ -2400,20 +823,12 @@ class PayPalWebCheckoutClientUnitTest {
         ineligibleReason = if (launchUrl.isNullOrEmpty()) "App switch not eligible" else null
     )
 
-    private fun createAppSwitchEligibilityResponse(redirectURL: String?): AppSwitchEligibility {
-        return AppSwitchEligibility(
-            appSwitchEligible = true,
-            launchUrl = redirectURL,
-            ineligibleReason = null
-        )
-    }
-
     // MARK: - Additional coverage: app-switch-eligible redirectUrl, failure analytics, noReturnToAppStrategyError
 
     @Test
     fun `start() with orderId prefers redirectUrl over checkoutFallbackUrl when app-switch eligible and installed`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every { deviceInspector.isPayPalInstalled } returns true
             every { deviceInspector.canResolvePayPalAppSwitch() } returns true
             val uriSlot = slot<Uri>()
@@ -2450,7 +865,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `start() with orderId uses checkoutFallbackUrl when app-switch eligible but not installed`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every { deviceInspector.isPayPalInstalled } returns false
             val uriSlot = slot<Uri>()
             every {
@@ -2486,7 +901,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `vault() with setupTokenId uses redirectUrl when session is app-switch eligible and app is installed`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every { deviceInspector.isPayPalInstalled } returns true
             every { deviceInspector.canResolvePayPalAppSwitch() } returns true
             val uriSlot = slot<Uri>()
@@ -2527,7 +942,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `vault() with setupTokenId uses ba_token as the param name when session tokenType is BILLING_TOKEN`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every { deviceInspector.isPayPalInstalled } returns true
             every { deviceInspector.canResolvePayPalAppSwitch() } returns true
             val uriSlot = slot<Uri>()
@@ -2568,7 +983,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `start() with orderId notifies checkout failure analytics when launch fails after session resolves`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             val sdkError = PayPalSDKError(123, "fake error description")
             every {
                 payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
@@ -2614,7 +1029,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `vault() with setupTokenId notifies vault failure analytics when launch fails after session resolves`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             val sdkError = PayPalSDKError(123, "fake error description")
             every {
                 payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
@@ -2660,7 +1075,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `start() with orderId notifies checkout failure analytics when the shopper session fetch throws`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             val callback = mockk<PayPalWebStartCallback>(relaxed = true)
             sutV3.createPayPalSession(
                 tokenType = TokenType.ORDER_ID,
@@ -2696,7 +1111,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `vault() with setupTokenId notifies vault failure analytics when the shopper session fetch throws`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
             sutV3.createPayPalSession(
                 tokenType = TokenType.VAULT_ID,
@@ -2728,44 +1143,12 @@ class PayPalWebCheckoutClientUnitTest {
                 )
             }
         }
-
-    @Test
-    fun `startAsync() delivers noReturnToAppStrategyError when strategy and urlScheme are absent`() =
-        runTest {
-            val request = PayPalWebCheckoutRequest(
-                orderId = "fake-order-id",
-                returnToAppStrategy = null
-            )
-
-            val result = sut.startAsync(activity, request) as PayPalPresentAuthChallengeResult.Failure
-
-            assertSame(PayPalWebCheckoutError.noReturnToAppStrategyError, result.error)
-            verify(exactly = 0) {
-                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-            }
-        }
-
-    @Test
-    fun `vaultAsync() delivers noReturnToAppStrategyError when strategy and urlScheme are absent`() =
-        runTest {
-            val request = PayPalWebVaultRequest(
-                setupTokenId = "fake-setup-token-id",
-                returnToAppStrategy = null
-            )
-
-            val result = sut.vaultAsync(activity, request) as PayPalPresentAuthChallengeResult.Failure
-
-            assertSame(PayPalWebCheckoutError.noReturnToAppStrategyError, result.error)
-            verify(exactly = 0) {
-                payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-            }
-        }
     // MARK: - Latency Analytics Tests
 
     @Test
     fun `start() emits user-perceived-latency with checkout flow and browser presentation`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every {
                 payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
             } returns PayPalPresentAuthChallengeResult.Success("auth state")
@@ -2794,7 +1177,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `start() emits user-perceived-latency with app-switch presentation when eligible and installed`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every { deviceInspector.isPayPalInstalled } returns true
             every { deviceInspector.canResolvePayPalAppSwitch() } returns true
             every {
@@ -2828,7 +1211,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `start() emits user-perceived-latency with error presentation on launch failure`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             val sdkError = PayPalSDKError(123, "fake error description")
             every {
                 payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
@@ -2875,7 +1258,7 @@ class PayPalWebCheckoutClientUnitTest {
     @Test
     fun `vault() emits user-perceived-latency with vault flow`() =
         runTest {
-            val sutV3 = makeSutWithUrlScheme()
+            val sutV3 = makeSutWithTestScope()
             every {
                 payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
             } returns PayPalPresentAuthChallengeResult.Success("auth state")
@@ -2899,25 +1282,4 @@ class PayPalWebCheckoutClientUnitTest {
                 )
             }
         }
-
-    @Test
-    fun `startAsync() does not emit api-request-latency when timing is absent`() = runTest {
-        every {
-            payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
-        } returns PayPalPresentAuthChallengeResult.Success("auth state")
-
-        coEvery {
-            updateClientConfigAPI.updateClientConfig(any(), any())
-        } returns UpdateClientConfigResult.Success(roundTripTiming = null)
-
-        val request = PayPalWebCheckoutRequest(
-            "fake-order-id",
-            returnToAppStrategy = ReturnToAppStrategy.AppLink(appLinkUrl)
-        )
-        sut.startAsync(activity, request)
-
-        verify(exactly = 0) {
-            analytics.notifyApiRequestLatency(any(), any(), any())
-        }
-    }
 }


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 Removes the 7 @Deprecated members from PayPalWebCheckoutClient and the private methods used only by them:

- 3-arg (urlScheme) constructor
- start(activity, request)
- start(activity, request, callback)
- vault(activity, request)
- vault(activity, request, callback)
- finishStart(intent, authState)
- finishVault(intent, authState)
- private startAsync / vaultAsync and their now-orphaned helpers (buildPayPalCheckoutUri, buildPayPalVaultUri, baseUrl, resolveReturnToAppStrategy), plus the dead urlScheme param and unused imports.
- Kept the 4-arg getLaunchUri helper and updateClientConfigAPI for the in-flight https://github.com/paypal/paypal-android/pull/468/ work.

 ### Checklist

 - [ ] Added a changelog entry N/A

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @ayer-ribeiro
