### PR TITLE
[MAJOR] Rename Environment enum to CoreEnvironment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Removed deprecated `CardClient.finishApproveOrder(intent, authState)` — use `CardClient.finishApproveOrder(intent)` instead
   * Removed deprecated `CardClient.finishVault(intent, authState)` — use `CardClient.finishVault(intent)` instead
   * Removed `authState` from public API of `CardPresentAuthChallengeResult.Success`
+* CorePayments
+  * Renamed `Environment` to `CoreEnvironment` and `CoreConfig.environment` to `CoreConfig.coreEnvironment`
 * PayPalPayments
   * Renamed the `PayPalWebPayments` module to `PayPalPayments` (Maven artifact `com.paypal.android:paypal-payments`, package `com.paypal.android.paypalpayments`)
   * Renamed `PayPalWebCheckoutClient` to `PayPalClient`, `PayPalWebLauncher` to `PayPalLauncher`, `PayPalWebCheckoutError(Code)` to `PayPalError(Code)`, `PayPalWebCheckoutSessionStore` to `PayPalSessionStore`, `PayPalWebCheckoutFinishStartResult` to `PayPalFinishStartResult`, `PayPalWebCheckoutFinishVaultResult` to `PayPalFinishVaultResult`, and `PayPalWebCheckoutFundingSource` to `PayPalCheckoutFundingSource`

--- a/CardPayments/src/test/java/com/paypal/android/cardpayments/DataVaultPaymentMethodTokensAPIUnitTest.kt
+++ b/CardPayments/src/test/java/com/paypal/android/cardpayments/DataVaultPaymentMethodTokensAPIUnitTest.kt
@@ -8,7 +8,7 @@ import com.paypal.android.cardpayments.api.UpdateSetupTokenResponse
 import com.paypal.android.cardpayments.api.UpdateSetupTokenVariables
 import com.paypal.android.corepayments.Address
 import com.paypal.android.corepayments.CoreConfig
-import com.paypal.android.corepayments.Environment
+import com.paypal.android.corepayments.CoreEnvironment
 import com.paypal.android.corepayments.LoadRawResourceResult
 import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.corepayments.ResourceLoader
@@ -36,7 +36,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class DataVaultPaymentMethodTokensAPIUnitTest {
 
-    private val coreConfig = CoreConfig("fake-client-id", "fake-merchant-id", Environment.SANDBOX)
+    private val coreConfig = CoreConfig("fake-client-id", "fake-merchant-id", CoreEnvironment.SANDBOX)
 
     private val resourceLoader = ResourceLoader()
     private val context = ApplicationProvider.getApplicationContext<Application>()

--- a/CorePayments/api/CorePayments.api
+++ b/CorePayments/api/CorePayments.api
@@ -49,30 +49,30 @@ public final class com/paypal/android/corepayments/BuildConfig {
 
 public final class com/paypal/android/corepayments/CoreConfig {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/paypal/android/corepayments/Environment;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/paypal/android/corepayments/Environment;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/paypal/android/corepayments/Environment;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/paypal/android/corepayments/CoreEnvironment;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/paypal/android/corepayments/CoreEnvironment;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/paypal/android/corepayments/CoreEnvironment;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lcom/paypal/android/corepayments/Environment;
+	public final fun component3 ()Lcom/paypal/android/corepayments/CoreEnvironment;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/paypal/android/corepayments/Environment;Ljava/lang/String;)Lcom/paypal/android/corepayments/CoreConfig;
-	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/CoreConfig;Ljava/lang/String;Ljava/lang/String;Lcom/paypal/android/corepayments/Environment;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/CoreConfig;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/paypal/android/corepayments/CoreEnvironment;Ljava/lang/String;)Lcom/paypal/android/corepayments/CoreConfig;
+	public static synthetic fun copy$default (Lcom/paypal/android/corepayments/CoreConfig;Ljava/lang/String;Ljava/lang/String;Lcom/paypal/android/corepayments/CoreEnvironment;Ljava/lang/String;ILjava/lang/Object;)Lcom/paypal/android/corepayments/CoreConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBnCode ()Ljava/lang/String;
 	public final fun getClientId ()Ljava/lang/String;
-	public final fun getEnvironment ()Lcom/paypal/android/corepayments/Environment;
+	public final fun getCoreEnvironment ()Lcom/paypal/android/corepayments/CoreEnvironment;
 	public final fun getMerchantId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/paypal/android/corepayments/Environment : java/lang/Enum {
-	public static final field LIVE Lcom/paypal/android/corepayments/Environment;
-	public static final field SANDBOX Lcom/paypal/android/corepayments/Environment;
+public final class com/paypal/android/corepayments/CoreEnvironment : java/lang/Enum {
+	public static final field LIVE Lcom/paypal/android/corepayments/CoreEnvironment;
+	public static final field SANDBOX Lcom/paypal/android/corepayments/CoreEnvironment;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/paypal/android/corepayments/Environment;
-	public static fun values ()[Lcom/paypal/android/corepayments/Environment;
+	public static fun valueOf (Ljava/lang/String;)Lcom/paypal/android/corepayments/CoreEnvironment;
+	public static fun values ()[Lcom/paypal/android/corepayments/CoreEnvironment;
 }
 
 public final class com/paypal/android/corepayments/HttpResponse$Companion {

--- a/CorePayments/src/debug/java/com/paypal/android/corepayments/CoreEnvironment.kt
+++ b/CorePayments/src/debug/java/com/paypal/android/corepayments/CoreEnvironment.kt
@@ -1,6 +1,6 @@
 package com.paypal.android.corepayments
 
-enum class Environment(internal open val url: String, internal open val graphQLEndpoint: String) {
+enum class CoreEnvironment(internal open val url: String, internal open val graphQLEndpoint: String) {
     // TODO: Look into improving the quality of this.
     //  CUSTOM is supposed to be static, but values are dynamic.
     //  url and graphQLEndpoint can be separated out, so that we don't have them dependent on the enum.

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/CoreConfig.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/CoreConfig.kt
@@ -3,6 +3,6 @@ package com.paypal.android.corepayments
 data class CoreConfig @JvmOverloads constructor(
     val clientId: String,
     val merchantId: String,
-    val environment: Environment = Environment.SANDBOX,
+    val coreEnvironment: CoreEnvironment = CoreEnvironment.SANDBOX,
     val bnCode: String? = null,
 )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/RestClient.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/RestClient.kt
@@ -26,7 +26,7 @@ class RestClient internal constructor(
         configuration: CoreConfig,
     ): HttpRequest {
         val path = apiRequest.path
-        val baseUrl = configuration.environment.url
+        val baseUrl = configuration.coreEnvironment.url
 
         val url = URL("$baseUrl/$path")
         val method = apiRequest.method

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventsAPI.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/TrackingEventsAPI.kt
@@ -80,7 +80,7 @@ internal class TrackingEventsAPI constructor(
 
     companion object {
         fun toLiveConfig(config: CoreConfig): CoreConfig =
-            CoreConfig(config.clientId, config.merchantId, environment = Environment.LIVE)
+            CoreConfig(config.clientId, config.merchantId, coreEnvironment = CoreEnvironment.LIVE)
 
         const val PPCP_CLIENTS_SDK = "ppcpclientsdk"
         const val EVENT_SOURCE_MOBILE_NATIVE = "mobile-native"

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/analytics/AnalyticsService.kt
@@ -5,7 +5,7 @@ import android.util.Log
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.paypal.android.corepayments.CoreConfig
-import com.paypal.android.corepayments.Environment
+import com.paypal.android.corepayments.CoreEnvironment
 import com.paypal.android.corepayments.PayPalSDKError
 import com.paypal.android.corepayments.TrackingEventsAPI
 import kotlinx.coroutines.CoroutineDispatcher
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AnalyticsService internal constructor(
     private val deviceInspector: DeviceInspector,
-    private val environment: Environment,
+    private val coreEnvironment: CoreEnvironment,
     private val trackingEventsAPI: TrackingEventsAPI,
     private val scope: CoroutineScope
 ) {
@@ -35,7 +35,7 @@ class AnalyticsService internal constructor(
     ) :
             this(
                 DeviceInspector(context),
-                coreConfig.environment,
+                coreConfig.coreEnvironment,
                 TrackingEventsAPI(coreConfig),
                 CoroutineScope(dispatcher)
             )
@@ -54,7 +54,7 @@ class AnalyticsService internal constructor(
             try {
                 val deviceData = deviceInspector.inspect()
                 val fullEventData = eventData.copy(
-                    environment = environment.name.lowercase(),
+                    environment = coreEnvironment.name.lowercase(),
                     eventName = name,
                     timestamp = timestamp,
                 )

--- a/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLClient.kt
+++ b/CorePayments/src/main/java/com/paypal/android/corepayments/graphql/GraphQLClient.kt
@@ -34,14 +34,14 @@ class GraphQLClient internal constructor(
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    private val graphQLEndpoint = coreConfig.environment.graphQLEndpoint
+    private val graphQLEndpoint = coreConfig.coreEnvironment.graphQLEndpoint
     private val graphQLURL = "$graphQLEndpoint/graphql"
 
     private val httpRequestHeaders = mutableMapOf(
         "Content-Type" to "application/json",
         "Accept" to "application/json",
         "x-app-name" to "nativecheckout",
-        "Origin" to coreConfig.environment.graphQLEndpoint
+        "Origin" to coreConfig.coreEnvironment.graphQLEndpoint
     )
 
     /**

--- a/CorePayments/src/release/java/com/paypal/android/corepayments/CoreEnvironment.kt
+++ b/CorePayments/src/release/java/com/paypal/android/corepayments/CoreEnvironment.kt
@@ -1,6 +1,6 @@
 package com.paypal.android.corepayments
 
-enum class Environment(internal val url: String, internal val graphQLEndpoint: String) {
+enum class CoreEnvironment(internal val url: String, internal val graphQLEndpoint: String) {
     LIVE(
         "https://api-m.paypal.com",
         "https://www.paypal.com"

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/CoreConfigUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/CoreConfigUnitTest.kt
@@ -8,6 +8,6 @@ class CoreConfigUnitTest {
     @Test
     fun `it should default to SANDBOX environment`() {
         val sut = CoreConfig("fake-client-id", "fake-merchant-id")
-        assertEquals(Environment.SANDBOX, sut.environment)
+        assertEquals(CoreEnvironment.SANDBOX, sut.coreEnvironment)
     }
 }

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/CoreEnvironmentUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/CoreEnvironmentUnitTest.kt
@@ -3,15 +3,15 @@ package com.paypal.android.corepayments
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class EnvironmentUnitTest {
+class CoreEnvironmentUnitTest {
 
     @Test
     fun `it should return the correct url for the LIVE environment`() {
-        assertEquals("https://api-m.paypal.com", Environment.LIVE.url)
+        assertEquals("https://api-m.paypal.com", CoreEnvironment.LIVE.url)
     }
 
     @Test
     fun `it should return the correct url for the SANDBOX environment`() {
-        assertEquals("https://api-m.sandbox.paypal.com", Environment.SANDBOX.url)
+        assertEquals("https://api-m.sandbox.paypal.com", CoreEnvironment.SANDBOX.url)
     }
 }

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/RestClientUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/RestClientUnitTest.kt
@@ -26,8 +26,8 @@ class RestClientUnitTest {
 
     private val httpSuccessResponse = HttpResponse(200)
 
-    private val sandboxConfig = CoreConfig("fake-sandbox-client-id", "fake-merchant-id", Environment.SANDBOX)
-    private val liveConfig = CoreConfig("fake-live-client-id", "fake-merchant-id", Environment.LIVE)
+    private val sandboxConfig = CoreConfig("fake-sandbox-client-id", "fake-merchant-id", CoreEnvironment.SANDBOX)
+    private val liveConfig = CoreConfig("fake-live-client-id", "fake-merchant-id", CoreEnvironment.LIVE)
 
     private lateinit var http: Http
     private lateinit var httpRequestSlot: CapturingSlot<HttpRequest>

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/TrackingEventsAPIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/TrackingEventsAPIUnitTest.kt
@@ -32,7 +32,7 @@ class TrackingEventsAPIUnitTest {
         clientOS = "fake client OS"
     )
 
-    private val coreConfig = CoreConfig("fake-client-id", "fake-merchant-id", Environment.SANDBOX)
+    private val coreConfig = CoreConfig("fake-client-id", "fake-merchant-id", CoreEnvironment.SANDBOX)
 
     private lateinit var restClient: RestClient
     private lateinit var apiRequestSlot: CapturingSlot<APIRequest>

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/analytics/AnalyticsServiceTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/analytics/AnalyticsServiceTest.kt
@@ -22,7 +22,7 @@ import org.robolectric.RobolectricTestRunner
 class AnalyticsServiceTest {
 
     private lateinit var sut: AnalyticsService
-    private lateinit var environment: Environment
+    private lateinit var coreEnvironment: CoreEnvironment
 
     private lateinit var trackingEventsAPI: TrackingEventsAPI
     private lateinit var deviceInspector: DeviceInspector
@@ -44,7 +44,7 @@ class AnalyticsServiceTest {
     fun setup() {
         deviceInspector = mockk()
         trackingEventsAPI = mockk(relaxed = true)
-        environment = Environment.SANDBOX
+        coreEnvironment = CoreEnvironment.SANDBOX
 
         every { deviceInspector.inspect() } returns deviceData
     }
@@ -56,7 +56,7 @@ class AnalyticsServiceTest {
             trackingEventsAPI.sendEvent(capture(analyticsEventDataSlot), deviceData)
         } returns httpSuccessResponse
 
-        sut = createAnalyticsService(environment, testScheduler)
+        sut = createAnalyticsService(coreEnvironment, testScheduler)
         sut.sendAnalyticsEvent("sample.event.name", AnalyticsEventData(orderId = "fake-order-id"))
         advanceUntilIdle()
 
@@ -71,7 +71,7 @@ class AnalyticsServiceTest {
         } returns httpSuccessResponse
 
         val timeBeforeEventSent = System.currentTimeMillis()
-        sut = createAnalyticsService(environment, testScheduler)
+        sut = createAnalyticsService(coreEnvironment, testScheduler)
         sut.sendAnalyticsEvent("sample.event.name", AnalyticsEventData(orderId = "fake-order-id"))
         advanceUntilIdle()
 
@@ -87,7 +87,7 @@ class AnalyticsServiceTest {
             trackingEventsAPI.sendEvent(capture(analyticsEventDataSlot), deviceData)
         } returns httpSuccessResponse
 
-        sut = createAnalyticsService(environment, testScheduler)
+        sut = createAnalyticsService(coreEnvironment, testScheduler)
         sut.sendAnalyticsEvent("fake-event", AnalyticsEventData(orderId = "fake-order-id"))
         advanceUntilIdle()
 
@@ -102,7 +102,7 @@ class AnalyticsServiceTest {
             trackingEventsAPI.sendEvent(capture(analyticsEventDataSlot), deviceData)
         } returns httpSuccessResponse
 
-        sut = createAnalyticsService(Environment.LIVE, testScheduler)
+        sut = createAnalyticsService(CoreEnvironment.LIVE, testScheduler)
         sut.sendAnalyticsEvent("fake-event", AnalyticsEventData(orderId = "fake-order-id"))
         advanceUntilIdle()
 
@@ -117,7 +117,7 @@ class AnalyticsServiceTest {
             trackingEventsAPI.sendEvent(capture(analyticsEventDataSlot), deviceData)
         } returns httpSuccessResponse
 
-        sut = createAnalyticsService(environment, testScheduler)
+        sut = createAnalyticsService(coreEnvironment, testScheduler)
         sut.sendAnalyticsEvent(
             name = "paypal-payments:api-request-latency",
             eventData = AnalyticsEventData(
@@ -139,7 +139,7 @@ class AnalyticsServiceTest {
     }
 
     private fun createAnalyticsService(
-        environment: Environment,
+        coreEnvironment: CoreEnvironment,
         testScheduler: TestCoroutineScheduler
     ): AnalyticsService {
         val testDispatcher = StandardTestDispatcher(testScheduler)
@@ -148,7 +148,7 @@ class AnalyticsServiceTest {
         // Ref: https://developer.android.com/kotlin/coroutines/test#injecting-test-dispatchers
         return AnalyticsService(
             deviceInspector,
-            environment,
+            coreEnvironment,
             trackingEventsAPI,
             scope
         )

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/api/AuthenticationSecureTokenServiceAPIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/api/AuthenticationSecureTokenServiceAPIUnitTest.kt
@@ -2,7 +2,7 @@ package com.paypal.android.corepayments.api
 
 import com.paypal.android.corepayments.APIRequest
 import com.paypal.android.corepayments.CoreConfig
-import com.paypal.android.corepayments.Environment
+import com.paypal.android.corepayments.CoreEnvironment
 import com.paypal.android.corepayments.HttpMethod
 import com.paypal.android.corepayments.HttpResponse
 import com.paypal.android.corepayments.RestClient
@@ -30,7 +30,7 @@ class AuthenticationSecureTokenServiceAPIUnitTest {
 
     @Before
     fun beforeEach() {
-        coreConfig = CoreConfig("test-client-id", "fake-merchant-id", Environment.SANDBOX)
+        coreConfig = CoreConfig("test-client-id", "fake-merchant-id", CoreEnvironment.SANDBOX)
         restClient = mockk(relaxed = true)
         sut = AuthenticationSecureTokenServiceAPI(coreConfig, restClient)
     }
@@ -205,7 +205,7 @@ class AuthenticationSecureTokenServiceAPIUnitTest {
     fun `createLowScopedAccessToken() creates proper Basic Auth header from client ID`() = runTest {
         // Given
         val clientId = "test-client-123"
-        val configWithCustomClientId = CoreConfig(clientId, "fake-merchant-id", Environment.LIVE)
+        val configWithCustomClientId = CoreConfig(clientId, "fake-merchant-id", CoreEnvironment.LIVE)
         val sutWithCustomConfig =
             AuthenticationSecureTokenServiceAPI(configWithCustomClientId, restClient)
 

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/api/CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest.kt
@@ -2,7 +2,7 @@ package com.paypal.android.corepayments.api
 
 import android.content.Context
 import com.paypal.android.corepayments.CoreConfig
-import com.paypal.android.corepayments.Environment
+import com.paypal.android.corepayments.CoreEnvironment
 import com.paypal.android.corepayments.Http
 import com.paypal.android.corepayments.HttpRequest
 import com.paypal.android.corepayments.HttpRoundTripTiming
@@ -52,7 +52,7 @@ class CreateShopperSessionWithAppSwitchEligibilityAPIUnitTest {
         context = mockk(relaxed = true)
         mockHttp = mockk(relaxed = true)
 
-        val coreConfig = CoreConfig("test-client-id", "fake-merchant-id", Environment.SANDBOX)
+        val coreConfig = CoreConfig("test-client-id", "fake-merchant-id", CoreEnvironment.SANDBOX)
         graphQLClient = GraphQLClient(coreConfig, mockHttp)
 
         resourceLoader = mockk(relaxed = true)

--- a/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/GraphQLClientUnitTest.kt
+++ b/CorePayments/src/test/java/com/paypal/android/corepayments/graphql/GraphQLClientUnitTest.kt
@@ -1,7 +1,7 @@
 package com.paypal.android.corepayments.graphql
 
 import com.paypal.android.corepayments.CoreConfig
-import com.paypal.android.corepayments.Environment
+import com.paypal.android.corepayments.CoreEnvironment
 import com.paypal.android.corepayments.Http
 import com.paypal.android.corepayments.HttpMethod
 import com.paypal.android.corepayments.HttpRequest
@@ -54,9 +54,9 @@ internal class GraphQLClientUnitTest {
         mockCoreConfig = mockk(relaxed = true)
 
         // Setup mock environment for the CoreConfig
-        val mockEnvironment = mockk<Environment>(relaxed = true)
-        every { mockEnvironment.graphQLEndpoint } returns "https://test-api.paypal.com"
-        every { mockCoreConfig.environment } returns mockEnvironment
+        val mockCoreEnvironment = mockk<CoreEnvironment>(relaxed = true)
+        every { mockCoreEnvironment.graphQLEndpoint } returns "https://test-api.paypal.com"
+        every { mockCoreConfig.coreEnvironment } returns mockCoreEnvironment
 
         // Create the GraphQLClient with mocked dependencies
         graphQLClient = GraphQLClient(mockCoreConfig, mockHttp)
@@ -250,11 +250,11 @@ internal class GraphQLClientUnitTest {
     fun `test invalid URL handling`() = runTest {
         // Arrange - setup a situation where creating the URL will fail
         // We'll use a mock environment with an invalid URL format
-        val invalidMockEnvironment = mockk<Environment>(relaxed = true)
-        every { invalidMockEnvironment.graphQLEndpoint } returns "invalid://endpoint"
+        val invalidMockCoreEnvironment = mockk<CoreEnvironment>(relaxed = true)
+        every { invalidMockCoreEnvironment.graphQLEndpoint } returns "invalid://endpoint"
 
         val invalidMockCoreConfig = mockk<CoreConfig>(relaxed = true)
-        every { invalidMockCoreConfig.environment } returns invalidMockEnvironment
+        every { invalidMockCoreConfig.coreEnvironment } returns invalidMockCoreEnvironment
 
         val invalidUrlClient = GraphQLClient(invalidMockCoreConfig, mockHttp)
 

--- a/Demo/src/debug/java/com/paypal/android/customenvironment/CustomEnvironmentRepository.kt
+++ b/Demo/src/debug/java/com/paypal/android/customenvironment/CustomEnvironmentRepository.kt
@@ -5,7 +5,7 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.paypal.android.api.services.MerchantIntegration
 import com.paypal.android.corepayments.CoreConfig
-import com.paypal.android.corepayments.Environment
+import com.paypal.android.corepayments.CoreEnvironment
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -67,8 +67,8 @@ class CustomEnvironmentRepository @Inject constructor(
 
     /**
      * Returns a [CoreConfig] for the active environment.
-     * - [SelectedEnvironment.LIVE] / [SelectedEnvironment.SANDBOX] → the corresponding [Environment].
-     * - [SelectedEnvironment.CUSTOM] with URLs configured → [Environment.CUSTOM] with those URLs.
+     * - [SelectedEnvironment.LIVE] / [SelectedEnvironment.SANDBOX] → the corresponding [CoreEnvironment].
+     * - [SelectedEnvironment.CUSTOM] with URLs configured → [CoreEnvironment.CUSTOM] with those URLs.
      * - [SelectedEnvironment.CUSTOM] without URLs → falls back to [fallbackConfig].
      */
     fun getCoreConfig(fallbackConfig: CoreConfig): CoreConfig {
@@ -78,20 +78,20 @@ class CustomEnvironmentRepository @Inject constructor(
                 CoreConfig(
                     clientId = fallbackConfig.clientId,
                     fallbackConfig.merchantId,
-                    environment = Environment.LIVE
+                    coreEnvironment = CoreEnvironment.LIVE
                 )
             SelectedEnvironment.SANDBOX ->
                 CoreConfig(
                     clientId = fallbackConfig.clientId,
                     fallbackConfig.merchantId,
-                    environment = Environment.SANDBOX
+                    coreEnvironment = CoreEnvironment.SANDBOX
                 )
             SelectedEnvironment.CUSTOM -> if (settings.isValidEnvironment) {
-                Environment.customRestUrl = settings.customSdkRestUrl.trim().trimEnd('/')
-                Environment.customGraphQLUrl = settings.customSdkGraphQLUrl.trim().trimEnd('/')
+                CoreEnvironment.customRestUrl = settings.customSdkRestUrl.trim().trimEnd('/')
+                CoreEnvironment.customGraphQLUrl = settings.customSdkGraphQLUrl.trim().trimEnd('/')
                 val resolvedClientId = settings.customClientId.trim().ifBlank { fallbackConfig.clientId }
                 val resolvedMerchantId = settings.customMerchantId.trim().ifBlank { fallbackConfig.merchantId }
-                CoreConfig(clientId = resolvedClientId, resolvedMerchantId, environment = Environment.CUSTOM)
+                CoreConfig(clientId = resolvedClientId, resolvedMerchantId, coreEnvironment = CoreEnvironment.CUSTOM)
             } else {
                 fallbackConfig
             }

--- a/FraudProtection/src/debug/java/com/paypal/android/fraudprotection/CoreConfigMagnesExt.kt
+++ b/FraudProtection/src/debug/java/com/paypal/android/fraudprotection/CoreConfigMagnesExt.kt
@@ -4,8 +4,8 @@ import com.paypal.android.corepayments.CoreConfig
 import lib.android.paypal.com.magnessdk.Environment
 
 internal val CoreConfig.magnesEnvironment: Environment
-    get() = when (environment) {
-        com.paypal.android.corepayments.Environment.LIVE -> Environment.LIVE
-        com.paypal.android.corepayments.Environment.SANDBOX -> Environment.SANDBOX
-        com.paypal.android.corepayments.Environment.CUSTOM -> Environment.SANDBOX
+    get() = when (coreEnvironment) {
+        com.paypal.android.corepayments.CoreEnvironment.LIVE -> Environment.LIVE
+        com.paypal.android.corepayments.CoreEnvironment.SANDBOX -> Environment.SANDBOX
+        com.paypal.android.corepayments.CoreEnvironment.CUSTOM -> Environment.SANDBOX
     }

--- a/FraudProtection/src/release/java/com/paypal/android/fraudprotection/CoreConfigMagnesExt.kt
+++ b/FraudProtection/src/release/java/com/paypal/android/fraudprotection/CoreConfigMagnesExt.kt
@@ -4,7 +4,7 @@ import com.paypal.android.corepayments.CoreConfig
 import lib.android.paypal.com.magnessdk.Environment
 
 internal val CoreConfig.magnesEnvironment: Environment
-    get() = when (environment) {
-        com.paypal.android.corepayments.Environment.LIVE -> Environment.LIVE
-        com.paypal.android.corepayments.Environment.SANDBOX -> Environment.SANDBOX
+    get() = when (coreEnvironment) {
+        com.paypal.android.corepayments.CoreEnvironment.LIVE -> Environment.LIVE
+        com.paypal.android.corepayments.CoreEnvironment.SANDBOX -> Environment.SANDBOX
     }

--- a/FraudProtection/src/test/java/com/paypal/android/fraudprotection/PayPalDataCollectorUnitTest.kt
+++ b/FraudProtection/src/test/java/com/paypal/android/fraudprotection/PayPalDataCollectorUnitTest.kt
@@ -3,7 +3,7 @@ package com.paypal.android.fraudprotection
 import android.content.Context
 import android.util.Log
 import com.paypal.android.corepayments.CoreConfig
-import com.paypal.android.corepayments.Environment
+import com.paypal.android.corepayments.CoreEnvironment
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -23,8 +23,8 @@ import java.util.UUID
 
 class PayPalDataCollectorUnitTest {
 
-    private val sandboxConfig = CoreConfig("fake-client-id", "fake-merchant-id", Environment.SANDBOX)
-    private val liveConfig = CoreConfig("fake-client-id", "fake-merchant-id", Environment.LIVE)
+    private val sandboxConfig = CoreConfig("fake-client-id", "fake-merchant-id", CoreEnvironment.SANDBOX)
+    private val liveConfig = CoreConfig("fake-client-id", "fake-merchant-id", CoreEnvironment.LIVE)
 
     private lateinit var context: Context
 

--- a/PayPalPayments/src/test/java/com/paypal/android/paypalpayments/PayPalClientUnitTest.kt
+++ b/PayPalPayments/src/test/java/com/paypal/android/paypalpayments/PayPalClientUnitTest.kt
@@ -4,7 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
 import com.paypal.android.corepayments.CoreConfig
-import com.paypal.android.corepayments.Environment
+import com.paypal.android.corepayments.CoreEnvironment
 import com.paypal.android.corepayments.HttpRoundTripTiming
 import com.paypal.android.corepayments.LinkType
 import com.paypal.android.corepayments.PayPalSDKError
@@ -76,7 +76,7 @@ class PayPalClientUnitTest {
 
     @MockK
     private val deviceInspector: DeviceInspector = mockk(relaxed = true)
-    private val coreConfig = CoreConfig("fake-client-id", "fake-merchant-id", Environment.SANDBOX)
+    private val coreConfig = CoreConfig("fake-client-id", "fake-merchant-id", CoreEnvironment.SANDBOX)
 
     private val intent = Intent()
 

--- a/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
+++ b/PaymentButtons/src/main/java/com/paypal/android/paymentbuttons/PaymentButton.kt
@@ -18,7 +18,7 @@ import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.RoundedCornerTreatment
 import com.google.android.material.shape.ShapeAppearanceModel
 import com.paypal.android.corepayments.CoreConfig
-import com.paypal.android.corepayments.Environment
+import com.paypal.android.corepayments.CoreEnvironment
 import com.paypal.android.corepayments.analytics.AnalyticsEventData
 import com.paypal.android.corepayments.analytics.AnalyticsService
 import com.paypal.android.ui.R
@@ -36,7 +36,7 @@ abstract class PaymentButton<C : PaymentButtonColor> @JvmOverloads constructor(
     private var shapeHasChanged = false
 
     internal val analyticsService: AnalyticsService =
-        AnalyticsService(context, CoreConfig(clientId = "N/A", merchantId = "N/A", environment = Environment.LIVE))
+        AnalyticsService(context, CoreConfig(clientId = "N/A", merchantId = "N/A", coreEnvironment = CoreEnvironment.LIVE))
 
     private var shapeAppearanceModel: ShapeAppearanceModel = ShapeAppearanceModel()
         set(value) {


### PR DESCRIPTION
### Summary
- Renamed the public `Environment` enum in `CorePayments` to `CoreEnvironment` to keep in sync with iOS.

### API / Contract Changes

## New

None

## Modified

- `com.paypal.android.corepayments.Environment` renamed to `com.paypal.android.corepayments.CoreEnvironment`
- `CoreConfig.environment` renamed to `CoreConfig.coreEnvironment`

## Breaking Changes

- [ ] No breaking changes
- [x] Breaking changes (describe migration steps below)

## Migration:

- Replace all references to `com.paypal.android.corepayments.Environment` with `com.paypal.android.corepayments.CoreEnvironment` (same enum values: `LIVE`, `SANDBOX`, `CUSTOM`).
- Replace named-argument/property usages of `CoreConfig(..., environment = ...)` / `coreConfig.environment` with `coreEnvironment`.

### Checklist

- [x] Added a changelog entry