### PR TITLE
New SESSION_CREATION_FAILED Error

### DIFF
--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -10,6 +10,7 @@ import androidx.core.net.toUri
 import com.paypal.android.corepayments.CoreConfig
 import com.paypal.android.corepayments.Environment
 import com.paypal.android.corepayments.HttpRoundTripTiming
+import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.corepayments.ReturnToAppStrategy
 import com.paypal.android.corepayments.UpdateClientConfigAPI
 import com.paypal.android.corepayments.analytics.AnalyticsService
@@ -166,21 +167,18 @@ class PayPalWebCheckoutClient internal constructor(
                 setShopperSessionAnalyticsParams(shopperSession)
                 analytics.notify(CheckoutEvent.STARTED, params = appSwitchAnalyticsEventParams)
 
-                val result = if (shopperSession != null) {
-                    launchCheckoutWithShopperSession(
+                if (shopperSession != null) {
+                    val result = launchCheckoutWithShopperSession(
                         activity = activity,
                         shopperSession = shopperSession,
                         orderId = orderId,
                         startTime = startTime,
                     )
+                    withContext(Dispatchers.Main) {
+                        callback.onPayPalWebStartResult(result)
+                    }
                 } else {
-                    launchCheckoutViaPatchCCOFallback(
-                        activity = activity,
-                        orderId = orderId,
-                    )
-                }
-                withContext(Dispatchers.Main) {
-                    callback.onPayPalWebStartResult(result)
+                    throw PayPalWebCheckoutError.sessionCreationFailedError
                 }
             } catch (e: Exception) {
                 analytics.notify(
@@ -192,7 +190,7 @@ class PayPalWebCheckoutClient internal constructor(
                 withContext(Dispatchers.Main) {
                     callback.onPayPalWebStartResult(
                         PayPalPresentAuthChallengeResult.Failure(
-                            PayPalWebCheckoutError.browserSwitchError(e)
+                            e as? PayPalSDKError ?: PayPalWebCheckoutError.browserSwitchError(e)
                         )
                     )
                 }
@@ -249,21 +247,18 @@ class PayPalWebCheckoutClient internal constructor(
                 setShopperSessionAnalyticsParams(shopperSession)
                 analytics.notify(VaultEvent.STARTED, params = appSwitchAnalyticsEventParams)
 
-                val result = if (shopperSession != null) {
-                    launchVaultWithSession(
+                if (shopperSession != null) {
+                    val result = launchVaultWithSession(
                         activity = activity,
                         shopperSession = shopperSession,
                         setupTokenId = setupTokenId,
                         startTime = startTime,
                     )
+                    withContext(Dispatchers.Main) {
+                        callback.onPayPalWebVaultResult(result)
+                    }
                 } else {
-                    launchVaultViaPatchCCOFallback(
-                        activity = activity,
-                        setupTokenId = setupTokenId,
-                    )
-                }
-                withContext(Dispatchers.Main) {
-                    callback.onPayPalWebVaultResult(result)
+                    throw PayPalWebCheckoutError.sessionCreationFailedError
                 }
             } catch (e: Exception) {
                 analytics.notify(
@@ -275,7 +270,7 @@ class PayPalWebCheckoutClient internal constructor(
                 withContext(Dispatchers.Main) {
                     callback.onPayPalWebVaultResult(
                         PayPalPresentAuthChallengeResult.Failure(
-                            PayPalWebCheckoutError.browserSwitchError(e)
+                            e as? PayPalSDKError ?: PayPalWebCheckoutError.browserSwitchError(e)
                         )
                     )
                 }
@@ -529,40 +524,6 @@ class PayPalWebCheckoutClient internal constructor(
                 )
             }
         }
-    }
-
-    /**
-     * Launches checkout after the Shopper Session fetch failed with a session-creation
-     * failure or network timeout.
-     *
-     * TODO: Re-implement fallback behavior for session-creation failure. This previously
-     *  fell back to the legacy patchCCO path via [getLaunchUri] (see git history / PR diff
-     *  for the removed implementation). Removed pending a decision on the replacement
-     *  behavior — currently unhandled.
-     */
-    @Suppress("UnusedPrivateMember")
-    private suspend fun launchCheckoutViaPatchCCOFallback(
-        activity: Activity,
-        orderId: String,
-    ): PayPalPresentAuthChallengeResult {
-        TODO("Re-implement checkout fallback for session-creation failure (patchCCO fallback removed)")
-    }
-
-    /**
-     * Launches vault after the Shopper Session fetch failed with a session-creation failure
-     * or network timeout. See [launchCheckoutViaPatchCCOFallback].
-     *
-     * TODO: Re-implement fallback behavior for session-creation failure. This previously
-     *  fell back to the legacy patchCCO path via [getLaunchUri] (see git history / PR diff
-     *  for the removed implementation). Removed pending a decision on the replacement
-     *  behavior — currently unhandled.
-     */
-    @Suppress("UnusedPrivateMember")
-    private suspend fun launchVaultViaPatchCCOFallback(
-        activity: Activity,
-        setupTokenId: String,
-    ): PayPalPresentAuthChallengeResult {
-        TODO("Re-implement vault fallback for session-creation failure (patchCCO fallback removed)")
     }
 
     @VisibleForTesting

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -190,7 +190,7 @@ class PayPalWebCheckoutClient internal constructor(
                 withContext(Dispatchers.Main) {
                     callback.onPayPalWebStartResult(
                         PayPalPresentAuthChallengeResult.Failure(
-                            e as? PayPalSDKError ?: PayPalWebCheckoutError.browserSwitchError(e)
+                            e as? PayPalSDKError ?: PayPalWebCheckoutError.unknownError
                         )
                     )
                 }
@@ -270,7 +270,7 @@ class PayPalWebCheckoutClient internal constructor(
                 withContext(Dispatchers.Main) {
                     callback.onPayPalWebVaultResult(
                         PayPalPresentAuthChallengeResult.Failure(
-                            e as? PayPalSDKError ?: PayPalWebCheckoutError.browserSwitchError(e)
+                            e as? PayPalSDKError ?: PayPalWebCheckoutError.unknownError
                         )
                     )
                 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/errors/PayPalWebCheckoutError.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/errors/PayPalWebCheckoutError.kt
@@ -33,4 +33,10 @@ internal object PayPalWebCheckoutError {
         code = PayPalWebCheckoutErrorCode.SESSION_NOT_CREATED.ordinal,
         errorDescription = "PayPal Session must be created. Call createPayPalSession()"
     )
+
+    // 5. PayPal Session creation failed
+    val sessionCreationFailedError = PayPalSDKError(
+        code = PayPalWebCheckoutErrorCode.SESSION_CREATION_FAILED.ordinal,
+        errorDescription = "Failed to create PayPal Session"
+    )
 }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/errors/PayPalWebCheckoutErrorCode.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/errors/PayPalWebCheckoutErrorCode.kt
@@ -6,4 +6,5 @@ internal enum class PayPalWebCheckoutErrorCode {
     BROWSER_SWITCH,
     NO_RETURN_TO_APP_STRATEGY,
     SESSION_NOT_CREATED,
+    SESSION_CREATION_FAILED,
 }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -1897,6 +1897,36 @@ class PayPalWebCheckoutClientUnitTest {
             }
         }
 
+    @Test
+    fun `start() with orderId delivers SESSION_CREATION_FAILED when shopperSession resolves to null`() =
+        runTest {
+            val sutV3 = makeSutWithUrlScheme()
+            val callback = mockk<PayPalWebStartCallback>(relaxed = true)
+            sutV3.createPayPalSession(
+                tokenType = TokenType.ORDER_ID,
+                userIdentity = fakeUserIdentity,
+                urlConfig = fakeUrlConfig,
+            )
+            // null represents a session-creation failure / network timeout (any non-LSAT
+            // APIResult.Failure from createShopperSessionWithAppSwitchEligibility).
+            sutV3.shopperSessionDeferred =
+                CompletableDeferred<CreateShopperSessionWithAppSwitchEligibilityResponse?>()
+                    .also { it.complete(null) }
+            sutV3.start(activity, "fake-order-id", callback)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                patchCCOWithAppSwitchEligibility(any(), any(), any(), any(), any())
+            }
+            verify {
+                callback.onPayPalWebStartResult(match {
+                    it is PayPalPresentAuthChallengeResult.Failure &&
+                        it.error.code == PayPalWebCheckoutError.sessionCreationFailedError.code &&
+                        it.error.errorDescription == PayPalWebCheckoutError.sessionCreationFailedError.errorDescription
+                })
+            }
+        }
+
     // --- LLD Section 3.8 fallback-to-patchCCO behavior ---
 
     @Ignore(
@@ -2132,6 +2162,36 @@ class PayPalWebCheckoutClientUnitTest {
             }
             verify {
                 callback.onPayPalWebVaultResult(match { it is PayPalPresentAuthChallengeResult.Failure })
+            }
+        }
+
+    @Test
+    fun `vault() with setupTokenId delivers SESSION_CREATION_FAILED when shopperSession resolves to null`() =
+        runTest {
+            val sutV3 = makeSutWithUrlScheme()
+            val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
+            sutV3.createPayPalSession(
+                tokenType = TokenType.VAULT_ID,
+                userIdentity = fakeUserIdentity,
+                urlConfig = fakeUrlConfig,
+            )
+            // null represents a session-creation failure / network timeout (any non-LSAT
+            // APIResult.Failure from createShopperSessionWithAppSwitchEligibility).
+            sutV3.shopperSessionDeferred =
+                CompletableDeferred<CreateShopperSessionWithAppSwitchEligibilityResponse?>()
+                    .also { it.complete(null) }
+            sutV3.vault(activity, "fake-setup-token-id", callback)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            coVerify(exactly = 0) {
+                patchCCOWithAppSwitchEligibility(any(), any(), any(), any(), any())
+            }
+            verify {
+                callback.onPayPalWebVaultResult(match {
+                    it is PayPalPresentAuthChallengeResult.Failure &&
+                        it.error.code == PayPalWebCheckoutError.sessionCreationFailedError.code &&
+                        it.error.errorDescription == PayPalWebCheckoutError.sessionCreationFailedError.errorDescription
+                })
             }
         }
 


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Adding a new error SESSION_CREATION_FAILED and throwing it when createShopperSessionWithAppSwitchEligibility fails. 

### Evidence

https://github.com/user-attachments/assets/cecf1eca-d0fa-416e-8763-edfa8bda959a


 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
