### PR TITLE
Formatting Deeplink Return Urls

### DIFF
--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebLauncher.kt
@@ -120,18 +120,21 @@ internal class PayPalWebLauncher(
             PayPalWebCheckoutFinishStartResult.Failure(unknownError, null)
         } else {
             val orderId = metadata.optString(METADATA_KEY_ORDER_ID)
-            val opType = deepLink.uri.getQueryParameter("opType")
             val payerId = deepLink.uri.getQueryParameter("PayerID")
-            when {
-                opType == "cancel" -> PayPalWebCheckoutFinishStartResult.Canceled(orderId)
-                !orderId.isNullOrBlank() && !payerId.isNullOrBlank() ->
-                    PayPalWebCheckoutFinishStartResult.Success(orderId, payerId)
-                orderId.isNullOrBlank() ->
-                    PayPalWebCheckoutFinishStartResult.Failure(
-                        PayPalWebCheckoutError.malformedResultError,
-                        orderId
-                    )
-                else -> PayPalWebCheckoutFinishStartResult.Canceled(orderId)
+            val isCancelUrl = deepLink.uri.path?.contains("cancel") ?: false
+            if (isCancelUrl) {
+                PayPalWebCheckoutFinishStartResult.Canceled(orderId)
+            } else {
+                when {
+                    !orderId.isNullOrBlank() && !payerId.isNullOrBlank() ->
+                        PayPalWebCheckoutFinishStartResult.Success(orderId, payerId)
+                    orderId.isNullOrBlank() ->
+                        PayPalWebCheckoutFinishStartResult.Failure(
+                            PayPalWebCheckoutError.malformedResultError,
+                            orderId
+                        )
+                    else -> PayPalWebCheckoutFinishStartResult.Canceled(orderId)
+                }
             }
         }
     }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/usecase/GetEffectiveReturnUrlConfigUseCase.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/usecase/GetEffectiveReturnUrlConfigUseCase.kt
@@ -41,10 +41,12 @@ class GetEffectiveReturnUrlConfigUseCase {
 
         return when (linkType) {
             LinkType.DEEP_LINK -> {
-                val successBaseUri = ReturnToAppStrategy.CustomUrlScheme(urlConfig.fallbackSchemeUrl).returnUrl.toUri()
+                val baseUrl = ReturnToAppStrategy.CustomUrlScheme(urlConfig.fallbackSchemeUrl).returnUrl
+                val successUri = "$baseUrl/success".toUri()
+                val cancelUri = "$baseUrl/cancel".toUri()
                 urlConfig.copy(
-                    returnAppUrl = successBaseUri.withQueryFrom(urlConfig.returnAppUrl).toString(),
-                    cancelAppUrl = successBaseUri.withQueryFrom(urlConfig.cancelAppUrl).toString(),
+                    returnAppUrl = successUri.withQueryFrom(urlConfig.returnAppUrl).toString(),
+                    cancelAppUrl = cancelUri.withQueryFrom(urlConfig.cancelAppUrl).toString(),
                 )
             }
 

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -2290,8 +2290,8 @@ class PayPalWebCheckoutClientUnitTest {
             // Deep-link chosen -> server must be told to redirect via the custom scheme, so the
             // return/cancel URLs sent to the shopper session are custom-scheme, not the merchant https.
             val expectedBase = "com.example.app://x-callback-url/paypal-sdk/paypal-checkout"
-            assertEquals(expectedBase, paramsSlot.captured.returnAppUrl)
-            assertEquals(expectedBase, paramsSlot.captured.cancelAppUrl)
+            assertEquals("$expectedBase/success", paramsSlot.captured.returnAppUrl)
+            assertEquals("$expectedBase/cancel", paramsSlot.captured.cancelAppUrl)
             // The raw fallback scheme is still forwarded unchanged.
             assertEquals("com.example.app", paramsSlot.captured.fallbackSchemeUrl)
             verify {

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebLauncherUnitTest.kt
@@ -257,7 +257,7 @@ class PayPalWebLauncherUnitTest {
     }
 
     @Test
-    fun `completeCheckoutAuthRequest() parses cancellation when Payer Id is blank and no opType`() {
+    fun `completeCheckoutAuthRequest() parses cancellation when Payer Id is blank and path is not a cancel path`() {
         val originalOptions = BrowserSwitchOptions(
             targetUri = "https://www.sandbox.paypal.com/checkoutnow".toUri(),
             requestCode = PAYPAL_CHECKOUT,
@@ -315,7 +315,7 @@ class PayPalWebLauncherUnitTest {
     }
 
     @Test
-    fun `completeCheckoutAuthRequest() parses checkout cancellation deep link url indicates failure`() {
+    fun `completeCheckoutAuthRequest() parses cancellation when deep link path contains the word cancel`() {
         val originalOptions = BrowserSwitchOptions(
             targetUri = "https://www.sandbox.paypal.com/checkoutnow".toUri(),
             requestCode = PAYPAL_CHECKOUT,
@@ -324,11 +324,12 @@ class PayPalWebLauncherUnitTest {
             metadata = createCheckoutMetadata("fake-order-id")
         )
         val authState = BrowserSwitchPendingState(originalOptions).toBase64EncodedJSON()
-        intent.data = "com.example.app://testurl.com/checkout?opType=cancel".toUri()
+        intent.data = "com.example.app://testurl.com/checkout/cancel?PayerID=fake-payer-id".toUri()
 
         sut = PayPalWebLauncher(browserSwitchClient)
         val result = sut.completeCheckoutAuthRequest(intent, authState)
-        assertTrue(result is PayPalWebCheckoutFinishStartResult.Canceled)
+                as PayPalWebCheckoutFinishStartResult.Canceled
+        assertEquals("fake-order-id", result.orderId)
     }
 
     @Test

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/usecase/GetEffectiveReturnUrlConfigUseCaseUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/usecase/GetEffectiveReturnUrlConfigUseCaseUnitTest.kt
@@ -19,12 +19,12 @@ class GetEffectiveReturnUrlConfigUseCaseUnitTest {
     )
 
     @Test
-    fun `deep-link returns the same custom-scheme url for return and cancel, with fallback preserved`() {
+    fun `deep-link returns distinct success and cancel custom-scheme urls, with fallback preserved`() {
         val result = sut(urlConfig, LinkType.DEEP_LINK)
 
         val base = "com.example.app://x-callback-url/paypal-sdk/paypal-checkout"
-        assertEquals(base, result.returnAppUrl)
-        assertEquals(base, result.cancelAppUrl)
+        assertEquals("$base/success", result.returnAppUrl)
+        assertEquals("$base/cancel", result.cancelAppUrl)
         assertEquals("com.example.app", result.fallbackSchemeUrl)
     }
 
@@ -38,8 +38,8 @@ class GetEffectiveReturnUrlConfigUseCaseUnitTest {
         val result = sut(configWithQueryParams, LinkType.DEEP_LINK)
 
         val base = "com.example.app://x-callback-url/paypal-sdk/paypal-checkout"
-        assertEquals("$base?ref=123", result.returnAppUrl)
-        assertEquals("$base?ref=456", result.cancelAppUrl)
+        assertEquals("$base/success?ref=123", result.returnAppUrl)
+        assertEquals("$base/cancel?ref=456", result.cancelAppUrl)
     }
 
     @Test


### PR DESCRIPTION
…ls when returning with fallbackSchemeUrl.

Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Appending `/success` and `/cancel` to deeplink return url to correctly between distinguish between success and cancel on return to merchant. 

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
