### PR TITLE
Pass AnalyticsEventParams into latency analytics events

### DIFF
--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -163,13 +163,11 @@ class PayPalWebCheckoutClient internal constructor(
             isVault = false,
         )
         if (urlConfig != null && !urlConfig.isValid()) {
-            logUserPerceivedLatencyError(LatencyFlow.CHECKOUT, startTime)
-            notifyCheckoutReturnToAppUrlConfigInvalid(orderId, callback)
+            notifyCheckoutReturnToAppUrlConfigInvalid(orderId, callback, startTime)
             return
         }
         if (deferred == null) {
-            logUserPerceivedLatencyError(LatencyFlow.CHECKOUT, startTime)
-            notifyCheckoutSessionNotStarted(callback)
+            notifyCheckoutSessionNotStarted(callback, startTime)
             return
         }
         applicationScope.launch {
@@ -237,13 +235,11 @@ class PayPalWebCheckoutClient internal constructor(
             isVault = true,
         )
         if (urlConfig != null && !urlConfig.isValid()) {
-            logUserPerceivedLatencyError(LatencyFlow.VAULT, startTime)
-            notifyVaultReturnToAppUrlConfigInvalid(setupTokenId, callback)
+            notifyVaultReturnToAppUrlConfigInvalid(setupTokenId, callback, startTime)
             return
         }
         if (deferred == null) {
-            logUserPerceivedLatencyError(LatencyFlow.VAULT, startTime)
-            notifyVaultSessionNotStarted(callback)
+            notifyVaultSessionNotStarted(callback, startTime)
             return
         }
         applicationScope.launch {
@@ -363,7 +359,6 @@ class PayPalWebCheckoutClient internal constructor(
         startTime: Long,
     ): PayPalPresentAuthChallengeResult {
         val isVault = tokenType == TokenType.VAULT_ID
-        val flowType = if (isVault) LatencyFlow.VAULT else LatencyFlow.CHECKOUT
 
         // Shouldn't return null in practice: start()/vault() already validate urlConfig before here.
         val returnToAppStrategy = getReturnToAppStrategyOrNull()
@@ -389,14 +384,7 @@ class PayPalWebCheckoutClient internal constructor(
             tokenType = tokenType,
             returnToAppStrategy = returnToAppStrategy,
         )
-        logPresentAuthChallengeResult(result)
-
-        // If failed to launch, log latency with error.
-        if (result is PayPalPresentAuthChallengeResult.Failure) {
-            logUserPerceivedLatencyError(flowType, startTime)
-        } else {
-            logUserPerceivedLatency(flowType, result, startTime, endTime)
-        }
+        logPresentAuthChallengeResult(result, isVault, startTime, endTime)
         return result
     }
 
@@ -583,9 +571,7 @@ class PayPalWebCheckoutClient internal constructor(
     ): PayPalPresentAuthChallengeResult {
         val error = PayPalWebCheckoutError.returnToAppUrlConfigMissingError
         val failureResult = PayPalPresentAuthChallengeResult.Failure(error)
-        val latencyFlow = if (isVault) LatencyFlow.VAULT else LatencyFlow.CHECKOUT
-        logPresentAuthChallengeResult(failureResult)
-        logUserPerceivedLatencyError(latencyFlow, startTime)
+        logPresentAuthChallengeResult(failureResult, isVault, startTime, System.currentTimeMillis())
         return failureResult
     }
 
@@ -704,7 +690,12 @@ class PayPalWebCheckoutClient internal constructor(
     /**
      * Logs the app-switch/auth-challenge success or failure event for a launch [result].
      */
-    private fun logPresentAuthChallengeResult(result: PayPalPresentAuthChallengeResult) {
+    private fun logPresentAuthChallengeResult(
+        result: PayPalPresentAuthChallengeResult,
+        isVault: Boolean,
+        startTime: Long,
+        endTime: Long
+    ) {
         when (result) {
             is PayPalPresentAuthChallengeResult.Success -> {
                 val event = if (appSwitchEnabled) {
@@ -714,6 +705,8 @@ class PayPalWebCheckoutClient internal constructor(
                 }
                 analytics.notify(event, params = analyticsEventParams)
                 sessionStore.authState = result.authState
+                val flowType = if (isVault) LatencyFlow.VAULT else LatencyFlow.CHECKOUT
+                logUserPerceivedLatency(flowType, result, startTime, endTime)
             }
             is PayPalPresentAuthChallengeResult.Failure -> {
                 val event = if (appSwitchEnabled) {
@@ -721,16 +714,19 @@ class PayPalWebCheckoutClient internal constructor(
                 } else {
                     PayPalEvent.AUTH_CHALLENGE_PRESENTATION_FAILED
                 }
+                val errorDescription = result.error.errorDescription
                 analytics.notify(
                     event,
                     params = analyticsEventParams,
-                    errorDescription = result.error.errorDescription
+                    errorDescription = errorDescription
                 )
                 analytics.notify(
                     PayPalEvent.FAILED,
                     params = analyticsEventParams,
-                    errorDescription = result.error.errorDescription
+                    errorDescription = errorDescription
                 )
+                val flowType = if (isVault) LatencyFlow.VAULT else LatencyFlow.CHECKOUT
+                logUserPerceivedLatencyError(flowType, startTime, errorDescription, endTime)
             }
         }
     }
@@ -750,18 +746,24 @@ class PayPalWebCheckoutClient internal constructor(
 
             is PayPalPresentAuthChallengeResult.Failure -> PresentationType.ERROR
         }
-        analytics.notifyUserPerceivedLatency(flow, presentationType, startTime, endTime, analyticsEventParams)
+        analytics.notifyUserPerceivedLatency(flow, presentationType, startTime, endTime, params = analyticsEventParams)
     }
 
     /**
      * Logs the user-perceived latency for a launch that failed before a [PayPalPresentAuthChallengeResult] was reached.
      */
-    private fun logUserPerceivedLatencyError(flow: String, startTime: Long) {
+    private fun logUserPerceivedLatencyError(
+        flow: String,
+        startTime: Long,
+        errorDescription: String,
+        endTime: Long = System.currentTimeMillis(),
+    ) {
         analytics.notifyUserPerceivedLatency(
             flow = flow,
             presentationType = PresentationType.ERROR,
             startTime = startTime,
-            endTime = System.currentTimeMillis(),
+            endTime = endTime,
+            errorDescription = errorDescription,
             params = analyticsEventParams,
         )
     }
@@ -779,13 +781,15 @@ class PayPalWebCheckoutClient internal constructor(
      * Logs [PayPalEvent.SESSION_NOT_STARTED] and notifies the merchant that [start] was called
      * before [createPayPalSession].
      */
-    private fun notifyCheckoutSessionNotStarted(callback: PayPalWebStartCallback) {
+    private fun notifyCheckoutSessionNotStarted(callback: PayPalWebStartCallback, startTime: Long) {
+        val errorDescription = "startPayPalSession() must be called before start()."
         applicationScope.launch(Dispatchers.Main) {
             analytics.notify(
                 PayPalEvent.SESSION_NOT_STARTED,
                 params = analyticsEventParams,
-                errorDescription = "startPayPalSession() must be called before start()."
+                errorDescription = errorDescription
             )
+            logUserPerceivedLatencyError(LatencyFlow.CHECKOUT, startTime, errorDescription)
             callback.onPayPalWebStartResult(
                 PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.sessionNotCreatedError)
             )
@@ -796,13 +800,15 @@ class PayPalWebCheckoutClient internal constructor(
      * Logs [PayPalEvent.SESSION_NOT_STARTED] and notifies the merchant that [vault] was called
      * before [createPayPalSession].
      */
-    private fun notifyVaultSessionNotStarted(callback: PayPalWebVaultCallback) {
+    private fun notifyVaultSessionNotStarted(callback: PayPalWebVaultCallback, startTime: Long) {
+        val errorDescription = "startPayPalSession() must be called before vault()."
         applicationScope.launch(Dispatchers.Main) {
             analytics.notify(
                 PayPalEvent.SESSION_NOT_STARTED,
                 params = analyticsEventParams,
-                errorDescription = "startPayPalSession() must be called before vault()."
+                errorDescription = errorDescription
             )
+            logUserPerceivedLatencyError(LatencyFlow.VAULT, startTime, errorDescription)
             callback.onPayPalWebVaultResult(
                 PayPalPresentAuthChallengeResult.Failure(PayPalWebCheckoutError.sessionNotCreatedError)
             )
@@ -813,7 +819,11 @@ class PayPalWebCheckoutClient internal constructor(
      * Logs [PayPalEvent.FAILED] and notifies the merchant that [start] was called with a [returnToAppUrlConfig]
      * that has neither a usable return app URL nor a fallback scheme.
      */
-    private fun notifyCheckoutReturnToAppUrlConfigInvalid(orderId: String, callback: PayPalWebStartCallback) {
+    private fun notifyCheckoutReturnToAppUrlConfigInvalid(
+        orderId: String,
+        callback: PayPalWebStartCallback,
+        startTime: Long
+    ) {
         applicationScope.launch(Dispatchers.Main) {
             val error = PayPalWebCheckoutError.returnToAppUrlConfigMissingError
             analytics.notify(
@@ -821,6 +831,7 @@ class PayPalWebCheckoutClient internal constructor(
                 params = analyticsEventParams.copy(orderIdOrSetupTokenId = orderId),
                 errorDescription = error.errorDescription
             )
+            logUserPerceivedLatencyError(LatencyFlow.CHECKOUT, startTime, error.errorDescription)
             callback.onPayPalWebStartResult(PayPalPresentAuthChallengeResult.Failure(error))
         }
     }
@@ -829,7 +840,11 @@ class PayPalWebCheckoutClient internal constructor(
      * Logs [PayPalEvent.FAILED] and notifies the merchant that [vault] was called with a [returnToAppUrlConfig]
      * that has neither a usable return app URL nor a fallback scheme.
      */
-    private fun notifyVaultReturnToAppUrlConfigInvalid(setupTokenId: String, callback: PayPalWebVaultCallback) {
+    private fun notifyVaultReturnToAppUrlConfigInvalid(
+        setupTokenId: String,
+        callback: PayPalWebVaultCallback,
+        startTime: Long
+    ) {
         applicationScope.launch(Dispatchers.Main) {
             val error = PayPalWebCheckoutError.returnToAppUrlConfigMissingError
             analytics.notify(
@@ -837,6 +852,7 @@ class PayPalWebCheckoutClient internal constructor(
                 params = analyticsEventParams.copy(orderIdOrSetupTokenId = setupTokenId),
                 errorDescription = error.errorDescription
             )
+            logUserPerceivedLatencyError(LatencyFlow.VAULT, startTime, error.errorDescription)
             callback.onPayPalWebVaultResult(PayPalPresentAuthChallengeResult.Failure(error))
         }
     }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -176,7 +176,6 @@ class PayPalWebCheckoutClient internal constructor(
             try {
                 val shopperSession = deferred.await()
                 shopperSessionDeferred = null
-                setShopperSessionAnalyticsParams(shopperSession)
                 analytics.notify(PayPalEvent.STARTED, params = analyticsEventParams)
 
                 if (shopperSession != null) {
@@ -251,7 +250,6 @@ class PayPalWebCheckoutClient internal constructor(
             try {
                 val shopperSession = deferred.await()
                 shopperSessionDeferred = null
-                setShopperSessionAnalyticsParams(shopperSession)
                 analytics.notify(PayPalEvent.STARTED, params = analyticsEventParams)
 
                 if (shopperSession != null) {
@@ -392,7 +390,13 @@ class PayPalWebCheckoutClient internal constructor(
             returnToAppStrategy = returnToAppStrategy,
         )
         logPresentAuthChallengeResult(result)
-        logUserPerceivedLatency(flowType, result, startTime, endTime)
+
+        // If failed to launch, log latency with error.
+        if (result is PayPalPresentAuthChallengeResult.Failure) {
+            logUserPerceivedLatencyError(flowType, startTime)
+        } else {
+            logUserPerceivedLatency(flowType, result, startTime, endTime)
+        }
         return result
     }
 
@@ -455,10 +459,9 @@ class PayPalWebCheckoutClient internal constructor(
             ),
         )
 
-        logApiRequestLatency(LatencyEndpoint.CREATE_SESSION, result.roundTripTiming)
-
-        return when (result) {
+        val shopperSessionWithAppSwitchEligibility = when (result) {
             is APIResult.Success -> {
+                setShopperSessionAnalyticsParams(result.data)
                 analyticsEventParams = analyticsEventParams.copy(
                     shopperSession = result.data,
                 )
@@ -475,6 +478,8 @@ class PayPalWebCheckoutClient internal constructor(
                 null
             }
         }
+        logApiRequestLatency(LatencyEndpoint.CREATE_SESSION, result.roundTripTiming)
+        return shopperSessionWithAppSwitchEligibility
     }
     // endregion
 
@@ -745,7 +750,7 @@ class PayPalWebCheckoutClient internal constructor(
 
             is PayPalPresentAuthChallengeResult.Failure -> PresentationType.ERROR
         }
-        analytics.notifyUserPerceivedLatency(flow, presentationType, startTime, endTime)
+        analytics.notifyUserPerceivedLatency(flow, presentationType, startTime, endTime, analyticsEventParams)
     }
 
     /**
@@ -756,7 +761,8 @@ class PayPalWebCheckoutClient internal constructor(
             flow = flow,
             presentationType = PresentationType.ERROR,
             startTime = startTime,
-            endTime = System.currentTimeMillis()
+            endTime = System.currentTimeMillis(),
+            params = analyticsEventParams,
         )
     }
 
@@ -764,7 +770,9 @@ class PayPalWebCheckoutClient internal constructor(
      * Logs the API round-trip latency for [endpoint], if [roundTripTiming] was captured.
      */
     private fun logApiRequestLatency(endpoint: String, roundTripTiming: HttpRoundTripTiming?) {
-        roundTripTiming?.let { analytics.notifyApiRequestLatency(endpoint, it.startTime, it.endTime) }
+        roundTripTiming?.let {
+            analytics.notifyApiRequestLatency(endpoint, it.startTime, it.endTime, analyticsEventParams)
+        }
     }
 
     /**

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClient.kt
@@ -696,6 +696,7 @@ class PayPalWebCheckoutClient internal constructor(
         startTime: Long,
         endTime: Long
     ) {
+        val flowType = if (isVault) LatencyFlow.VAULT else LatencyFlow.CHECKOUT
         when (result) {
             is PayPalPresentAuthChallengeResult.Success -> {
                 val event = if (appSwitchEnabled) {
@@ -705,7 +706,6 @@ class PayPalWebCheckoutClient internal constructor(
                 }
                 analytics.notify(event, params = analyticsEventParams)
                 sessionStore.authState = result.authState
-                val flowType = if (isVault) LatencyFlow.VAULT else LatencyFlow.CHECKOUT
                 logUserPerceivedLatency(flowType, result, startTime, endTime)
             }
             is PayPalPresentAuthChallengeResult.Failure -> {
@@ -725,7 +725,6 @@ class PayPalWebCheckoutClient internal constructor(
                     params = analyticsEventParams,
                     errorDescription = errorDescription
                 )
-                val flowType = if (isVault) LatencyFlow.VAULT else LatencyFlow.CHECKOUT
                 logUserPerceivedLatencyError(flowType, startTime, errorDescription, endTime)
             }
         }

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/PayPalWebAnalytics.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/PayPalWebAnalytics.kt
@@ -49,6 +49,7 @@ internal class PayPalWebAnalytics(private val analyticsService: AnalyticsService
         presentationType: String,
         startTime: Long,
         endTime: Long,
+        errorDescription: String? = null,
         params: AnalyticsEventParams = AnalyticsEventParams(),
     ) {
         analyticsService.sendAnalyticsEvent(
@@ -56,6 +57,7 @@ internal class PayPalWebAnalytics(private val analyticsService: AnalyticsService
             eventData = AnalyticsEventData(
                 orderId = params.orderIdOrSetupTokenId,
                 shopperSessionId = params.shopperSession?.shopperSessionConfig?.id,
+                errorDescription = errorDescription,
                 flow = flow,
                 presentationType = presentationType,
                 startTime = startTime,

--- a/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/PayPalWebAnalytics.kt
+++ b/PayPalWebPayments/src/main/java/com/paypal/android/paypalwebpayments/analytics/PayPalWebAnalytics.kt
@@ -26,10 +26,17 @@ internal class PayPalWebAnalytics(private val analyticsService: AnalyticsService
         )
     }
 
-    fun notifyApiRequestLatency(endpoint: String, startTime: Long, endTime: Long) {
+    fun notifyApiRequestLatency(
+        endpoint: String,
+        startTime: Long,
+        endTime: Long,
+        params: AnalyticsEventParams = AnalyticsEventParams(),
+    ) {
         analyticsService.sendAnalyticsEvent(
             name = LatencyEvent.API_REQUEST_LATENCY.value,
             eventData = AnalyticsEventData(
+                orderId = params.orderIdOrSetupTokenId,
+                shopperSessionId = params.shopperSession?.shopperSessionConfig?.id,
                 endpoint = endpoint,
                 startTime = startTime,
                 endTime = endTime,
@@ -41,11 +48,14 @@ internal class PayPalWebAnalytics(private val analyticsService: AnalyticsService
         flow: String,
         presentationType: String,
         startTime: Long,
-        endTime: Long
+        endTime: Long,
+        params: AnalyticsEventParams = AnalyticsEventParams(),
     ) {
         analyticsService.sendAnalyticsEvent(
             name = LatencyEvent.USER_PERCEIVED_LATENCY.value,
             eventData = AnalyticsEventData(
+                orderId = params.orderIdOrSetupTokenId,
+                shopperSessionId = params.shopperSession?.shopperSessionConfig?.id,
                 flow = flow,
                 presentationType = presentationType,
                 startTime = startTime,

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -1985,6 +1985,7 @@ class PayPalWebCheckoutClientUnitTest {
                     presentationType = PresentationType.ERROR,
                     startTime = any(),
                     endTime = any(),
+                    errorDescription = any(),
                     params = any()
                 )
             }
@@ -2004,6 +2005,7 @@ class PayPalWebCheckoutClientUnitTest {
                     presentationType = PresentationType.ERROR,
                     startTime = any(),
                     endTime = any(),
+                    errorDescription = any(),
                     params = any()
                 )
             }

--- a/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
+++ b/PayPalWebPayments/src/test/java/com/paypal/android/paypalwebpayments/PayPalWebCheckoutClientUnitTest.kt
@@ -1335,7 +1335,8 @@ class PayPalWebCheckoutClientUnitTest {
                 analytics.notifyApiRequestLatency(
                     endpoint = LatencyEndpoint.CREATE_SESSION,
                     startTime = 1000L,
-                    endTime = 1500L
+                    endTime = 1500L,
+                    params = any()
                 )
             }
         }
@@ -1560,6 +1561,10 @@ class PayPalWebCheckoutClientUnitTest {
                 payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
             } returns PayPalPresentAuthChallengeResult.Failure(sdkError)
 
+            coEvery {
+                createShopperSessionAPI(token = any(), tokenType = any(), params = any())
+            } returns APIResult.Success(fakeSessionResponse)
+
             val callback = mockk<PayPalWebStartCallback>(relaxed = true)
             sutV3.createPayPalSession(
                 tokenType = TokenType.ORDER_ID,
@@ -1606,6 +1611,10 @@ class PayPalWebCheckoutClientUnitTest {
             every {
                 payPalWebLauncher.launchWithUrl(any(), any(), any(), any(), any())
             } returns PayPalPresentAuthChallengeResult.Failure(sdkError)
+
+            coEvery {
+                createShopperSessionAPI(token = any(), tokenType = any(), params = any())
+            } returns APIResult.Success(fakeSessionResponse)
 
             val callback = mockk<PayPalWebVaultCallback>(relaxed = true)
             sutV3.createPayPalSession(
@@ -1910,7 +1919,8 @@ class PayPalWebCheckoutClientUnitTest {
                     flow = LatencyFlow.CHECKOUT,
                     presentationType = PresentationType.BROWSER,
                     startTime = any(),
-                    endTime = any()
+                    endTime = any(),
+                    params = any()
                 )
             }
         }
@@ -1944,7 +1954,8 @@ class PayPalWebCheckoutClientUnitTest {
                     flow = LatencyFlow.CHECKOUT,
                     presentationType = PresentationType.APP_SWITCH,
                     startTime = any(),
-                    endTime = any()
+                    endTime = any(),
+                    params = any()
                 )
             }
         }
@@ -1973,7 +1984,8 @@ class PayPalWebCheckoutClientUnitTest {
                     flow = LatencyFlow.CHECKOUT,
                     presentationType = PresentationType.ERROR,
                     startTime = any(),
-                    endTime = any()
+                    endTime = any(),
+                    params = any()
                 )
             }
         }
@@ -1991,7 +2003,8 @@ class PayPalWebCheckoutClientUnitTest {
                     flow = LatencyFlow.CHECKOUT,
                     presentationType = PresentationType.ERROR,
                     startTime = any(),
-                    endTime = any()
+                    endTime = any(),
+                    params = any()
                 )
             }
         }
@@ -2019,7 +2032,8 @@ class PayPalWebCheckoutClientUnitTest {
                     flow = LatencyFlow.VAULT,
                     presentationType = any(),
                     startTime = any(),
-                    endTime = any()
+                    endTime = any(),
+                    params = any()
                 )
             }
         }


### PR DESCRIPTION
Thank you for your contribution to PayPal. 

> Before submitting this PR, note that we cannot accept language translation PRs. We have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

 - Adding shopperSessionId and orderId as analytics params for latency events, so they'll be included in analytics searches when searching by either of those fields.  

### Evidence
<img width="974" height="674" alt="Screenshot 2026-07-30 at 1 27 58 PM" src="https://github.com/user-attachments/assets/eb718964-61bd-4cbc-bd23-ba3d0f81de2a" />


 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
