### PR TITLE
Consolidating Buttons in PayPal Checkout and PayPal Vault

### DIFF
--- a/Demo/src/androidTest/java/com/paypal/android/PayPalCheckoutTest.kt
+++ b/Demo/src/androidTest/java/com/paypal/android/PayPalCheckoutTest.kt
@@ -58,12 +58,13 @@ class PayPalCheckoutTest {
 
         checkoutRobot
             .navigateToPayPalCheckout()
-            .createOrder(
+            .checkoutWithPayPal(
                 appSwitchEnabled = appSwitchEnabled,
                 intent = intent,
-                returnToAppStrategy = returnToAppStrategy
+                returnToAppStrategy = returnToAppStrategy,
+                email = TestConfig.TEST_EMAIL,
+                password = TestConfig.TEST_PASSWORD
             )
-            .startCheckoutWithLogin(TestConfig.TEST_EMAIL, TestConfig.TEST_PASSWORD)
             .completeOrder()
 
         Log.d(TAG, "✅ Test completed successfully!")

--- a/Demo/src/androidTest/java/com/paypal/android/PayPalVaultTest.kt
+++ b/Demo/src/androidTest/java/com/paypal/android/PayPalVaultTest.kt
@@ -57,11 +57,12 @@ class PayPalVaultTest {
 
         robot
             .navigateToPayPalVault()
-            .vaultWithAppSwitch(
+            .vaultWithPayPal(
                 appSwitchEnabled = appSwitchEnabled,
-                returnToAppStrategy = returnToAppStrategy
+                returnToAppStrategy = returnToAppStrategy,
+                email = TestConfig.TEST_EMAIL,
+                password = TestConfig.TEST_PASSWORD
             )
-            .startVaultWithLogin(TestConfig.TEST_EMAIL, TestConfig.TEST_PASSWORD)
             .createPaymentToken()
 
         Log.d(TAG, "✅ Test completed successfully!")

--- a/Demo/src/androidTest/java/com/paypal/android/robots/DemoRobot.kt
+++ b/Demo/src/androidTest/java/com/paypal/android/robots/DemoRobot.kt
@@ -56,7 +56,7 @@ class DemoRobot(
         )
         composeTestRule.onNodeWithText("PayPal Checkout").performClick()
         composeTestRule.waitUntilExactlyOneExists(
-            hasText("Create an Order"),
+            hasText("Launch PayPal"),
             TIMEOUT_LONG_MS
         )
     }
@@ -89,22 +89,47 @@ class DemoRobot(
         )
     }
 
-    fun createOrder(
+    fun clickCheckoutWithPayPal() = apply {
+        composeTestRule.waitUntilExactlyOneExists(hasText("CHECKOUT WITH PAYPAL"), TIMEOUT_LONG_MS)
+        composeTestRule.onNode(hasScrollAction())
+            .performScrollToNode(hasText("CHECKOUT WITH PAYPAL"))
+        composeTestRule.onNodeWithText("CHECKOUT WITH PAYPAL").performClick()
+    }
+
+    /**
+     * Exercises the PayPal Checkout view's single button, which triggers
+     * createPayPalSession(), order creation, and PayPalWebCheckoutClient.start() all from
+     * one tap, then completes the login/approval flow in the browser.
+     */
+    fun checkoutWithPayPal(
         appSwitchEnabled: Boolean,
         intent: String,
-        returnToAppStrategy: ReturnToAppStrategyOption
+        returnToAppStrategy: ReturnToAppStrategyOption,
+        email: String,
+        password: String,
     ) = apply {
         setAppSwitch(appSwitchEnabled)
         setIntent(intent)
         setReturnToAppStrategyOption(returnToAppStrategy)
-        clickCreateOrder()
-        verifyOrderCreated()
+        clickCheckoutWithPayPal()
 
-        // Verify the "ID" label exists, which indicates OrderView is displayed
-        composeTestRule.waitUntilExactlyOneExists(hasText("ID"), TIMEOUT_LONG_MS)
+        // Delegate to web page robot for login
+        Log.d(TAG, "🚪 Starting PayPal checkout with login for email: $email")
+        webPageRobot.checkout(email, password)
+
+        // Wait for return to app and checkout completion
+        waitForAppToReturn()
+
+        composeTestRule.waitUntilExactlyOneExists(hasText("CHECKOUT COMPLETE"), TIMEOUT_LONG_MS)
+
+        // Verify Order ID and Payer ID labels are present
+        composeTestRule.waitUntilExactlyOneExists(hasText("Order ID"))
+        composeTestRule.waitUntilExactlyOneExists(hasText("Payer ID"))
+
         Log.d(
             TAG,
-            "✅ Order created successfully with intent: $intent, returnToAppStrategy: $returnToAppStrategy"
+            "🚀 PayPal checkout with login completed successfully with intent: $intent, " +
+                    "returnToAppStrategy: $returnToAppStrategy"
         )
     }
 
@@ -130,37 +155,6 @@ class DemoRobot(
             StoreInVaultOption.NO -> "NO"
         }
         composeTestRule.onNodeWithText(optionText).performClick()
-    }
-
-    fun startCheckoutWithLogin(email: String, password: String) = apply {
-        // Wait for Step 2 to appear
-        composeTestRule.waitUntilExactlyOneExists(
-            hasText("Launch PayPal"),
-            TIMEOUT_LONG_MS
-        )
-
-        // Click on "START CHECKOUT" button
-        composeTestRule.onNode(hasScrollAction())
-            .performScrollToNode(hasText("START CHECKOUT"))
-
-        composeTestRule
-            .waitUntilExactlyOneExists(hasText("START CHECKOUT"), TIMEOUT_LONG_MS)
-        composeTestRule.onNodeWithText("START CHECKOUT").performClick()
-
-        // Delegate to web page robot for login
-        Log.d(TAG, "🚪 Starting PayPal checkout with login for email: $email")
-        webPageRobot.checkout(email, password)
-
-        // Wait for return to app and checkout completion
-        waitForAppToReturn()
-
-        composeTestRule.waitUntilExactlyOneExists(hasText("CHECKOUT COMPLETE"), TIMEOUT_LONG_MS)
-
-        // Verify Order ID and Payer ID labels are present
-        composeTestRule.waitUntilExactlyOneExists(hasText("Order ID"))
-        composeTestRule.waitUntilExactlyOneExists(hasText("Payer ID"))
-
-        Log.d(TAG, "🚀 PayPal checkout with login completed successfully")
     }
 
     fun completeOrder(intent: String? = null) = apply {
@@ -194,22 +188,42 @@ class DemoRobot(
         )
         composeTestRule.onNodeWithText("Paypal Vault").performClick()
         composeTestRule.waitUntilExactlyOneExists(
-            hasText("Create Setup Token")
+            hasText("Vault PayPal")
         )
     }
 
-    fun vaultWithAppSwitch(
+    fun clickVaultWithPayPal() = apply {
+        composeTestRule.waitUntilExactlyOneExists(hasText("VAULT WITH PAYPAL"), TIMEOUT_LONG_MS)
+        composeTestRule.onNodeWithText("VAULT WITH PAYPAL").performClick()
+    }
+
+    /**
+     * Exercises the PayPal Vault view's single button, which triggers createPayPalSession(),
+     * setup token creation, and PayPalWebCheckoutClient.vault() all from one tap, then completes
+     * the login/approval flow in the browser.
+     */
+    fun vaultWithPayPal(
         appSwitchEnabled: Boolean,
-        returnToAppStrategy: ReturnToAppStrategyOption
+        returnToAppStrategy: ReturnToAppStrategyOption,
+        email: String,
+        password: String,
     ) = apply {
         setAppSwitch(appSwitchEnabled)
         setReturnToAppStrategyOption(returnToAppStrategy)
-        clickCreateSetupToken()
-        verifySetupTokenCreated()
+        clickVaultWithPayPal()
+
+        webPageRobot.checkout(email, password)
+
+        // Wait for return to app and vault completion
+        waitForAppToReturn()
+
+        // Wait for vault to complete and verify success
+        composeTestRule.waitUntilExactlyOneExists(hasText("PAYPAL VAULTED"), TIMEOUT_LONG_MS)
+        composeTestRule.waitUntilExactlyOneExists(hasText("Approval Session ID"))
 
         Log.d(
             TAG,
-            "✅ Setup token created successfully with appSwitch: $appSwitchEnabled, " +
+            "🚀 PayPal vault with login completed successfully with appSwitch: $appSwitchEnabled, " +
                     "returnToAppStrategy: $returnToAppStrategy"
         )
     }
@@ -227,28 +241,6 @@ class DemoRobot(
             hasText("SETUP TOKEN CREATED"),
             TIMEOUT_LONG_MS
         )
-    }
-
-    fun startVaultWithLogin(email: String, password: String) = apply {
-        // Wait for Step 2 to appear
-        composeTestRule.waitUntilExactlyOneExists(
-            hasText("VAULT PAYPAL")
-        )
-
-        // Click on "START VAULT" button
-        composeTestRule.waitUntilExactlyOneExists(hasText("VAULT PAYPAL"))
-        composeTestRule.onNodeWithText("VAULT PAYPAL").performClick()
-
-        webPageRobot.checkout(email, password)
-
-        // Wait for return to app and vault completion
-        waitForAppToReturn()
-
-        // Wait for vault to complete and verify success
-        composeTestRule.waitUntilExactlyOneExists(hasText("PAYPAL VAULTED"), TIMEOUT_LONG_MS)
-        composeTestRule.waitUntilExactlyOneExists(hasText("Approval Session ID"))
-
-        Log.d(TAG, "🚀 PayPal vault with login completed successfully")
     }
 
     fun createPaymentToken() = apply {

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutView.kt
@@ -43,7 +43,7 @@ fun PayPalCheckoutView(
     val scrollState = rememberScrollState()
     LaunchedEffect(scrollState.maxValue) {
         // Auto-scroll once the user has started the flow; avoids scrolling on initial render
-        if (uiState.createOrderState !is ActionState.Idle) {
+        if (uiState.checkoutState !is ActionState.Idle) {
             scrollState.animateScrollTo(scrollState.maxValue)
         }
     }
@@ -66,23 +66,21 @@ fun PayPalCheckoutView(
             .padding(horizontal = contentPadding)
             .verticalScroll(scrollState)
     ) {
-        Step1_CreateOrder(uiState, viewModel)
-        if (uiState.isCreateOrderSuccessful) {
-            Step2_StartPayPalCheckout(uiState, viewModel)
-        }
+        Step1_CheckoutWithPayPal(uiState, viewModel)
         if (uiState.isPayPalWebCheckoutSuccessful) {
-            Step3_CompleteOrder(uiState, viewModel)
+            Step2_CompleteOrder(uiState, viewModel)
         }
         Spacer(modifier = Modifier.size(contentPadding))
     }
 }
 
 @Composable
-private fun Step1_CreateOrder(uiState: PayPalUiState, viewModel: PayPalCheckoutViewModel) {
+private fun Step1_CheckoutWithPayPal(uiState: PayPalUiState, viewModel: PayPalCheckoutViewModel) {
+    val context = LocalContext.current
     Column(
         verticalArrangement = UIConstants.spacingMedium,
     ) {
-        StepHeader(stepNumber = 1, title = "Create an Order")
+        StepHeader(stepNumber = 1, title = stringResource(R.string.launch_paypal))
         PayPalUserIdentityForm(
             userIdentity = uiState.userIdentity,
             onUserIdentityChange = { value -> viewModel.userIdentity = value },
@@ -104,38 +102,19 @@ private fun Step1_CreateOrder(uiState: PayPalUiState, viewModel: PayPalCheckoutV
             shouldVault = uiState.shouldVaultOption,
             onShouldVaultChanged = { value -> viewModel.shouldVault = value }
         )
-        ActionButtonColumn(
-            defaultTitle = "CREATE ORDER",
-            successTitle = "ORDER CREATED",
-            state = uiState.createOrderState,
-            onClick = { viewModel.createOrder() },
-            modifier = Modifier
-                .fillMaxWidth()
-        ) { state ->
-            when (state) {
-                is CompletedActionState.Failure -> ErrorView(error = state.value)
-                is CompletedActionState.Success -> OrderView(order = state.value)
-            }
-        }
-    }
-}
-
-@Composable
-private fun Step2_StartPayPalCheckout(uiState: PayPalUiState, viewModel: PayPalCheckoutViewModel) {
-    val context = LocalContext.current
-    Column(
-        verticalArrangement = UIConstants.spacingMedium,
-    ) {
-        StepHeader(stepNumber = 2, title = stringResource(R.string.launch_paypal))
         StartPayPalWebCheckoutForm(
             fundingSource = uiState.fundingSource,
             onFundingSourceChange = { value -> viewModel.fundingSource = value },
         )
+        // Single tap: createPayPalSession() -> create order -> start PayPal checkout.
+        // createPayPalSession() must fire on the buyer's checkout-intent tap, not earlier.
         ActionButtonColumn(
-            defaultTitle = "START CHECKOUT",
+            defaultTitle = "CHECKOUT WITH PAYPAL",
             successTitle = "CHECKOUT COMPLETE",
-            state = uiState.payPalWebCheckoutState,
-            onClick = { context.getActivityOrNull()?.let { viewModel.startCheckout(it) } },
+            state = uiState.checkoutState,
+            onClick = {
+                context.getActivityOrNull()?.let { viewModel.createOrderAndStartCheckout(it) }
+            },
             modifier = Modifier.fillMaxWidth()
         ) { state ->
             when (state) {
@@ -149,12 +128,12 @@ private fun Step2_StartPayPalCheckout(uiState: PayPalUiState, viewModel: PayPalC
 }
 
 @Composable
-private fun Step3_CompleteOrder(uiState: PayPalUiState, viewModel: PayPalCheckoutViewModel) {
+private fun Step2_CompleteOrder(uiState: PayPalUiState, viewModel: PayPalCheckoutViewModel) {
     val context = LocalContext.current
     Column(
         verticalArrangement = UIConstants.spacingMedium,
     ) {
-        StepHeader(stepNumber = 3, title = "Complete Order")
+        StepHeader(stepNumber = 2, title = "Complete Order")
         ActionButtonColumn(
             defaultTitle = "COMPLETE ORDER",
             successTitle = "ORDER COMPLETED",

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutView.kt
@@ -106,8 +106,6 @@ private fun Step1_CheckoutWithPayPal(uiState: PayPalUiState, viewModel: PayPalCh
             fundingSource = uiState.fundingSource,
             onFundingSourceChange = { value -> viewModel.fundingSource = value },
         )
-        // Single tap: createPayPalSession() -> create order -> start PayPal checkout.
-        // createPayPalSession() must fire on the buyer's checkout-intent tap, not earlier.
         ActionButtonColumn(
             defaultTitle = "CHECKOUT WITH PAYPAL",
             successTitle = "CHECKOUT COMPLETE",

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalCheckoutViewModel.kt
@@ -117,7 +117,7 @@ class PayPalCheckoutViewModel @Inject constructor(
         )
     }
 
-    fun createOrder() {
+    fun createOrderAndStartCheckout(activity: ComponentActivity) {
         createPayPalSession()
         viewModelScope.launch {
             createOrderState = ActionState.Loading
@@ -125,16 +125,11 @@ class PayPalCheckoutViewModel @Inject constructor(
                 val shouldVault = shouldVaultOption == StoreInVaultOption.ON_SUCCESS
                 OrderRequest(intentOption, shouldVault)
             }
-            createOrderState = createOrderUseCase(orderRequest).mapToActionState()
-        }
-    }
-
-    fun startCheckout(activity: ComponentActivity) {
-        val orderId = createdOrder?.id
-        if (orderId == null) {
-            payPalWebCheckoutState = ActionState.Failure(Exception("Create an order to continue."))
-        } else {
-            startCheckoutWithOrderId(activity, orderId)
+            val result = createOrderUseCase(orderRequest).mapToActionState()
+            createOrderState = result
+            (result as? ActionState.Success)?.value?.id?.let { orderId ->
+                startCheckoutWithOrderId(activity, orderId)
+            }
         }
     }
 

--- a/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalUiState.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalweb/PayPalUiState.kt
@@ -19,8 +19,13 @@ data class PayPalUiState(
     val completeOrderState: ActionState<Order, Exception> = ActionState.Idle,
     val fundingSource: PayPalWebCheckoutFundingSource = PayPalWebCheckoutFundingSource.PAYPAL,
 ) {
-    val isCreateOrderSuccessful: Boolean
-        get() = createOrderState is ActionState.Success
+    val checkoutState: ActionState<PayPalWebCheckoutFinishStartResult.Success, Exception>
+        get() = when (createOrderState) {
+            is ActionState.Idle -> ActionState.Idle
+            is ActionState.Loading -> ActionState.Loading
+            is ActionState.Failure -> createOrderState
+            is ActionState.Success -> payPalWebCheckoutState
+        }
 
     val isPayPalWebCheckoutSuccessful: Boolean
         get() = payPalWebCheckoutState is ActionState.Success

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultUiState.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultUiState.kt
@@ -14,8 +14,13 @@ data class PayPalVaultUiState(
     val vaultPayPalState: ActionState<PayPalWebCheckoutFinishVaultResult.Success, Exception> = ActionState.Idle,
     val createPaymentTokenState: ActionState<PayPalPaymentToken, Exception> = ActionState.Idle,
 ) {
-    val isCreateSetupTokenSuccessful: Boolean
-        get() = createSetupTokenState is ActionState.Success
+    val vaultState: ActionState<PayPalWebCheckoutFinishVaultResult.Success, Exception>
+        get() = when (createSetupTokenState) {
+            is ActionState.Idle -> ActionState.Idle
+            is ActionState.Loading -> ActionState.Loading
+            is ActionState.Failure -> createSetupTokenState
+            is ActionState.Success -> vaultPayPalState
+        }
 
     val isVaultPayPalSuccessful: Boolean
         get() = vaultPayPalState is ActionState.Success

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultView.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultView.kt
@@ -22,7 +22,6 @@ import com.paypal.android.uishared.components.ActionButtonColumn
 import com.paypal.android.uishared.components.EnumOptionList
 import com.paypal.android.uishared.components.ErrorView
 import com.paypal.android.uishared.components.PayPalPaymentTokenView
-import com.paypal.android.uishared.components.PayPalSetupTokenView
 import com.paypal.android.uishared.components.PayPalUserIdentityForm
 import com.paypal.android.uishared.components.PropertyView
 import com.paypal.android.uishared.components.StepHeader
@@ -40,7 +39,7 @@ fun PayPalVaultView(viewModel: PayPalVaultViewModel = hiltViewModel()) {
     val scrollState = rememberScrollState()
     LaunchedEffect(scrollState.maxValue) {
         // Auto-scroll once the user has started the flow; avoids scrolling on initial render
-        if (uiState.createSetupTokenState !is ActionState.Idle) {
+        if (uiState.vaultState !is ActionState.Idle) {
             scrollState.animateScrollTo(scrollState.maxValue)
         }
     }
@@ -63,26 +62,24 @@ fun PayPalVaultView(viewModel: PayPalVaultViewModel = hiltViewModel()) {
             .padding(horizontal = contentPadding)
             .verticalScroll(scrollState)
     ) {
-        Step1_CreateSetupToken(uiState, viewModel)
-        if (uiState.isCreateSetupTokenSuccessful) {
-            Step2_VaultPayPal(uiState, viewModel)
-        }
+        Step1_VaultWithPayPal(uiState, viewModel)
         if (uiState.isVaultPayPalSuccessful) {
-            Step3_CreatePaymentToken(uiState, viewModel)
+            Step2_CreatePaymentToken(uiState, viewModel)
         }
         Spacer(modifier = Modifier.size(contentPadding))
     }
 }
 
 @Composable
-private fun Step1_CreateSetupToken(
+private fun Step1_VaultWithPayPal(
     uiState: PayPalVaultUiState,
     viewModel: PayPalVaultViewModel
 ) {
+    val context = LocalContext.current
     Column(
         verticalArrangement = UIConstants.spacingMedium,
     ) {
-        StepHeader(stepNumber = 1, title = "Create Setup Token")
+        StepHeader(stepNumber = 1, title = "Vault PayPal")
         PayPalUserIdentityForm(
             userIdentity = uiState.userIdentity,
             onUserIdentityChange = { value -> viewModel.userIdentity = value },
@@ -96,36 +93,12 @@ private fun Step1_CreateSetupToken(
             modifier = Modifier.fillMaxWidth()
         )
         ActionButtonColumn(
-            defaultTitle = "CREATE SETUP TOKEN",
-            successTitle = "SETUP TOKEN CREATED",
-            state = uiState.createSetupTokenState,
-            onClick = { viewModel.createSetupToken() }
-        ) { state ->
-            when (state) {
-                is CompletedActionState.Failure -> ErrorView(error = state.value)
-                is CompletedActionState.Success -> PayPalSetupTokenView(setupToken = state.value)
-            }
-        }
-    }
-}
-
-@Composable
-private fun Step2_VaultPayPal(
-    uiState: PayPalVaultUiState,
-    viewModel: PayPalVaultViewModel
-) {
-    val context = LocalContext.current
-    Column(
-        verticalArrangement = UIConstants.spacingMedium,
-    ) {
-        StepHeader(stepNumber = 2, title = "Vault PayPal")
-        ActionButtonColumn(
-            defaultTitle = "VAULT PAYPAL",
+            defaultTitle = "VAULT WITH PAYPAL",
             successTitle = "PAYPAL VAULTED",
-            state = uiState.vaultPayPalState,
+            state = uiState.vaultState,
             onClick = {
                 context.getActivityOrNull()?.let { activity ->
-                    viewModel.vaultSetupToken(activity)
+                    viewModel.createSetupTokenAndVault(activity)
                 }
             }
         ) { state ->
@@ -138,14 +111,14 @@ private fun Step2_VaultPayPal(
 }
 
 @Composable
-private fun Step3_CreatePaymentToken(
+private fun Step2_CreatePaymentToken(
     uiState: PayPalVaultUiState,
     viewModel: PayPalVaultViewModel
 ) {
     Column(
         verticalArrangement = UIConstants.spacingMedium,
     ) {
-        StepHeader(stepNumber = 3, title = "Create Payment Token")
+        StepHeader(stepNumber = 2, title = "Create Payment Token")
         ActionButtonColumn(
             defaultTitle = "CREATE PAYMENT TOKEN",
             successTitle = "PAYMENT TOKEN CREATED",

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
@@ -87,12 +87,6 @@ class PayPalVaultViewModel @Inject constructor(
     private val createdSetupToken: PayPalSetupToken?
         get() = (createSetupTokenState as? ActionState.Success)?.value
 
-    /**
-     * Triggered by a single button tap: pre-warms the PayPal session, creates the setup token,
-     * and — on success — immediately starts PayPal vault with that setup token.
-     * createPayPalSession() must be called from the buyer's vault-intent tap (not earlier), so
-     * this all happens within one click handler rather than across separate buttons.
-     */
     fun createSetupTokenAndVault(activity: ComponentActivity) {
         createPayPalSession()
         viewModelScope.launch {

--- a/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
+++ b/Demo/src/main/java/com/paypal/android/ui/paypalwebvault/PayPalVaultViewModel.kt
@@ -84,34 +84,38 @@ class PayPalVaultViewModel @Inject constructor(
         )
     }
 
-    fun createSetupToken() {
-        createPayPalSession()
-        viewModelScope.launch {
-            createSetupTokenState = ActionState.Loading
-            createSetupTokenState = createPayPalSetupTokenUseCase().mapToActionState()
-        }
-    }
-
     private val createdSetupToken: PayPalSetupToken?
         get() = (createSetupTokenState as? ActionState.Success)?.value
 
-    fun vaultSetupToken(activity: ComponentActivity) {
-        val setupTokenId = createdSetupToken?.id
+    /**
+     * Triggered by a single button tap: pre-warms the PayPal session, creates the setup token,
+     * and — on success — immediately starts PayPal vault with that setup token.
+     * createPayPalSession() must be called from the buyer's vault-intent tap (not earlier), so
+     * this all happens within one click handler rather than across separate buttons.
+     */
+    fun createSetupTokenAndVault(activity: ComponentActivity) {
+        createPayPalSession()
+        viewModelScope.launch {
+            createSetupTokenState = ActionState.Loading
+            val result = createPayPalSetupTokenUseCase().mapToActionState()
+            createSetupTokenState = result
+            (result as? ActionState.Success)?.value?.id?.let { setupTokenId ->
+                vaultSetupTokenId(activity, setupTokenId)
+            }
+        }
+    }
 
-        if (setupTokenId == null) {
-            vaultPayPalState = ActionState.Failure(Exception("Create a setup token to continue."))
-        } else {
-            vaultPayPalState = ActionState.Loading
+    private fun vaultSetupTokenId(activity: ComponentActivity, setupTokenId: String) {
+        vaultPayPalState = ActionState.Loading
 
-            paypalClient.vault(activity, setupTokenId) { result ->
-                when (result) {
-                    is PayPalPresentAuthChallengeResult.Success -> {
-                        // do nothing; wait for user to authenticate PayPal vault in Chrome Custom Tab
-                    }
-
-                    is PayPalPresentAuthChallengeResult.Failure ->
-                        vaultPayPalState = ActionState.Failure(result.error)
+        paypalClient.vault(activity, setupTokenId) { result ->
+            when (result) {
+                is PayPalPresentAuthChallengeResult.Success -> {
+                    // do nothing; wait for user to authenticate PayPal vault in Chrome Custom Tab
                 }
+
+                is PayPalPresentAuthChallengeResult.Failure ->
+                    vaultPayPalState = ActionState.Failure(result.error)
             }
         }
     }


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Consolidating the Create Order and Start Checkout buttons in the PayPal Checkout View into one button. On one button click, createPayPalSession, createOrder, and start() are all called. 
 - Same case with PayPal Vault. 

### Evidence

https://github.com/user-attachments/assets/46c29253-5d90-455c-8d0a-3036e574c046


https://github.com/user-attachments/assets/0accbd6b-b076-4bf6-8655-09a4e749f370


https://github.com/user-attachments/assets/4fa5b58d-6d2e-44af-a3a4-a92e3af37211




 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
