### PR TITLE
[NOVERSION] Remove unused GPG signing step from build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,6 @@ jobs:
   build_aar:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      SIGNING_KEY_FILE_PATH: /home/runner/secretKey.gpg
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -17,15 +15,5 @@ jobs:
         with:
           java-version: '17'
           distribution: 'microsoft'
-            #After decoding the secret key, place the file in ~ /. Gradle/ secring.gpg
-      - name: Decode Signing Key
-        uses: ./.github/actions/decode_signing_key_action
-        with:
-          signing_key_file: ${{ secrets.SIGNING_KEY_FILE }}
-          signing_file_path: ${{ env.SIGNING_KEY_FILE_PATH }}
       - name: Assemble
         run: ./gradlew --stacktrace assemble -x :Demo:assemble # we exclude Demo module in assemble
-        env:
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          SIGNING_KEY_FILE: ${{ env.SIGNING_KEY_FILE_PATH }}


### PR DESCRIPTION
### Summary
- Removes the "Decode Signing Key" step and related GPG env vars from `build.yml`, since the PR-triggered `assemble` task doesn't require signing credentials (confirmed by testing that `assemble` succeeds without them — Gradle `Sign` tasks are only wired into `publish` tasks, not `assemble`).

### API / Contract Changes

## New

None

## Modified

None

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe migration steps below)

## Migration:



### Checklist

- [ ] Added a changelog entry